### PR TITLE
[core] Add typo-suggestion support via Levenshtein distance

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@ A command-line argument parser library for [Mojo](https://www.modular.com/mojo),
 
 > **A**rguments **R**esolved and **G**rouped into **M**eaningful **O**ptions and **J**oined **O**bjects
 
+[![CI](https://img.shields.io/github/actions/workflow/status/forfudan/argmojo/run_tests.yaml?branch=main&label=tests)](https://github.com/forfudan/argmojo/actions/workflows/run_tests.yaml)
+[![Version](https://img.shields.io/github/v/tag/forfudan/argmojo?label=version&color=blue)](https://github.com/forfudan/argmojo/releases)
+![Mojo](https://img.shields.io/badge/mojo-0.26.1-orange)
+[![pixi](https://img.shields.io/badge/pixi%20add-argmojo-brightgreen)](https://prefix.dev/channels/modular-community/packages/argmojo)
+
+<!-- 
+[![License](https://img.shields.io/github/license/forfudan/argmojo)](LICENSE)
+[![Stars](https://img.shields.io/github/stars/forfudan/argmojo?style=flat)](https://github.com/forfudan/argmojo/stargazers)
+[![Issues](https://img.shields.io/github/issues/forfudan/argmojo)](https://github.com/forfudan/argmojo/issues)
+[![Last Commit](https://img.shields.io/github/last-commit/forfudan/argmojo)](https://github.com/forfudan/argmojo/commits/main)
+![Platforms](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-lightgrey)
+ -->
+
 ## Overview
 
 ArgMojo provides a builder-pattern API for defining and parsing command-line arguments in Mojo. It currently supports:

--- a/README.md
+++ b/README.md
@@ -1,14 +1,8 @@
 # ArgMojo
 
-A command-line argument parser library for [Mojo](https://www.modular.com/mojo).
+A command-line argument parser library for [Mojo](https://www.modular.com/mojo), inspired by Python's `argparse`, Rust's `clap`, Go's `cobra`, and other popular libraries.
 
-> **A**rguments  
-> **R**esolved and  
-> **G**rouped into  
-> **M**eaningful  
-> **O**ptions and  
-> **J**oined  
-> **O**bjects
+> **A**rguments **R**esolved and **G**rouped into **M**eaningful **O**ptions and **J**oined **O**bjects
 
 ## Overview
 

--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -69,7 +69,7 @@ These features appear across multiple libraries and depend only on string operat
 | Partial parsing (known args)       | ✓        | —     | —     | ✓    |                        | Phase 5       |
 | Require equals syntax              | —        | —     | —     | ✓    |                        | Phase 5       |
 | Default-if-present (const)         | ✓        | —     | —     | ✓    |                        | Phase 5       |
-| Suggest on typo (Levenshtein)      | ✓ (3.14) | —     | ✓     | ✓    |                        | Phase 5       |
+| Suggest on typo (Levenshtein)      | ✓ (3.14) | —     | ✓     | ✓    |                        | **Done**      |
 | CJK-aware help formatting          | —        | —     | —     | —    | ArgMojo unique feature | Phase 6       |
 | CJK full-to-half-width correction  | —        | —     | —     | —    | ArgMojo unique feature | Phase 6       |
 | CJK punctuation detection          | —        | —     | —     | —    | ArgMojo unique feature | Phase 6       |

--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -75,6 +75,7 @@ These features appear across multiple libraries and depend only on string operat
 | Suggest on typo (Levenshtein)      | ✓ (3.14) | —     | ✓     | ✓    |                        | **Done**      |
 | Mutual implication (`implies`)     | —        | —     | —     | —    | ArgMojo unique feature | Phase 5       |
 | Stdin value (`-` convention)       | —        | —     | ✓     | —    | Unix convention        | Phase 5       |
+| Shell completion script generation | —        | ✓     | ✓     | ✓    | bash / zsh / fish      | Phase 5       |
 | CJK-aware help formatting          | —        | —     | —     | —    | ArgMojo unique feature | Phase 6       |
 | CJK full-to-half-width correction  | —        | —     | —     | —    | ArgMojo unique feature | Phase 6       |
 | CJK punctuation detection          | —        | —     | —     | —    | ArgMojo unique feature | Phase 6       |
@@ -89,7 +90,6 @@ These features appear across multiple libraries and depend only on string operat
 | Feature                                       | Reason for Exclusion                                      |
 | --------------------------------------------- | --------------------------------------------------------- |
 | Derive / decorator API                        | Mojo has no macros or decorators                          |
-| Shell auto-completion generation              | Requires writing shell scripts; out of scope              |
 | Usage-string-driven parsing (docopt style)    | Too implicit; not a good fit for a typed systems language |
 | Type-conversion callbacks                     | Use `get_int()` / `get_string()` pattern instead          |
 | Config file reading (`fromfile_prefix_chars`) | Out of scope; users can pre-process argv                  |
@@ -545,7 +545,6 @@ Before adding Phase 5 features, further decompose `parse_args()` for readability
 These will **NOT** be implemented (but who knows :D maybe in the future if there's demand):
 
 - Derive/decorator-based API (no macros in Mojo)
-- Shell completion script generation
 - Usage-string-driven parsing (docopt style)
 - Config file parsing (users can pre-process argv)
 - Environment variable fallback

--- a/examples/git.mojo
+++ b/examples/git.mojo
@@ -28,7 +28,7 @@ from argmojo import Argument, Command
 fn main() raises:
     var app = Command(
         "git",
-        "The stupid content tracker.",
+        "A git-like CLI to demonstrate argmojo with subcommands.",
         version="2.47.0",
     )
 
@@ -91,6 +91,7 @@ fn main() raises:
         .long("recurse-submodules")
         .flag()
     )
+    clone.help_on_no_args()
     app.add_subcommand(clone^)
 
     # ── init ─────────────────────────────────────────────────────────────
@@ -317,12 +318,14 @@ fn main() raises:
         .short("f")
         .flag()
     )
+    remote_add.help_on_no_args()
     remote.add_subcommand(remote_add^)
 
     var remote_remove = Command("remove", "Remove a remote")
     remote_remove.add_argument(
         Argument("name", help="Remote name to remove").positional().required()
     )
+    remote_remove.help_on_no_args()
     remote.add_subcommand(remote_remove^)
 
     var remote_rename = Command("rename", "Rename a remote")
@@ -332,14 +335,17 @@ fn main() raises:
     remote_rename.add_argument(
         Argument("new", help="New remote name").positional().required()
     )
+    remote_rename.help_on_no_args()
     remote.add_subcommand(remote_rename^)
 
     var remote_show = Command("show", "Show information about a remote")
     remote_show.add_argument(
         Argument("name", help="Remote name").positional().required()
     )
+    remote_show.help_on_no_args()
     remote.add_subcommand(remote_show^)
 
+    remote.help_on_no_args()
     app.add_subcommand(remote^)
 
     # ── branch ───────────────────────────────────────────────────────────

--- a/pixi.toml
+++ b/pixi.toml
@@ -34,7 +34,8 @@ test = """\
     && mojo run -I src tests/test_extras.mojo \
     && mojo run -I src tests/test_subcommands.mojo \
     && mojo run -I src tests/test_negative_numbers.mojo \
-    && mojo run -I src tests/test_persistent.mojo"""
+    && mojo run -I src tests/test_persistent.mojo \
+    && mojo run -I src tests/test_typo_suggestions.mojo"""
 
 # build example binaries
 build = """pixi run package \

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -1635,21 +1635,13 @@ struct Command(Copyable, Movable, Stringable, Writable):
         Raises:
             Error if no argument matches.
         """
-        var all_shorts = List[String]()
         for i in range(len(self.args)):
             if self.args[i].short_name == name:
                 return self.args[i].copy()
-            if self.args[i].short_name != "":
-                all_shorts.append(self.args[i].short_name)
-        var suggestion = _suggest_similar(name, all_shorts)
-        if suggestion != "":
-            self._error(
-                "Unknown option '-"
-                + name
-                + "'. Did you mean '-"
-                + suggestion
-                + "'?"
-            )
+        # Short options are always a single character; any two single-character
+        # inputs have Levenshtein distance ≤ 1, so the threshold would always
+        # fire and produce meaningless suggestions (e.g. "-z" → "Did you mean
+        # '-v'?"). Suggestions are therefore disabled for short options.
         self._error("Unknown option '-" + name + "'")
         raise Error(
             "unreachable"

--- a/tests/test_typo_suggestions.mojo
+++ b/tests/test_typo_suggestions.mojo
@@ -1,0 +1,172 @@
+"""Tests for argmojo — typo suggestions (Levenshtein distance)."""
+
+from testing import assert_true, assert_false, assert_equal, TestSuite
+import argmojo
+from argmojo import Argument, Command, ParseResult
+
+# ── Long option typo suggestions ─────────────────────────────────────────────
+
+
+fn test_typo_long_option_suggests() raises:
+    """Tests that a typo like --verbos suggests --verbose."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("verbose", help="Verbose output").long("verbose").flag()
+    )
+    command.add_argument(
+        Argument("version", help="Show version").long("version").flag()
+    )
+
+    var args: List[String] = ["test", "--verbos"]
+    # --verbos is a prefix match for --verbose, so it should resolve.
+    # Use a more distant typo to test suggestion path.
+    var args2: List[String] = ["test", "--vrebose"]
+    var caught = False
+    try:
+        _ = command.parse_args(args2)
+    except e:
+        caught = True
+        var msg = String(e)
+        assert_true(
+            "Did you mean" in msg,
+            msg="Error should suggest a correction",
+        )
+        assert_true(
+            "verbose" in msg,
+            msg="Error should suggest --verbose",
+        )
+    assert_true(caught, msg="Should have raised error for --vrebose")
+    print("  ✓ test_typo_long_option_suggests")
+
+
+fn test_typo_long_option_no_suggestion() raises:
+    """Tests that a completely unrelated option doesn't produce a suggestion."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("verbose", help="Verbose output").long("verbose").flag()
+    )
+
+    var args: List[String] = ["test", "--zzzzzzz"]
+    var caught = False
+    try:
+        _ = command.parse_args(args)
+    except e:
+        caught = True
+        var msg = String(e)
+        assert_false(
+            "Did you mean" in msg,
+            msg="Error should not suggest anything for unrelated option",
+        )
+    assert_true(caught, msg="Should have raised error for --zzzzzzz")
+    print("  ✓ test_typo_long_option_no_suggestion")
+
+
+fn test_typo_long_option_single_char_diff() raises:
+    """Tests that a single character difference triggers a suggestion."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("output", help="Output file").long("output").short("o")
+    )
+
+    var args: List[String] = ["test", "--outptu", "file.txt"]
+    var caught = False
+    try:
+        _ = command.parse_args(args)
+    except e:
+        caught = True
+        var msg = String(e)
+        assert_true(
+            "Did you mean" in msg,
+            msg="Error should suggest a correction for --outptu",
+        )
+        assert_true(
+            "output" in msg,
+            msg="Error should suggest --output",
+        )
+    assert_true(caught, msg="Should have raised error for --outptu")
+    print("  ✓ test_typo_long_option_single_char_diff")
+
+
+# ── Subcommand typo suggestions ──────────────────────────────────────────────
+
+
+fn test_typo_subcommand_suggests() raises:
+    """Tests that a typo subcommand like 'serach' suggests 'search'."""
+    var root = Command("app", "Test app")
+    var search = Command("search", "Search items")
+    var list_cmd = Command("list", "List items")
+    root.add_subcommand(search^)
+    root.add_subcommand(list_cmd^)
+
+    var args: List[String] = ["app", "serach"]
+    var caught = False
+    try:
+        _ = root.parse_args(args)
+    except e:
+        caught = True
+        var msg = String(e)
+        assert_true(
+            "Did you mean" in msg,
+            msg="Error should suggest a correction for 'serach'",
+        )
+        assert_true(
+            "search" in msg,
+            msg="Error should suggest 'search'",
+        )
+    assert_true(caught, msg="Should have raised error for 'serach'")
+    print("  ✓ test_typo_subcommand_suggests")
+
+
+fn test_typo_subcommand_no_suggestion() raises:
+    """Tests that a completely unrelated subcommand doesn't produce a suggestion.
+    """
+    var root = Command("app", "Test app")
+    var search = Command("search", "Search items")
+    root.add_subcommand(search^)
+
+    var args: List[String] = ["app", "xxxxxxx"]
+    var caught = False
+    try:
+        _ = root.parse_args(args)
+    except e:
+        caught = True
+        var msg = String(e)
+        assert_false(
+            "Did you mean" in msg,
+            msg="Error should not suggest anything for unrelated command",
+        )
+    assert_true(caught, msg="Should have raised error for 'xxxxxxx'")
+    print("  ✓ test_typo_subcommand_no_suggestion")
+
+
+# ── Alias typo suggestions ──────────────────────────────────────────────────
+
+
+fn test_typo_alias_suggests() raises:
+    """Tests that a typo close to an alias triggers a suggestion."""
+    var command = Command("test", "Test app")
+    var alias_list: List[String] = ["color"]
+    command.add_argument(
+        Argument("colour", help="Enable colour output")
+        .long("colour")
+        .flag()
+        .aliases(alias_list^)
+    )
+
+    var args: List[String] = ["test", "--colro"]
+    var caught = False
+    try:
+        _ = command.parse_args(args)
+    except e:
+        caught = True
+        var msg = String(e)
+        assert_true(
+            "Did you mean" in msg,
+            msg="Error should suggest a correction for --colro",
+        )
+    assert_true(caught, msg="Should have raised error for --colro")
+    print("  ✓ test_typo_alias_suggests")
+
+
+fn main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
This PR adds typo-suggestion support (via Levenshtein distance) to ArgMojo’s option/subcommand parsing errors, and updates tests/docs/examples to reflect the improved UX.

**Changes:**
- Add Levenshtein-based suggestion helper in `utils.mojo` and integrate it into unknown long/short option and subcommand error paths.
- Improve validation errors to print a plain usage line + “try --help” tip via `_error_with_usage()`.
- Add a new test suite for typo suggestions and wire it into the `pixi.toml` test command; update docs/examples accordingly.