### PR TITLE
[core] Refactor: decompose large methods & extract utils.mojo

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,8 @@ argmojo/
 │       ├── __init__.mojo              # Package exports
 │       ├── argument.mojo              # Argument struct (argument definition)
 │       ├── command.mojo               # Command struct (parsing logic)
-│       └── parse_result.mojo          # ParseResult struct (parsed values)
+│       ├── parse_result.mojo          # ParseResult struct (parsed values)
+│       └── utils.mojo                 # ANSI colour constants and utility functions
 ├── tests/                             # Test suites (241 tests)
 │   ├── test_parse.mojo
 │   ├── test_groups.mojo

--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -284,7 +284,7 @@ Subcommands (`app <subcommand> [args]`) are the first feature that turns ArgMojo
 
 #### Architecture: composition inside `Command`
 
-- **No file split.** Everything stays in `command.mojo`. Mojo has no partial structs, so splitting would force free functions + parameter threading for little gain at ~2400 lines.
+- **No file split.** Core logic stays in `command.mojo`. Mojo has no partial structs, so splitting would force free functions + parameter threading for little gain at ~2250 lines. ANSI colour constants and small utility functions live in `utils.mojo` (internal-only, all symbols `_`-prefixed).
 - **No tokenizer.** The single-pass cursor walk (`startswith` checks) is sufficient. Token types are trivially identified inline. The parsing logic in `parse_args()` delegates to four sub-methods (`_parse_long_option`, `_parse_short_single`, `_parse_short_merged`, `_dispatch_subcommand`) for readability, but the overall flow is still a simple cursor walk.
 - **Composition-based.** `Command` gains a child command list. When `parse_args()` hits a non-option token matching a registered subcommand, it delegates the remaining argv slice to the child's own `parse_args()`. 100% logic reuse, zero duplication.
 
@@ -421,6 +421,8 @@ Before adding Phase 5 features, further decompose `parse_args()` for readability
 - [x] Extract `_help_commands_section()` — "Commands:" section listing subcommands
 - [x] Extract `_help_tips_section()` — "Tips:" section with `--` hint and user-defined tips
 - [x] Verify all 241 tests still pass after help refactor
+- [x] Extract `utils.mojo` — move ANSI colour constants (`_RESET`, `_BOLD_UL`, `_RED`…`_ORANGE`, default colour aliases) and utility functions (`_looks_like_number`, `_is_ascii_digit`, `_resolve_color`) into a dedicated internal module; `command.mojo` imports them
+- [x] Verify all tests still pass after utils extraction
 
 #### Features
 

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -4,117 +4,16 @@ from sys import argv, exit, stderr
 
 from .argument import Argument
 from .parse_result import ParseResult
-
-# ── ANSI colour codes ────────────────────────────────────────────────────────
-comptime _RESET = "\x1b[0m"
-comptime _BOLD_UL = "\x1b[1;4m"  # bold + underline (no colour)
-
-# Bright foreground colours.
-comptime _RED = "\x1b[91m"
-comptime _GREEN = "\x1b[92m"
-comptime _YELLOW = "\x1b[93m"
-comptime _BLUE = "\x1b[94m"
-comptime _MAGENTA = "\x1b[95m"
-comptime _CYAN = "\x1b[96m"
-comptime _WHITE = "\x1b[97m"
-comptime _ORANGE = "\x1b[33m"  # dark yellow — renders as orange on most terminals
-
-# Default colours.
-comptime _DEFAULT_HEADER_COLOR = _YELLOW
-comptime _DEFAULT_ARG_COLOR = _MAGENTA
-comptime _DEFAULT_WARN_COLOR = _ORANGE
-comptime _DEFAULT_ERROR_COLOR = _RED
-
-
-fn _looks_like_number(token: String) -> Bool:
-    """Returns True if *token* is a negative-number literal.
-
-    Recognises the forms ``-N``, ``-N.N``, ``-.N``, ``-NeX``, ``-N.NeX``,
-    and the corresponding ``-Ne+X`` / ``-Ne-X`` variants (same grammar as
-    Python / argparse numeric detection).
-    """
-    if len(token) < 2 or token[0:1] != "-":
-        return False
-    var j = 1
-    # Optional leading '.' after minus (e.g. -.5).
-    if token[j : j + 1] == ".":
-        j += 1
-        if j >= len(token) or not (
-            token[j : j + 1] >= "0" and token[j : j + 1] <= "9"
-        ):
-            return False
-    elif not (token[j : j + 1] >= "0" and token[j : j + 1] <= "9"):
-        return False
-    # Integer digits.
-    while j < len(token) and (
-        token[j : j + 1] >= "0" and token[j : j + 1] <= "9"
-    ):
-        j += 1
-    # Optional fractional part.
-    if j < len(token) and token[j : j + 1] == ".":
-        j += 1
-        while j < len(token) and (
-            token[j : j + 1] >= "0" and token[j : j + 1] <= "9"
-        ):
-            j += 1
-    # Optional exponent.
-    if j < len(token) and (token[j : j + 1] == "e" or token[j : j + 1] == "E"):
-        j += 1
-        if j < len(token) and (
-            token[j : j + 1] == "+" or token[j : j + 1] == "-"
-        ):
-            j += 1
-        if j >= len(token) or not (
-            token[j : j + 1] >= "0" and token[j : j + 1] <= "9"
-        ):
-            return False
-        while j < len(token) and (
-            token[j : j + 1] >= "0" and token[j : j + 1] <= "9"
-        ):
-            j += 1
-    return j == len(token)
-
-
-fn _is_ascii_digit(ch: String) -> Bool:
-    """Returns True if *ch* is a single ASCII digit character ('0'-'9')."""
-    return ch >= "0" and ch <= "9"
-
-
-fn _resolve_color(name: String) raises -> String:
-    """Maps a user-facing colour name to its ANSI code.
-
-    Accepted names (case-insensitive): RED, GREEN, YELLOW, BLUE,
-    MAGENTA, PINK (alias for MAGENTA), CYAN, WHITE, ORANGE.
-
-    Returns:
-        The ANSI escape code for the colour.
-
-    Raises:
-        Error if the name is not recognised.
-    """
-    var upper = name.upper()
-    if upper == "RED":
-        return _RED
-    if upper == "GREEN":
-        return _GREEN
-    if upper == "YELLOW":
-        return _YELLOW
-    if upper == "BLUE":
-        return _BLUE
-    if upper == "MAGENTA" or upper == "PINK":
-        return _MAGENTA
-    if upper == "CYAN":
-        return _CYAN
-    if upper == "WHITE":
-        return _WHITE
-    if upper == "ORANGE":
-        return _ORANGE
-    raise Error(
-        "Unknown colour '"
-        + name
-        + "'. Choose from: RED, GREEN, YELLOW, BLUE, MAGENTA, PINK, CYAN,"
-        " WHITE, ORANGE"
-    )
+from .utils import (
+    _RESET,
+    _BOLD_UL,
+    _DEFAULT_HEADER_COLOR,
+    _DEFAULT_ARG_COLOR,
+    _DEFAULT_WARN_COLOR,
+    _DEFAULT_ERROR_COLOR,
+    _looks_like_number,
+    _resolve_color,
+)
 
 
 struct Command(Copyable, Movable, Stringable, Writable):

--- a/src/argmojo/utils.mojo
+++ b/src/argmojo/utils.mojo
@@ -1,0 +1,115 @@
+"""ANSI colour constants and small utility functions used by ArgMojo."""
+
+# ── ANSI colour codes ────────────────────────────────────────────────────────
+comptime _RESET = "\x1b[0m"
+comptime _BOLD_UL = "\x1b[1;4m"  # bold + underline (no colour)
+
+# Bright foreground colours.
+comptime _RED = "\x1b[91m"
+comptime _GREEN = "\x1b[92m"
+comptime _YELLOW = "\x1b[93m"
+comptime _BLUE = "\x1b[94m"
+comptime _MAGENTA = "\x1b[95m"
+comptime _CYAN = "\x1b[96m"
+comptime _WHITE = "\x1b[97m"
+comptime _ORANGE = "\x1b[33m"  # dark yellow — renders as orange on most terminals
+
+# Default colours.
+comptime _DEFAULT_HEADER_COLOR = _YELLOW
+comptime _DEFAULT_ARG_COLOR = _MAGENTA
+comptime _DEFAULT_WARN_COLOR = _ORANGE
+comptime _DEFAULT_ERROR_COLOR = _RED
+
+
+# ── Utility functions ────────────────────────────────────────────────────────
+
+
+fn _looks_like_number(token: String) -> Bool:
+    """Returns True if *token* is a negative-number literal.
+
+    Recognises the forms ``-N``, ``-N.N``, ``-.N``, ``-NeX``, ``-N.NeX``,
+    and the corresponding ``-Ne+X`` / ``-Ne-X`` variants (same grammar as
+    Python / argparse numeric detection).
+    """
+    if len(token) < 2 or token[0:1] != "-":
+        return False
+    var j = 1
+    # Optional leading '.' after minus (e.g. -.5).
+    if token[j : j + 1] == ".":
+        j += 1
+        if j >= len(token) or not (
+            token[j : j + 1] >= "0" and token[j : j + 1] <= "9"
+        ):
+            return False
+    elif not (token[j : j + 1] >= "0" and token[j : j + 1] <= "9"):
+        return False
+    # Integer digits.
+    while j < len(token) and (
+        token[j : j + 1] >= "0" and token[j : j + 1] <= "9"
+    ):
+        j += 1
+    # Optional fractional part.
+    if j < len(token) and token[j : j + 1] == ".":
+        j += 1
+        while j < len(token) and (
+            token[j : j + 1] >= "0" and token[j : j + 1] <= "9"
+        ):
+            j += 1
+    # Optional exponent.
+    if j < len(token) and (token[j : j + 1] == "e" or token[j : j + 1] == "E"):
+        j += 1
+        if j < len(token) and (
+            token[j : j + 1] == "+" or token[j : j + 1] == "-"
+        ):
+            j += 1
+        if j >= len(token) or not (
+            token[j : j + 1] >= "0" and token[j : j + 1] <= "9"
+        ):
+            return False
+        while j < len(token) and (
+            token[j : j + 1] >= "0" and token[j : j + 1] <= "9"
+        ):
+            j += 1
+    return j == len(token)
+
+
+fn _is_ascii_digit(ch: String) -> Bool:
+    """Returns True if *ch* is a single ASCII digit character ('0'-'9')."""
+    return ch >= "0" and ch <= "9"
+
+
+fn _resolve_color(name: String) raises -> String:
+    """Maps a user-facing colour name to its ANSI code.
+
+    Accepted names (case-insensitive): RED, GREEN, YELLOW, BLUE,
+    MAGENTA, PINK (alias for MAGENTA), CYAN, WHITE, ORANGE.
+
+    Returns:
+        The ANSI escape code for the colour.
+
+    Raises:
+        Error if the name is not recognised.
+    """
+    var upper = name.upper()
+    if upper == "RED":
+        return _RED
+    if upper == "GREEN":
+        return _GREEN
+    if upper == "YELLOW":
+        return _YELLOW
+    if upper == "BLUE":
+        return _BLUE
+    if upper == "MAGENTA" or upper == "PINK":
+        return _MAGENTA
+    if upper == "CYAN":
+        return _CYAN
+    if upper == "WHITE":
+        return _WHITE
+    if upper == "ORANGE":
+        return _ORANGE
+    raise Error(
+        "Unknown colour '"
+        + name
+        + "'. Choose from: RED, GREEN, YELLOW, BLUE, MAGENTA, PINK, CYAN,"
+        " WHITE, ORANGE"
+    )

--- a/src/argmojo/utils.mojo
+++ b/src/argmojo/utils.mojo
@@ -27,9 +27,8 @@ comptime _DEFAULT_ERROR_COLOR = _RED
 fn _looks_like_number(token: String) -> Bool:
     """Returns True if *token* is a negative-number literal.
 
-    Recognises the forms ``-N``, ``-N.N``, ``-.N``, ``-NeX``, ``-N.NeX``,
-    and the corresponding ``-Ne+X`` / ``-Ne-X`` variants (same grammar as
-    Python / argparse numeric detection).
+    Recognises the forms `-N`, `-N.N`, `-.N`, `-NeX`, `-N.NeX`, `-N.NEX`,
+    `-.NE+X`, and the corresponding `-Ne+X`, `-Ne-X`, `-NE+X`, `-NE-X` variants.
     """
     if len(token) < 2 or token[0:1] != "-":
         return False


### PR DESCRIPTION
This PR refactors the code to improve readability and maintainability before the next stage.

**No public API changes. No behaviour changes.**

### What changed

**1. Decompose `parse_args()` to 4 sub-methods**. The `parse_args()` body is reduced to a ~50-line main loop that delegates to:

| New method               | Responsibility                                                                             |
| ------------------------ | ------------------------------------------------------------------------------------------ |
| `_parse_long_option()`   | `--key`, `--key=value`, `--no-X` negation, prefix matching, count/flag/nargs/value         |
| `_parse_short_single()`  | Single-character short option (`-k`, `-k value`)                                           |
| `_parse_short_merged()`  | Merged flags & attached values (`-abc`, `-ofile.txt`)                                      |
| `_dispatch_subcommand()` | Subcommand matching, child argv construction, persistent arg injection, bidirectional sync |

**2. Decompose `_generate_help()` to 5 sub-methods**

The ~318-line `_generate_help()` body is reduced to a ~25-line coordinator that calls:

| New method                    | Responsibility                                               |
| ----------------------------- | ------------------------------------------------------------ |
| `_help_usage_line()`          | Description + `Usage:` line with positionals/COMMAND/OPTIONS |
| `_help_positionals_section()` | `Arguments:` section with dynamic padding                    |
| `_help_options_section()`     | `Options:` + `Global Options:` sections                      |
| `_help_commands_section()`    | `Commands:` section listing subcommands                      |
| `_help_tips_section()`        | `Tips:` section with `--` hint and user-defined tips         |

**3. Extract `utils.mojo`**

Move ANSI colour constants (14 `comptime` values) and utility functions (`_looks_like_number`, `_is_ascii_digit`, `_resolve_color`) out of command.mojo into a new internal module. All symbols are `_`-prefixed (private).