### PR TITLE
[core] Add shell completion support + built-in completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ ArgMojo provides a builder-pattern API for defining and parsing command-line arg
 - **One-required groups**: require at least one argument from a group (e.g., must provide `--json` or `--yaml`)
 - **Value delimiter**: `--env dev,staging,prod` splits by delimiter into a list with `.delimiter(",")`
 - **Multi-value options (nargs)**: `--point 10 20` consumes N consecutive values with `.nargs(N)`
+- **Shell completion script generation**: `generate_completion("bash"|"zsh"|"fish")` produces a complete tab-completion script for your CLI
 
 ---
 
@@ -142,7 +143,7 @@ ArgMojo ships with two complete example CLIs:
 | Example                 | File                 | Features                                                                                                                                                                                                                                                                                                                       |
 | ----------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `grep` — simulated grep | `examples/grep.mojo` | Positional args, flags, count flags, negatable flags, choices, metavar, append/collect, value delimiter, nargs, mutually exclusive groups, required-together groups, conditional requirements, numeric range, key-value map, aliases, deprecated args, hidden args, negative-number passthrough, `--` stop marker, custom tips |
-| `git` — simulated git   | `examples/git.mojo`  | Subcommands (clone/init/add/commit/push/pull/log/remote/branch/diff/tag/stash), nested subcommands (remote add/remove/rename/show), persistent (global) flags, per-command args, mutually exclusive groups, choices, aliases, deprecated args, custom tips                                                                     |
+| `git` — simulated git   | `examples/git.mojo`  | Subcommands (clone/init/add/commit/push/pull/log/remote/branch/diff/tag/stash), nested subcommands (remote add/remove/rename/show), persistent (global) flags, per-command args, mutually exclusive groups, choices, aliases, deprecated args, custom tips, shell completion script generation                                 |
 
 Build both example binaries:
 
@@ -195,6 +196,11 @@ pixi run build
 # Unknown subcommand → clear error
 ./git foo
 # error: git: Unknown command 'foo'. Available commands: clone, init, ...
+
+# Shell completion script generation
+./git --generate-completions bash   # bash completion script
+./git --generate-completions zsh    # zsh completion script
+./git --generate-completions fish   # fish completion script
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ A command-line argument parser library for [Mojo](https://www.modular.com/mojo),
 [![pixi](https://img.shields.io/badge/pixi%20add-argmojo-brightgreen)](https://prefix.dev/channels/modular-community/packages/argmojo)
 [![User manual](https://img.shields.io/badge/user-manual-purple)](https://github.com/forfudan/argmojo/wiki)
 
+<video src="https://raw.githubusercontent.com/forfudan/forfudan-github-data/main/argmojo/completions.mp4" controls width="800"></video>
+<p align="center"><em>Shell auto-completion of a mock <code>git</code> CLI built with ArgMojo</em></p>
+
 <!-- 
 [![CI](https://img.shields.io/github/actions/workflow/status/forfudan/argmojo/run_tests.yaml?branch=main&label=tests)](https://github.com/forfudan/argmojo/actions/workflows/run_tests.yaml)
 [![License](https://img.shields.io/github/license/forfudan/argmojo)](LICENSE)
@@ -153,6 +156,8 @@ pixi run build
 
 ### `grep` (no subcommands)
 
+![grep CLI demo](https://raw.githubusercontent.com/forfudan/forfudan-github-data/main/argmojo/grep.png)
+
 ```bash
 # Help and version
 ./grep --help
@@ -175,6 +180,8 @@ pixi run build
 ```
 
 ### `git` (with subcommands)
+
+![git clone subcommand](https://raw.githubusercontent.com/forfudan/forfudan-github-data/main/argmojo/git-clone.png)
 
 ```bash
 # Root help — shows Commands section + Global Options

--- a/README.md
+++ b/README.md
@@ -205,9 +205,9 @@ pixi run build
 # error: git: Unknown command 'foo'. Available commands: clone, init, ...
 
 # Shell completion script generation
-./git --generate-completions bash   # bash completion script
-./git --generate-completions zsh    # zsh completion script
-./git --generate-completions fish   # fish completion script
+./git --completions bash   # bash completion script
+./git --completions zsh    # zsh completion script
+./git --completions fish   # fish completion script
 ```
 
 ## Development

--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -521,6 +521,7 @@ Before adding Phase 5 features, further decompose `parse_args()` for readability
 - [x] **Typo suggestions** — "Unknown option '--vrb', did you mean '--verbose'?" (Levenshtein distance; cobra, argparse 3.14)
 - [ ] **Flag counter with ceiling** — `.count().max(3)` caps `-vvvvv` at 3 (no major library has this)
 - [x] **Colored error output** — ANSI styled error messages (help output already colored)
+- [x] **Shell completion script generation** — `generate_completion("bash"|"zsh"|"fish")` returns a complete completion script; static approach (no runtime hook), covers options/flags/choices/subcommands (clap `generate`, cobra `completion`, click `shell_complete`)
 - [ ] **Argument groups in help** — group related options under headings (argparse add_argument_group)
 - [ ] **Usage line customisation** — two approaches: (1) manual override via `.usage("...")` for git-style hand-written usage strings (e.g. `[-v | --version] [-h | --help] [-C <path>] ...`); (2) auto-expanded mode that enumerates every flag inline like argparse (good for small CLIs, noisy for large ones). Current default `[OPTIONS]` / `<COMMAND>` is the cobra/clap/click convention and is the right default.
 - [ ] **Partial parsing** — parse known args only, return unknown args as-is (argparse `parse_known_args`)

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -2049,7 +2049,8 @@ Every `Command` automatically responds to `--completions <shell>` — just like 
 var app = Command("myapp", "My application", version="1.0.0")
 app.add_argument(Argument("verbose", help="Verbose output").long("verbose").short("v").flag())
 app.add_argument(Argument("output", help="Output file").long("output").short("o").metavar("FILE"))
-app.add_argument(Argument("format", help="Output format").long("format").choices("json", "csv", "table"))
+var formats: List[String] = ["json", "csv", "table"]
+app.add_argument(Argument("format", help="Output format").long("format").choices(formats^))
 
 var sub = Command("serve", "Start a server")
 sub.add_argument(Argument("port", help="Port number").long("port").short("p"))
@@ -2136,8 +2137,6 @@ After generating a script, users `source` it or place it in a shell-specific dir
 **Bash:**
 
 ```bash
-# If compdef is not already loaded, initialize Zsh completion system
-autoload -Uz compinit && compinit
 # One-shot (current session only)
 eval "$(myapp --completions bash)"
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -57,6 +57,14 @@ from argmojo import Argument, Command
   - [Negative Number Passthrough](#negative-number-passthrough)
   - [Long Option Prefix Matching](#long-option-prefix-matching)
   - [The `--` Stop Marker](#the----stop-marker)
+- [Shell Completion](#shell-completion)
+  - [Built-in `--completions` Flag](#built-in---completions-flag)
+  - [Disabling the Built-in Flag](#disabling-the-built-in-flag)
+  - [Customising the Trigger Name](#customising-the-trigger-name)
+  - [Using a Subcommand Instead of an Option](#using-a-subcommand-instead-of-an-option)
+  - [Generating a Script Programmatically](#generating-a-script-programmatically)
+  - [Installing Completions](#installing-completions)
+  - [What Gets Completed](#what-gets-completed)
 
 ## Getting Started
 
@@ -2026,3 +2034,156 @@ myapp -- -10.18
 ```
 
 > **Tip:** ArgMojo's [Auto-detect](#negative-number-passthrough) can handle most negative-number cases without `--`. Use `--` only when auto-detect is insufficient (e.g., a digit short option is registered without `allow_negative_numbers()`).
+
+## Shell Completion
+
+ArgMojo can generate **shell completion scripts** for Bash, Zsh, and Fish. These scripts enable tab-completion for your CLI's options, flags, subcommands, and choice values — with zero runtime overhead.
+
+The generated scripts are **static**: they are produced once from your command tree and sourced by the user's shell. No runtime hook or callback mechanism is needed.
+
+### Built-in `--completions` Flag
+
+Every `Command` automatically responds to `--completions <shell>` — just like `--help` and `--version`. **No extra code is required.**
+
+```mojo
+var app = Command("myapp", "My application", version="1.0.0")
+app.add_argument(Argument("verbose", help="Verbose output").long("verbose").short("v").flag())
+app.add_argument(Argument("output", help="Output file").long("output").short("o").metavar("FILE"))
+app.add_argument(Argument("format", help="Output format").long("format").choices("json", "csv", "table"))
+
+var sub = Command("serve", "Start a server")
+sub.add_argument(Argument("port", help="Port number").long("port").short("p"))
+app.add_subcommand(sub^)
+
+# parse() handles --completions automatically — no extra code needed
+var result = app.parse()
+```
+
+Users run:
+
+```bash
+myapp --completions bash   # prints Bash completion script and exits
+myapp --completions zsh    # prints Zsh completion script and exits
+myapp --completions fish   # prints Fish completion script and exits
+```
+
+The `--completions` option is shown in the help output alongside `--help` and `--version`:
+
+```bash
+Options:
+  --help                  Show this help message and exit
+  --version               Show the version and exit
+  --completions {bash,zsh,fish}
+                          Generate shell completion script
+```
+
+### Disabling the Built-in Flag
+
+If you want to use `completions` as a regular argument name — or handle completion triggering entirely on your own — call `disable_default_completions()`:
+
+```mojo
+var app = Command("myapp", "My CLI")
+app.disable_default_completions()   # --completions is now an unknown option
+```
+
+`disable_default_completions()` removes `--completions` from the parse loop, help output, and all generated completion scripts. The `generate_completion()` method remains available for programmatic use.
+
+### Customising the Trigger Name
+
+By default the option is called `--completions`. Use `completions_name()` to rename it:
+
+```mojo
+var app = Command("myapp", "My CLI")
+app.completions_name("autocomp")    # → --autocomp bash/zsh/fish
+```
+
+Help output, parse loop, and generated scripts all reflect the new name.
+
+### Using a Subcommand Instead of an Option
+
+To expose completion generation as a subcommand rather than a `--` option, call `completions_as_subcommand()`:
+
+```mojo
+var app = Command("myapp", "My CLI")
+app.completions_as_subcommand()     # → myapp completions bash
+```
+
+The trigger moves from `Options:` to `Commands:` in help output. This can be combined with `completions_name()`:
+
+```mojo
+app.completions_name("comp")
+app.completions_as_subcommand()     # → myapp comp bash
+```
+
+### Generating a Script Programmatically
+
+You can also call `generate_completion(shell)` directly to get a completion script as a `String`:
+
+```mojo
+# Generate for any supported shell
+var script = app.generate_completion("bash")   # or "zsh" or "fish"
+print(script)
+```
+
+The `shell` argument is **case-insensitive** (`"Bash"`, `"BASH"`, `"bash"` all work). An error is raised for unrecognised shell names.
+
+### Installing Completions
+
+After generating a script, users `source` it or place it in a shell-specific directory.
+
+---
+
+**Bash:**
+
+```bash
+# If compdef is not already loaded, initialize Zsh completion system
+autoload -Uz compinit && compinit
+# One-shot (current session only)
+eval "$(myapp --completions bash)"
+
+# Persistent
+myapp --completions bash > ~/.bash_completion.d/myapp
+# Then add to ~/.bashrc:  source ~/.bash_completion.d/myapp
+```
+
+---
+
+**Zsh:**
+
+```bash
+# Place in your fpath (file must be named _myapp)
+myapp --completions zsh > ~/.zsh/completions/_myapp
+
+# Make sure ~/.zsh/completions is in fpath (add to ~/.zshrc):
+#   fpath=(~/.zsh/completions $fpath)
+#   autoload -Uz compinit && compinit
+```
+
+---
+
+**Fish:**
+
+```bash
+# Fish auto-loads from this directory
+myapp --completions fish > ~/.config/fish/completions/myapp.fish
+```
+
+### What Gets Completed
+
+The generated scripts cover the full command tree:
+
+| Element                           | Completed?       | Notes                                                                |
+| --------------------------------- | ---------------- | -------------------------------------------------------------------- |
+| Long options (`--verbose`)        | Yes              | With description text from `help`                                    |
+| Short options (`-v`)              | Yes              | Paired with long option when both exist                              |
+| Boolean flags                     | Yes              | Marked as no-argument (no file/value completion after the flag)      |
+| Count flags (`-vvv`)              | Yes              | Treated like boolean flags (no value expected)                       |
+| Choices (`--format json`)         | Yes              | Tab-completes the allowed values (`json`, `csv`, `table`)            |
+| Subcommands                       | Yes              | Listed with descriptions; scoped completions for each subcommand     |
+| Built-in `--help` / `--version`   | Yes              | Automatically included                                               |
+| Built-in `--completions {bash,…}` | Yes              | Automatically included; disable with `disable_default_completions()` |
+| Hidden arguments                  | No (intentional) | `.hidden()` arguments are excluded from completion                   |
+| Positional arguments              | No (by design)   | Positionals use default shell completion (file paths, etc.)          |
+| Persistent (global) flags         | Yes (root level) | Inherited flags appear in the root command's completions             |
+
+> **Note:** Negatable flags (`--color` / `--no-color`) — the `--no-X` form is **not** separately listed in completions. The base `--color` flag is completed; users type `--no-` manually. This matches the behaviour of other CLI frameworks.

--- a/examples/git.mojo
+++ b/examples/git.mojo
@@ -9,7 +9,8 @@ required arguments, metavar, hidden arguments, append/collect, value
 delimiter, mutually exclusive groups, required-together groups, conditional
 requirements, numeric range validation, aliases, deprecated arguments,
 Commands section in help, Global Options heading, full command path in
-child help/errors, unknown subcommand error, and custom tips.
+child help/errors, unknown subcommand error, custom tips, and shell
+completion script generation.
 
 Try these:
   git --help                        # root help (Commands + Global Options)
@@ -20,6 +21,7 @@ Try these:
   git log --oneline -n 20 --author "Alice"
   git remote add origin https://example.com/repo.git
   git -v push origin main --force --tags
+  git --completions bash           # shell completion script (built-in)
 """
 
 from argmojo import Argument, Command

--- a/pixi.toml
+++ b/pixi.toml
@@ -35,7 +35,8 @@ test = """\
     && mojo run -I src tests/test_subcommands.mojo \
     && mojo run -I src tests/test_negative_numbers.mojo \
     && mojo run -I src tests/test_persistent.mojo \
-    && mojo run -I src tests/test_typo_suggestions.mojo"""
+    && mojo run -I src tests/test_typo_suggestions.mojo \
+    && mojo run -I src tests/test_completion.mojo"""
 
 # build example binaries
 build = """pixi run package \

--- a/src/argmojo/argument.mojo
+++ b/src/argmojo/argument.mojo
@@ -2,7 +2,7 @@
 
 
 comptime Arg = Argument
-"""Shorthand alias for `Argument`."""
+"""Shorthand alias for ``Argument``."""
 
 
 struct Argument(Copyable, Movable, Stringable, Writable):
@@ -321,8 +321,8 @@ struct Argument(Copyable, Movable, Stringable, Writable):
     fn metavar(var self, name: String) -> Self:
         """Sets the display name for the value in help text.
 
-        For example, `.metavar("FILE")` causes help to show `--output FILE`
-        instead of `--output OUTPUT`.
+        For example, ``.metavar("FILE")`` causes help to show ``--output FILE``
+        instead of ``--output OUTPUT``.
 
         Args:
             name: The display name.
@@ -345,8 +345,8 @@ struct Argument(Copyable, Movable, Stringable, Writable):
     fn count(var self) -> Self:
         """Marks this argument as a counter flag.
 
-        Each occurrence increments a counter. For example, `-vvv` sets
-        the count to 3. Use `get_count()` on ParseResult to retrieve.
+        Each occurrence increments a counter. For example, ``-vvv`` sets
+        the count to 3. Use ``get_count()`` on ParseResult to retrieve.
 
         Returns:
             Self marked as a counter.
@@ -358,9 +358,9 @@ struct Argument(Copyable, Movable, Stringable, Writable):
     fn negatable(var self) -> Self:
         """Marks this flag as negatable.
 
-        A negatable flag accepts both `--X` (sets True) and `--no-X`
-        (sets False). For example, `.long("color").flag().negatable()`
-        accepts `--color` and `--no-color`.
+        A negatable flag accepts both ``--X`` (sets True) and ``--no-X``
+        (sets False). For example, ``.long("color").flag().negatable()``
+        accepts ``--color`` and ``--no-color``.
 
         Returns:
             Self marked as negatable.
@@ -372,7 +372,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         """Marks this argument as an append/collect option.
 
         Each occurrence adds its value to a list. For example,
-        `--tag x --tag y` collects `["x", "y"]`. Use `get_list()`
+        ``--tag x --tag y`` collects ``["x", "y"]``. Use ``get_list()``
         on ParseResult to retrieve the collected values.
 
         Returns:
@@ -390,9 +390,9 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         """Sets a value delimiter for splitting a single value into multiple.
 
         When set, each provided value is split by the delimiter, and each
-        piece is added to the list individually.  Implies `.append()`.
-        For example, `.delimiter(",")` causes `--tag a,b,c` to produce
-        `["a", "b", "c"]`.
+        piece is added to the list individually.  Implies ``.append()``.
+        For example, ``.delimiter(",")`` causes ``--tag a,b,c`` to produce
+        ``["a", "b", "c"]``.
 
         Args:
             sep: The delimiter string (e.g., ",").

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -80,19 +80,19 @@ struct Command(Copyable, Movable, Stringable, Writable):
     Call `allow_positional_with_subcommands()` to opt in explicitly."""
     var _completions_enabled: Bool
     """When True (default), a built-in completion trigger is active.
-    Call ``disable_default_completions()`` to opt out entirely."""
+    Call `disable_default_completions()` to opt out entirely."""
     var _completions_name: String
     """The name used for the built-in completion trigger.
-    Defaults to ``"completions"`` → ``--completions <shell>``.
-    Change via ``completions_name()``."""
+    Defaults to `"completions"` → `--completions <shell>`.
+    Change via `completions_name()`."""
     var _completions_is_subcommand: Bool
     """When True, the completion trigger is a subcommand instead of an
-    option.  Default False → ``--completions``.  Call
-    ``completions_as_subcommand()`` to switch to ``myapp completions bash``."""
+    option.  Default False → `--completions`.  Call
+    `completions_as_subcommand()` to switch to `myapp completions bash`."""
     var _tips: List[String]
     """User-defined tips shown at the bottom of the help message.
-    Add entries via ``add_tip()``.  Each tip is printed on its own line
-    prefixed with the same bold ``Tip:`` label as the built-in hint."""
+    Add entries via `add_tip()`.  Each tip is printed on its own line
+    prefixed with the same bold `Tip:` label as the built-in hint."""
 
     # ===------------------------------------------------------------------=== #
     # Life cycle methods
@@ -169,9 +169,9 @@ struct Command(Copyable, Movable, Stringable, Writable):
         """Creates a deep copy of a Command.
 
         All field data — including registered args and subcommands — is
-        duplicated.  Builder-pattern usage with ``add_subcommand(sub^)``
+        duplicated.  Builder-pattern usage with `add_subcommand(sub^)`
         moves rather than copies, so this is only triggered when a
-        ``Command`` value is assigned via ``=``.
+        `Command` value is assigned via `=`.
 
         Args:
             copy: The Command to copy from.
@@ -221,7 +221,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         Raises:
             Error if adding a positional argument to a Command that already
             has subcommands registered, unless
-            ``allow_positional_with_subcommands()`` has been called.
+            `allow_positional_with_subcommands()` has been called.
 
         Args:
             argument: The Argument to register.
@@ -2549,9 +2549,9 @@ struct Command(Copyable, Movable, Stringable, Writable):
         to a file:
 
         ```bash
-        myapp --generate-completions bash > ~/.bash_completion.d/myapp
-        myapp --generate-completions zsh  > ~/.zsh/completions/_myapp
-        myapp --generate-completions fish > ~/.config/fish/completions/myapp.fish
+        myapp --completions bash > ~/.bash_completion.d/myapp
+        myapp --completions zsh  > ~/.zsh/completions/_myapp
+        myapp --completions fish > ~/.config/fish/completions/myapp.fish
         ```
 
         Args:
@@ -2644,7 +2644,9 @@ struct Command(Copyable, Movable, Stringable, Writable):
 
                 # Subcommand-specific options.
                 var sub_cond = "__fish_seen_subcommand_from " + sub.name
-                s += self._fish_options_for(self.name, sub_cond)
+                s += self._fish_options_for(
+                    self.name, sub_cond, persistent_only=True
+                )
                 # Iterate sub.args for subcommand's own arguments.
                 for j in range(len(sub.args)):
                     var arg = sub.args[j].copy()
@@ -2693,12 +2695,15 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 )
         return s
 
-    fn _fish_options_for(self, cmd_name: String, condition: String) -> String:
+    fn _fish_options_for(
+        self, cmd_name: String, condition: String, persistent_only: Bool = False
+    ) -> String:
         """Generates ``complete`` lines for this command's own arguments.
 
         Args:
             cmd_name: The top-level command name (for ``complete -c``).
             condition: Fish condition string (empty for root-level).
+            persistent_only: When True, only emit persistent arguments.
 
         Returns:
             Lines of ``complete`` commands for non-hidden, non-positional args.
@@ -2707,6 +2712,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
         for i in range(len(self.args)):
             var arg = self.args[i].copy()
             if arg.is_hidden or arg.is_positional:
+                continue
+            if persistent_only and not arg.is_persistent:
                 continue
             var line = "complete -c " + cmd_name
             if condition:
@@ -2763,6 +2770,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
             if not self.subcommands[i]._is_help_subcommand:
                 has_subcommands = True
                 break
+        if self._completions_enabled and self._completions_is_subcommand:
+            has_subcommands = True
 
         if has_subcommands:
             s += self._zsh_with_subcommands()
@@ -2990,6 +2999,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
             if not self.subcommands[i]._is_help_subcommand:
                 has_subcommands = True
                 break
+        if self._completions_enabled and self._completions_is_subcommand:
+            has_subcommands = True
 
         if has_subcommands:
             s += self._bash_with_subcommands()
@@ -3072,6 +3083,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
         s += "  done\n\n"
 
         s += "  if [[ -z $subcmd ]]; then\n"
+        # Root-level $prev choices completion.
+        s += self._bash_prev_cases_for_args(self.args, "    ")
         s += (
             '    COMPREPLY=($(compgen -W "'
             + root_words
@@ -3097,6 +3110,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 if arg.short_name:
                     sub_words += " -" + arg.short_name
             s += "    " + sub.name + ")\n"
+            # Subcommand-level $prev choices completion.
+            s += self._bash_prev_cases_for_args(sub.args, "      ")
             s += (
                 '      COMPREPLY=($(compgen -W "'
                 + sub_words
@@ -3166,6 +3181,66 @@ struct Command(Copyable, Movable, Stringable, Writable):
             s += "      return\n"
             s += "      ;;\n"
         s += "  esac\n"
+        return s
+
+    fn _bash_prev_cases_for_args(
+        self, args: List[Argument], indent: String
+    ) -> String:
+        """Generates `case $prev` blocks for a given list of arguments.
+
+        Used by `_bash_with_subcommands()` to emit choice-value
+        completion for both root-level and subcommand-level options.
+
+        Args:
+            args: The argument list to scan for choice-bearing options.
+            indent: Whitespace prefix for each emitted line.
+
+        Returns:
+            A `case`/`esac` block string, or empty if no choices.
+        """
+        var has_choices = False
+        for i in range(len(args)):
+            if (
+                not args[i].is_hidden
+                and not args[i].is_positional
+                and len(args[i].choice_values) > 0
+            ):
+                has_choices = True
+                break
+        if not has_choices:
+            return ""
+
+        var s = indent + "case $prev in\n"
+        for i in range(len(args)):
+            var arg = args[i].copy()
+            if (
+                arg.is_hidden
+                or arg.is_positional
+                or len(arg.choice_values) == 0
+            ):
+                continue
+            var pattern = String("")
+            if arg.long_name:
+                pattern += "--" + arg.long_name
+            if arg.short_name:
+                if pattern:
+                    pattern += "|"
+                pattern += "-" + arg.short_name
+            var choices = String("")
+            for k in range(len(arg.choice_values)):
+                if choices:
+                    choices += " "
+                choices += arg.choice_values[k]
+            s += indent + "  " + pattern + ")\n"
+            s += (
+                indent
+                + '    COMPREPLY=($(compgen -W "'
+                + choices
+                + '" -- "$cur"))\n'
+            )
+            s += indent + "    return\n"
+            s += indent + "    ;;\n"
+        s += indent + "esac\n"
         return s
 
     fn __str__(self) -> String:

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -78,6 +78,17 @@ struct Command(Copyable, Movable, Stringable, Writable):
     By default (False), registering a positional arg on a Command that already 
     has subcommands (or vice versa) raises an Error at registration time.
     Call `allow_positional_with_subcommands()` to opt in explicitly."""
+    var _completions_enabled: Bool
+    """When True (default), a built-in completion trigger is active.
+    Call ``disable_default_completions()`` to opt out entirely."""
+    var _completions_name: String
+    """The name used for the built-in completion trigger.
+    Defaults to ``"completions"`` → ``--completions <shell>``.
+    Change via ``completions_name()``."""
+    var _completions_is_subcommand: Bool
+    """When True, the completion trigger is a subcommand instead of an
+    option.  Default False → ``--completions``.  Call
+    ``completions_as_subcommand()`` to switch to ``myapp completions bash``."""
     var _tips: List[String]
     """User-defined tips shown at the bottom of the help message.
     Add entries via ``add_tip()``.  Each tip is printed on its own line
@@ -114,6 +125,9 @@ struct Command(Copyable, Movable, Stringable, Writable):
         self._help_subcommand_enabled = True
         self._allow_negative_numbers = False
         self._allow_positional_with_subcommands = False
+        self._completions_enabled = True
+        self._completions_name = String("completions")
+        self._completions_is_subcommand = False
         self._tips = List[String]()
         self._header_color = _DEFAULT_HEADER_COLOR
         self._arg_color = _DEFAULT_ARG_COLOR
@@ -142,6 +156,9 @@ struct Command(Copyable, Movable, Stringable, Writable):
         self._allow_positional_with_subcommands = (
             move._allow_positional_with_subcommands
         )
+        self._completions_enabled = move._completions_enabled
+        self._completions_name = move._completions_name^
+        self._completions_is_subcommand = move._completions_is_subcommand
         self._tips = move._tips^
         self._header_color = move._header_color^
         self._arg_color = move._arg_color^
@@ -185,6 +202,9 @@ struct Command(Copyable, Movable, Stringable, Writable):
         self._allow_positional_with_subcommands = (
             copy._allow_positional_with_subcommands
         )
+        self._completions_enabled = copy._completions_enabled
+        self._completions_name = copy._completions_name
+        self._completions_is_subcommand = copy._completions_is_subcommand
         self._tips = copy._tips.copy()
         self._header_color = copy._header_color
         self._arg_color = copy._arg_color
@@ -408,6 +428,75 @@ struct Command(Copyable, Movable, Stringable, Writable):
         ```
         """
         self._allow_positional_with_subcommands = True
+
+    fn disable_default_completions(mut self):
+        """Disables the built-in completion trigger entirely.
+
+        By default, every ``Command`` has a built-in ``--completions bash``
+        (or ``zsh`` / ``fish``) that prints a shell completion script and
+        exits.  Call this method to remove that trigger completely.
+
+        The ``generate_completion()`` method is still available for
+        programmatic use — only the automatic trigger is removed.
+
+        Example:
+
+        ```mojo
+        var app = Command("myapp", "My CLI")
+        app.disable_default_completions()
+        # --completions is now an unknown option
+        # but app.generate_completion("bash") still works
+        ```
+        """
+        self._completions_enabled = False
+
+    fn completions_name(mut self, name: String):
+        """Sets the name used for the built-in completion trigger.
+
+        Default is ``"completions"`` → ``--completions <shell>``.
+        Change to any name you prefer:
+
+        - ``app.completions_name("autocomp")`` → ``--autocomp bash``
+        - ``app.completions_name("generate-completions")`` → ``--generate-completions bash``
+
+        Combine with ``completions_as_subcommand()`` to use as a subcommand:
+
+        - ``app.completions_name("comp")`` + ``app.completions_as_subcommand()``
+          → ``myapp comp bash``
+
+        Args:
+            name: The new trigger name (without ``--`` prefix).
+
+        Example:
+
+        ```mojo
+        var app = Command("myapp", "My CLI")
+        app.completions_name("autocomp")
+        # Now: myapp --autocomp bash
+        ```
+        """
+        self._completions_name = name
+
+    fn completions_as_subcommand(mut self):
+        """Switches the built-in completion trigger from an option to a subcommand.
+
+        Default behaviour: ``myapp --completions bash``
+        After calling this: ``myapp completions bash``
+
+        Combine with ``completions_name()`` to customise the subcommand name:
+
+        ```mojo
+        app.completions_name("comp")
+        app.completions_as_subcommand()
+        # → myapp comp bash
+        ```
+
+        The subcommand is auto-registered when ``parse()`` runs. It does
+        **not** appear in help output by default (like the ``help``
+        subcommand). The auto-registered subcommand takes one positional
+        argument (the shell name) and handles printing + exiting.
+        """
+        self._completions_is_subcommand = True
 
     fn add_tip(mut self, tip: String):
         """Adds a custom tip line to the bottom of the help message.
@@ -825,6 +914,29 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 print(self.name + " " + self.version)
                 exit(0)
 
+            # Handle --<completions_name> <shell>  (built-in, like --help/--version)
+            if (
+                self._completions_enabled
+                and not self._completions_is_subcommand
+                and arg == "--" + self._completions_name
+            ):
+                if i + 1 < len(raw_args):
+                    i += 1
+                    var shell_arg = raw_args[i]
+                    try:
+                        print(self.generate_completion(shell_arg))
+                    except e:
+                        self._error(String(e))
+                        exit(2)
+                    exit(0)
+                else:
+                    self._error(
+                        "--"
+                        + self._completions_name
+                        + " requires a shell name: bash, zsh, or fish"
+                    )
+                    exit(2)
+
             # Long option: --key, --key=value, --key value
             if arg.startswith("--"):
                 i = self._parse_long_option(raw_args, i, result)
@@ -857,6 +969,27 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 continue
 
             # Positional argument — check for subcommand dispatch first.
+            # Built-in completions subcommand (when in subcommand mode).
+            if (
+                self._completions_enabled
+                and self._completions_is_subcommand
+                and arg == self._completions_name
+            ):
+                if i + 1 < len(raw_args):
+                    i += 1
+                    var shell_arg = raw_args[i]
+                    try:
+                        print(self.generate_completion(shell_arg))
+                    except e:
+                        self._error(String(e))
+                        exit(2)
+                    exit(0)
+                else:
+                    self._error(
+                        self._completions_name
+                        + " requires a shell name: bash, zsh, or fish"
+                    )
+                    exit(2)
             if len(self.subcommands) > 0:
                 var new_i = self._dispatch_subcommand(arg, raw_args, i, result)
                 if new_i >= 0:
@@ -2098,6 +2231,25 @@ struct Command(Copyable, Movable, Stringable, Writable):
         opt_colors.append(version_colored)
         opt_persistent.append(False)
         opt_helps.append(String("Show version"))
+        if self._completions_enabled and not self._completions_is_subcommand:
+            var comp_plain = String(
+                "  --" + self._completions_name + " {bash,zsh,fish}"
+            )
+            var comp_colored = (
+                "  "
+                + arg_color
+                + "--"
+                + self._completions_name
+                + reset_code
+                + " "
+                + arg_color
+                + "{bash,zsh,fish}"
+                + reset_code
+            )
+            opt_plains.append(comp_plain)
+            opt_colors.append(comp_colored)
+            opt_persistent.append(False)
+            opt_helps.append(String("Generate shell completion script"))
 
         # Check if there are any persistent (global) options.
         var has_global = False
@@ -2168,6 +2320,9 @@ struct Command(Copyable, Movable, Stringable, Writable):
             if not self.subcommands[i]._is_help_subcommand:
                 has_subcommands = True
                 break
+        # Also count completions subcommand if in subcommand mode.
+        if self._completions_enabled and self._completions_is_subcommand:
+            has_subcommands = True
 
         if not has_subcommands:
             return ""
@@ -2187,6 +2342,16 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 cmd_plains.append(plain)
                 cmd_colors.append(colored)
                 cmd_helps.append(self.subcommands[i].description)
+        # Append completions subcommand if in subcommand mode.
+        if self._completions_enabled and self._completions_is_subcommand:
+            var cname = self._completions_name
+            var plain = String("  ") + cname
+            var colored = String("  ") + arg_color + cname + reset_code
+            cmd_plains.append(plain)
+            cmd_colors.append(colored)
+            cmd_helps.append(
+                String("Generate shell completion script (bash, zsh, fish)")
+            )
         # Compute padding.
         var cmd_max: Int = 0
         for k in range(len(cmd_plains)):
@@ -2371,6 +2536,637 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 line += " "
             line += value_strs[k]
             print(line)
+
+    # ===------------------------------------------------------------------=== #
+    # Shell completion generation
+    # ===------------------------------------------------------------------=== #
+
+    fn generate_completion(self, shell: String) raises -> String:
+        """Generates a shell completion script for this command tree.
+
+        Supports ``bash``, ``zsh``, and ``fish`` shells.  The returned
+        string is a complete script that the user can source or redirect
+        to a file:
+
+        ```bash
+        myapp --generate-completions bash > ~/.bash_completion.d/myapp
+        myapp --generate-completions zsh  > ~/.zsh/completions/_myapp
+        myapp --generate-completions fish > ~/.config/fish/completions/myapp.fish
+        ```
+
+        Args:
+            shell: One of ``"bash"``, ``"zsh"``, or ``"fish"``
+                   (case-insensitive).
+
+        Returns:
+            The completion script as a string.
+
+        Raises:
+            Error if *shell* is not recognised.
+        """
+        var lower = shell.lower()
+        if lower == "fish":
+            return self._completion_fish()
+        if lower == "zsh":
+            return self._completion_zsh()
+        if lower == "bash":
+            return self._completion_bash()
+        raise Error("Unknown shell '" + shell + "'. Supported: bash, zsh, fish")
+
+    fn _completion_fish(self) -> String:
+        """Generates a Fish shell completion script.
+
+        Each option/subcommand becomes a single ``complete`` line.
+        Subcommand-specific completions use ``-n '__fish_seen_subcommand_from <sub>'``
+        to scope them.
+
+        Returns:
+            A complete Fish completion script.
+        """
+        var s = String("# Fish completions for " + self.name + "\n")
+        s += "# Generated by ArgMojo\n\n"
+
+        # Root-level options.
+        s += self._fish_options_for(self.name, "")
+        # Built-in options.
+        s += (
+            "complete -c "
+            + self.name
+            + " -s h -l help -d 'Show this help message'\n"
+        )
+        s += "complete -c " + self.name + " -s V -l version -d 'Show version'\n"
+        if self._completions_enabled and not self._completions_is_subcommand:
+            s += (
+                "complete -c "
+                + self.name
+                + " -l "
+                + self._completions_name
+                + " -r -a 'bash zsh fish'"
+                + " -d 'Generate shell completion script'\n"
+            )
+
+        # Subcommands.
+        var _comp_is_sub = (
+            self._completions_enabled and self._completions_is_subcommand
+        )
+        if len(self.subcommands) > 0 or _comp_is_sub:
+            # Condition: no subcommand seen yet.
+            var sub_names = String("")
+            for i in range(len(self.subcommands)):
+                if not self.subcommands[i]._is_help_subcommand:
+                    if sub_names:
+                        sub_names += " "
+                    sub_names += self.subcommands[i].name
+            if _comp_is_sub:
+                if sub_names:
+                    sub_names += " "
+                sub_names += self._completions_name
+            var no_sub_cond = "__fish_seen_subcommand_from " + sub_names
+
+            for i in range(len(self.subcommands)):
+                if self.subcommands[i]._is_help_subcommand:
+                    continue
+                var sub = self.subcommands[i].copy()
+                # Register the subcommand itself.
+                s += (
+                    "complete -c "
+                    + self.name
+                    + " -n 'not "
+                    + no_sub_cond
+                    + "'"
+                    + " -f -a '"
+                    + sub.name
+                    + "'"
+                )
+                if sub.description:
+                    s += " -d '" + self._fish_escape(sub.description) + "'"
+                s += "\n"
+
+                # Subcommand-specific options.
+                var sub_cond = "__fish_seen_subcommand_from " + sub.name
+                s += self._fish_options_for(self.name, sub_cond)
+                # Iterate sub.args for subcommand's own arguments.
+                for j in range(len(sub.args)):
+                    var arg = sub.args[j].copy()
+                    if arg.is_hidden or arg.is_positional:
+                        continue
+                    var line = "complete -c " + self.name
+                    line += " -n '" + sub_cond + "'"
+                    if arg.short_name:
+                        line += " -s " + arg.short_name
+                    if arg.long_name:
+                        line += " -l " + arg.long_name
+                    if not arg.is_flag and not arg.is_count:
+                        line += " -r"
+                    if len(arg.choice_values) > 0:
+                        var choices = String("")
+                        for k in range(len(arg.choice_values)):
+                            if choices:
+                                choices += " "
+                            choices += arg.choice_values[k]
+                        line += " -a '" + choices + "'"
+                    if arg.help_text:
+                        line += " -d '" + self._fish_escape(arg.help_text) + "'"
+                    s += line + "\n"
+
+            # Completions subcommand entry.
+            if _comp_is_sub:
+                var cname = self._completions_name
+                s += (
+                    "complete -c "
+                    + self.name
+                    + " -n 'not "
+                    + no_sub_cond
+                    + "'"
+                    + " -f -a '"
+                    + cname
+                    + "'"
+                    + " -d 'Generate shell completion script'\n"
+                )
+                s += (
+                    "complete -c "
+                    + self.name
+                    + " -n '__fish_seen_subcommand_from "
+                    + cname
+                    + "'"
+                    + " -r -a 'bash zsh fish'\n"
+                )
+        return s
+
+    fn _fish_options_for(self, cmd_name: String, condition: String) -> String:
+        """Generates ``complete`` lines for this command's own arguments.
+
+        Args:
+            cmd_name: The top-level command name (for ``complete -c``).
+            condition: Fish condition string (empty for root-level).
+
+        Returns:
+            Lines of ``complete`` commands for non-hidden, non-positional args.
+        """
+        var s = String("")
+        for i in range(len(self.args)):
+            var arg = self.args[i].copy()
+            if arg.is_hidden or arg.is_positional:
+                continue
+            var line = "complete -c " + cmd_name
+            if condition:
+                line += " -n '" + condition + "'"
+            if arg.short_name:
+                line += " -s " + arg.short_name
+            if arg.long_name:
+                line += " -l " + arg.long_name
+            if not arg.is_flag and not arg.is_count:
+                line += " -r"
+            if len(arg.choice_values) > 0:
+                var choices = String("")
+                for k in range(len(arg.choice_values)):
+                    if choices:
+                        choices += " "
+                    choices += arg.choice_values[k]
+                line += " -a '" + choices + "'"
+            if arg.help_text:
+                line += " -d '" + self._fish_escape(arg.help_text) + "'"
+            s += line + "\n"
+        return s
+
+    fn _fish_escape(self, text: String) -> String:
+        """Escapes single quotes in text for Fish shell strings.
+
+        Args:
+            text: The text to escape.
+
+        Returns:
+            The escaped text with ``'`` replaced by ``\\'``.
+        """
+        var result = String("")
+        for i in range(len(text)):
+            var ch = text[i : i + 1]
+            if ch == "'":
+                result += "\\'"
+            else:
+                result += ch
+        return result
+
+    fn _completion_zsh(self) -> String:
+        """Generates a Zsh completion script using ``_arguments``.
+
+        Returns:
+            A complete Zsh completion script.
+        """
+        var s = String("#compdef " + self.name + "\n")
+        s += "# Zsh completions for " + self.name + "\n"
+        s += "# Generated by ArgMojo\n\n"
+
+        # If there are subcommands, generate a dispatcher function.
+        var has_subcommands = False
+        for i in range(len(self.subcommands)):
+            if not self.subcommands[i]._is_help_subcommand:
+                has_subcommands = True
+                break
+
+        if has_subcommands:
+            s += self._zsh_with_subcommands()
+        else:
+            s += self._zsh_simple()
+
+        s += "compdef _" + self.name + " " + self.name + "\n"
+        return s
+
+    fn _zsh_simple(self) -> String:
+        """Generates a simple Zsh completion function (no subcommands).
+
+        Returns:
+            The function body string.
+        """
+        var s = String("_" + self.name + "() {\n")
+        s += "  _arguments \\\n"
+        # User-defined arguments.
+        for i in range(len(self.args)):
+            var arg = self.args[i].copy()
+            if arg.is_hidden:
+                continue
+            if arg.is_positional:
+                continue
+            s += "    " + self._zsh_arg_spec(arg) + " \\\n"
+        # Built-in options.
+        s += "    '(- *)'{-h,--help}'[Show this help message]' \\\n"
+        if self._completions_enabled and not self._completions_is_subcommand:
+            s += "    '(- *)'{-V,--version}'[Show version]' \\\n"
+            s += (
+                "    '--"
+                + self._completions_name
+                + "[Generate shell completion script]:shell:(bash zsh fish)'\n"
+            )
+        else:
+            s += "    '(- *)'{-V,--version}'[Show version]'\n"
+        s += "}\n\n"
+        return s
+
+    fn _zsh_with_subcommands(self) -> String:
+        """Generates a Zsh completion function with subcommand dispatch.
+
+        Returns:
+            The function body string with subcommand handling.
+        """
+        var s = String("_" + self.name + "() {\n")
+        s += "  local -a commands\n"
+        s += "  commands=(\n"
+        for i in range(len(self.subcommands)):
+            if self.subcommands[i]._is_help_subcommand:
+                continue
+            var sub = self.subcommands[i].copy()
+            var desc = self._zsh_escape(
+                sub.description
+            ) if sub.description else ""
+            s += "    '" + sub.name + ":" + desc + "'\n"
+        if self._completions_enabled and self._completions_is_subcommand:
+            s += (
+                "    '"
+                + self._completions_name
+                + ":Generate shell completion script'\n"
+            )
+        s += "  )\n\n"
+
+        s += "  _arguments -C \\\n"
+        # Root-level options.
+        for i in range(len(self.args)):
+            var arg = self.args[i].copy()
+            if arg.is_hidden or arg.is_positional:
+                continue
+            s += "    " + self._zsh_arg_spec(arg) + " \\\n"
+        s += "    '(- *)'{-h,--help}'[Show this help message]' \\\n"
+        s += "    '(- *)'{-V,--version}'[Show version]' \\\n"
+        if self._completions_enabled and not self._completions_is_subcommand:
+            s += (
+                "    '--"
+                + self._completions_name
+                + "[Generate shell completion"
+                " script]:shell:(bash zsh fish)' \\\n"
+            )
+        s += "    '1:command:->cmd' \\\n"
+        s += "    '*::arg:->args'\n\n"
+
+        s += "  case $state in\n"
+        s += "    cmd)\n"
+        s += "      _describe -t commands 'command' commands\n"
+        s += "      ;;\n"
+        s += "    args)\n"
+        s += "      case $words[1] in\n"
+        for i in range(len(self.subcommands)):
+            if self.subcommands[i]._is_help_subcommand:
+                continue
+            var sub = self.subcommands[i].copy()
+            s += "        " + sub.name + ")\n"
+            s += "          _arguments \\\n"
+            for j in range(len(sub.args)):
+                var arg = sub.args[j].copy()
+                if arg.is_hidden:
+                    continue
+                if arg.is_positional:
+                    continue
+                s += "            " + self._zsh_arg_spec(arg) + " \\\n"
+            s += "            '(- *)'{-h,--help}'[Show this help message]'\n"
+            s += "          ;;\n"
+
+        if self._completions_enabled and self._completions_is_subcommand:
+            s += "        " + self._completions_name + ")\n"
+            s += (
+                "          _arguments \\\n"
+                "            '1:shell:(bash zsh fish)'\n"
+            )
+            s += "          ;;\n"
+
+        s += "      esac\n"
+        s += "      ;;\n"
+        s += "  esac\n"
+        s += "}\n\n"
+        return s
+
+    fn _zsh_arg_spec(self, arg: Argument) -> String:
+        """Builds a single ``_arguments`` spec string for an argument.
+
+        Args:
+            arg: The argument to generate a spec for.
+
+        Returns:
+            A ``_arguments``-compatible spec string, e.g.
+            ``'--verbose[Enable verbose output]'``.
+        """
+        var spec = String("")
+        var desc = self._zsh_escape(arg.help_text) if arg.help_text else ""
+
+        if arg.short_name and arg.long_name:
+            # Grouped short+long form.
+            spec += (
+                "'(-"
+                + arg.short_name
+                + " --"
+                + arg.long_name
+                + ")'"
+                + "{-"
+                + arg.short_name
+                + ",--"
+                + arg.long_name
+                + "}"
+            )
+        elif arg.long_name:
+            spec += "'--" + arg.long_name
+        elif arg.short_name:
+            spec += "'-" + arg.short_name
+
+        if arg.short_name and arg.long_name:
+            # Description + value spec.
+            spec += "'[" + desc + "]"
+            if not arg.is_flag and not arg.is_count:
+                if len(arg.choice_values) > 0:
+                    var choices = String("")
+                    for k in range(len(arg.choice_values)):
+                        if choices:
+                            choices += " "
+                        choices += arg.choice_values[k]
+                    spec += ":value:(" + choices + ")"
+                else:
+                    var mv = arg.metavar_name if arg.metavar_name else arg.name
+                    spec += ":" + mv + ":"
+            spec += "'"
+        else:
+            if not arg.is_flag and not arg.is_count:
+                if len(arg.choice_values) > 0:
+                    var choices = String("")
+                    for k in range(len(arg.choice_values)):
+                        if choices:
+                            choices += " "
+                        choices += arg.choice_values[k]
+                    spec += "[" + desc + "]:value:(" + choices + ")'"
+                else:
+                    var mv = arg.metavar_name if arg.metavar_name else arg.name
+                    spec += "[" + desc + "]:" + mv + ":'"
+            else:
+                spec += "[" + desc + "]'"
+
+        return spec
+
+    fn _zsh_escape(self, text: String) -> String:
+        """Escapes special characters in text for Zsh completion specs.
+
+        Escapes ``[``, ``]``, ``'``, and ``:`` which have special meaning
+        in ``_arguments`` spec syntax.
+
+        Args:
+            text: The text to escape.
+
+        Returns:
+            The escaped text.
+        """
+        var result = String("")
+        for i in range(len(text)):
+            var ch = text[i : i + 1]
+            if ch == "[" or ch == "]":
+                result += "\\" + ch
+            elif ch == "'":
+                result += "'\"'\"'"
+            elif ch == ":":
+                result += "\\:"
+            else:
+                result += ch
+        return result
+
+    fn _completion_bash(self) -> String:
+        """Generates a Bash completion script using ``complete -F``.
+
+        Returns:
+            A complete Bash completion script.
+        """
+        var fn_name = "_" + self.name + "_completion"
+        var s = String("# Bash completions for " + self.name + "\n")
+        s += "# Generated by ArgMojo\n\n"
+        s += fn_name + "() {\n"
+        s += '  local cur="${COMP_WORDS[COMP_CWORD]}"\n'
+        s += '  local prev="${COMP_WORDS[COMP_CWORD-1]}"\n'
+
+        # Check if there are subcommands.
+        var has_subcommands = False
+        for i in range(len(self.subcommands)):
+            if not self.subcommands[i]._is_help_subcommand:
+                has_subcommands = True
+                break
+
+        if has_subcommands:
+            s += self._bash_with_subcommands()
+        else:
+            s += self._bash_simple()
+
+        s += "}\n\n"
+        s += "complete -F " + fn_name + " " + self.name + "\n"
+        return s
+
+    fn _bash_simple(self) -> String:
+        """Generates the body of a simple Bash completion function.
+
+        Returns:
+            The case/COMPREPLY logic for a command with no subcommands.
+        """
+        # Collect all option words.
+        var words = String("--help --version")
+        if self._completions_enabled and not self._completions_is_subcommand:
+            words += " --" + self._completions_name
+        for i in range(len(self.args)):
+            var arg = self.args[i].copy()
+            if arg.is_hidden or arg.is_positional:
+                continue
+            if arg.long_name:
+                words += " --" + arg.long_name
+            if arg.short_name:
+                words += " -" + arg.short_name
+
+        # Handle value completion for prev.
+        var s = self._bash_prev_cases()
+        s += '  COMPREPLY=($(compgen -W "' + words + '" -- "$cur"))\n'
+        return s
+
+    fn _bash_with_subcommands(self) -> String:
+        """Generates the body of a Bash completion function with subcommands.
+
+        Uses ``COMP_WORDS`` scanning to detect which subcommand is active,
+        then scopes completions accordingly.
+
+        Returns:
+            The completion logic body string.
+        """
+        # Collect subcommand names.
+        var sub_names = String("")
+        for i in range(len(self.subcommands)):
+            if self.subcommands[i]._is_help_subcommand:
+                continue
+            if sub_names:
+                sub_names += " "
+            sub_names += self.subcommands[i].name
+        if self._completions_enabled and self._completions_is_subcommand:
+            if sub_names:
+                sub_names += " "
+            sub_names += self._completions_name
+
+        var s = String("")
+        # Root-level options.
+        var root_words = String("--help --version")
+        if self._completions_enabled and not self._completions_is_subcommand:
+            root_words += " --" + self._completions_name
+        for i in range(len(self.args)):
+            var arg = self.args[i].copy()
+            if arg.is_hidden or arg.is_positional:
+                continue
+            if arg.long_name:
+                root_words += " --" + arg.long_name
+            if arg.short_name:
+                root_words += " -" + arg.short_name
+
+        # Detect subcommand in COMP_WORDS.
+        s += "  local subcmd=''\n"
+        s += "  for ((i=1; i<COMP_CWORD; i++)); do\n"
+        s += "    case ${COMP_WORDS[i]} in\n"
+        s += "      " + sub_names.replace(" ", "|") + ")\n"
+        s += "        subcmd=${COMP_WORDS[i]}\n"
+        s += "        break\n"
+        s += "        ;;\n"
+        s += "    esac\n"
+        s += "  done\n\n"
+
+        s += "  if [[ -z $subcmd ]]; then\n"
+        s += (
+            '    COMPREPLY=($(compgen -W "'
+            + root_words
+            + " "
+            + sub_names
+            + '" -- "$cur"))\n'
+        )
+        s += "    return\n"
+        s += "  fi\n\n"
+
+        s += "  case $subcmd in\n"
+        for i in range(len(self.subcommands)):
+            if self.subcommands[i]._is_help_subcommand:
+                continue
+            var sub = self.subcommands[i].copy()
+            var sub_words = String("--help")
+            for j in range(len(sub.args)):
+                var arg = sub.args[j].copy()
+                if arg.is_hidden or arg.is_positional:
+                    continue
+                if arg.long_name:
+                    sub_words += " --" + arg.long_name
+                if arg.short_name:
+                    sub_words += " -" + arg.short_name
+            s += "    " + sub.name + ")\n"
+            s += (
+                '      COMPREPLY=($(compgen -W "'
+                + sub_words
+                + '" -- "$cur"))\n'
+            )
+            s += "      ;;\n"
+        if self._completions_enabled and self._completions_is_subcommand:
+            s += "    " + self._completions_name + ")\n"
+            s += '      COMPREPLY=($(compgen -W "bash zsh fish" -- "$cur"))\n'
+            s += "      ;;\n"
+        s += "  esac\n"
+        return s
+
+    fn _bash_prev_cases(self) -> String:
+        """Generates ``case $prev`` blocks for options with choices.
+
+        When the previous word is an option that has a fixed set of
+        choices, completes those values.
+
+        Returns:
+            A ``case``/``esac`` block string, or empty if no choices.
+        """
+        var has_choices = (
+            self._completions_enabled and not self._completions_is_subcommand
+        )
+        if not has_choices:
+            for i in range(len(self.args)):
+                if (
+                    not self.args[i].is_hidden
+                    and not self.args[i].is_positional
+                    and len(self.args[i].choice_values) > 0
+                ):
+                    has_choices = True
+                    break
+
+        if not has_choices:
+            return ""
+
+        var s = String("  case $prev in\n")
+        if self._completions_enabled and not self._completions_is_subcommand:
+            s += "    --" + self._completions_name + ")\n"
+            s += '      COMPREPLY=($(compgen -W "bash zsh fish" -- "$cur"))\n'
+            s += "      return\n"
+            s += "      ;;\n"
+        for i in range(len(self.args)):
+            var arg = self.args[i].copy()
+            if (
+                arg.is_hidden
+                or arg.is_positional
+                or len(arg.choice_values) == 0
+            ):
+                continue
+            var pattern = String("")
+            if arg.long_name:
+                pattern += "--" + arg.long_name
+            if arg.short_name:
+                if pattern:
+                    pattern += "|"
+                pattern += "-" + arg.short_name
+            var choices = String("")
+            for k in range(len(arg.choice_values)):
+                if choices:
+                    choices += " "
+                choices += arg.choice_values[k]
+            s += "    " + pattern + ")\n"
+            s += '      COMPREPLY=($(compgen -W "' + choices + '" -- "$cur"))\n'
+            s += "      return\n"
+            s += "      ;;\n"
+        s += "  esac\n"
+        return s
 
     fn __str__(self) -> String:
         """Returns a string representation of this command."""

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -60,39 +60,39 @@ struct Command(Copyable, Movable, Stringable, Writable):
     """ANSI code for parse error messages (default: red)."""
     var _is_help_subcommand: Bool
     """True for the auto-inserted 'help' pseudo-subcommand.
-    Never set this manually; use `add_subcommand()` to register subcommands and
-    `disable_help_subcommand()` to opt out.
+    Never set this manually; use ``add_subcommand()`` to register subcommands and
+    ``disable_help_subcommand()`` to opt out.
     """
     var _help_subcommand_enabled: Bool
     """When True (default), auto-insert a 'help' subcommand on first 
-    `add_subcommand()` call."""
+    ``add_subcommand()`` call."""
     var _allow_negative_numbers: Bool
     """When True, tokens matching negative-number format (-N, -N.N, -NeX)
     are always treated as positional arguments.
     When False (default), the same treatment applies automatically whenever
     no registered short option uses a digit character (auto-detect).
-    Enable explicitly via `allow_negative_numbers()` when you have a digit
+    Enable explicitly via ``allow_negative_numbers()`` when you have a digit
     short option and still need negative-number literals to pass through."""
     var _allow_positional_with_subcommands: Bool
     """When True, allows mixing positional arguments with subcommands.
     By default (False), registering a positional arg on a Command that already 
     has subcommands (or vice versa) raises an Error at registration time.
-    Call `allow_positional_with_subcommands()` to opt in explicitly."""
+    Call ``allow_positional_with_subcommands()`` to opt in explicitly."""
     var _completions_enabled: Bool
     """When True (default), a built-in completion trigger is active.
-    Call `disable_default_completions()` to opt out entirely."""
+    Call ``disable_default_completions()`` to opt out entirely."""
     var _completions_name: String
     """The name used for the built-in completion trigger.
-    Defaults to `"completions"` → `--completions <shell>`.
-    Change via `completions_name()`."""
+    Defaults to ``"completions"`` → ``--completions <shell>``.
+    Change via ``completions_name()``."""
     var _completions_is_subcommand: Bool
     """When True, the completion trigger is a subcommand instead of an
-    option.  Default False → `--completions`.  Call
-    `completions_as_subcommand()` to switch to `myapp completions bash`."""
+    option.  Default False → ``--completions``.  Call
+    ``completions_as_subcommand()`` to switch to ``myapp completions bash``."""
     var _tips: List[String]
     """User-defined tips shown at the bottom of the help message.
-    Add entries via `add_tip()`.  Each tip is printed on its own line
-    prefixed with the same bold `Tip:` label as the built-in hint."""
+    Add entries via ``add_tip()``.  Each tip is printed on its own line
+    prefixed with the same bold ``Tip:`` label as the built-in hint."""
 
     # ===------------------------------------------------------------------=== #
     # Life cycle methods
@@ -169,9 +169,9 @@ struct Command(Copyable, Movable, Stringable, Writable):
         """Creates a deep copy of a Command.
 
         All field data — including registered args and subcommands — is
-        duplicated.  Builder-pattern usage with `add_subcommand(sub^)`
+        duplicated.  Builder-pattern usage with ``add_subcommand(sub^)``
         moves rather than copies, so this is only triggered when a
-        `Command` value is assigned via `=`.
+        ``Command`` value is assigned via ``=``.
 
         Args:
             copy: The Command to copy from.
@@ -221,7 +221,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         Raises:
             Error if adding a positional argument to a Command that already
             has subcommands registered, unless
-            `allow_positional_with_subcommands()` has been called.
+            ``allow_positional_with_subcommands()`` has been called.
 
         Args:
             argument: The Argument to register.
@@ -366,9 +366,9 @@ struct Command(Copyable, Movable, Stringable, Writable):
         from argmojo import Command
         var app = Command("search", "Search engine")
         app.disable_help_subcommand()   # "help" is a valid search query
-        # Now: `search help init`  →  positionals ["help", "init"] on root,
+        # Now: ``search help init``  →  positionals ["help", "init"] on root,
         #    so that you can do something like: search "help" in path "init".
-        #    `search init --help`  →  shows init's help page
+        #    ``search init --help``  →  shows init's help page
         ```
         """
         self._help_subcommand_enabled = False
@@ -442,6 +442,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         Example:
 
         ```mojo
+        from argmojo import Command
         var app = Command("myapp", "My CLI")
         app.disable_default_completions()
         # --completions is now an unknown option
@@ -470,6 +471,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         Example:
 
         ```mojo
+        from argmojo import Command
         var app = Command("myapp", "My CLI")
         app.completions_name("autocomp")
         # Now: myapp --autocomp bash
@@ -486,6 +488,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
         Combine with ``completions_name()`` to customise the subcommand name:
 
         ```mojo
+        from argmojo import Command
+        var app = Command("decimo", "CLI calculator based on decimo")
         app.completions_name("comp")
         app.completions_as_subcommand()
         # → myapp comp bash
@@ -722,12 +726,12 @@ struct Command(Copyable, Movable, Stringable, Writable):
         self._error_color = _resolve_color(name)
 
     # Here is a high-level outline of the parsing algorithm implemented in
-    # `parse_args`:
+    # ``parse_args``:
     #
     # 1. Initialize ParseResult and register positional names.
-    # 2. If `help_on_no_args` is enabled and only argv[0] is present:
+    # 2. If ``help_on_no_args`` is enabled and only argv[0] is present:
     #    print help and exit.
-    # 3. Iterate from argv[1] with cursor `i`:
+    # 3. Iterate from argv[1] with cursor ``i``:
     #    ├─ If token is "--": enter positional-only mode.
     #    ├─ If in positional-only mode: append token to positionals.
     #    ├─ If token is --help / -h / -?: print help and exit.
@@ -826,7 +830,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         return s
 
     fn parse(self) raises -> ParseResult:
-        """Parses command-line arguments from `sys.argv()`.
+        """Parses command-line arguments from ``sys.argv()``.
 
         Errors from parsing (missing/invalid arguments, validation failures)
         are printed in colour to stderr and the process exits with code 2.
@@ -853,7 +857,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
     fn parse_args(self, raw_args: List[String]) raises -> ParseResult:
         """Parses the given argument list.
 
-        The first element, e.g., `argv[0]`, is expected to be the program name
+        The first element, e.g., ``argv[0]``, is expected to be the program name
         and is skipped.
 
         Args:
@@ -867,7 +871,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
 
         Notes:
 
-        The modifier for `self` is `read` but not `mut`. This ensures that the
+        The modifier for ``self`` is ``read`` but not ``mut``. This ensures that the
         parsing process does not mutate the Command instance itself, which
         prevents contamination and conflicts between multiple parses, e.g.,
         in testing scenarios, REPL usage, and autocompletion.
@@ -1457,7 +1461,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         """Fills in default values for arguments not provided by the user.
 
         For positional arguments, defaults are placed into the correct slot.
-        For named arguments, the default is stored in `result.values`.
+        For named arguments, the default is stored in ``result.values``.
 
         Args:
             result: The parse result to mutate in-place.
@@ -3186,9 +3190,9 @@ struct Command(Copyable, Movable, Stringable, Writable):
     fn _bash_prev_cases_for_args(
         self, args: List[Argument], indent: String
     ) -> String:
-        """Generates `case $prev` blocks for a given list of arguments.
+        """Generates ``case $prev`` blocks for a given list of arguments.
 
-        Used by `_bash_with_subcommands()` to emit choice-value
+        Used by ``_bash_with_subcommands()`` to emit choice-value
         completion for both root-level and subcommand-level options.
 
         Args:
@@ -3196,7 +3200,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
             indent: Whitespace prefix for each emitted line.
 
         Returns:
-            A `case`/`esac` block string, or empty if no choices.
+            A ``case``/``esac`` block string, or empty if no choices.
         """
         var has_choices = False
         for i in range(len(args)):

--- a/src/argmojo/parse_result.mojo
+++ b/src/argmojo/parse_result.mojo
@@ -159,7 +159,7 @@ struct ParseResult(Copyable, Movable, Stringable, Writable):
             The list of collected values.
 
         Note:
-            For map-type arguments (`.map_option()`), each entry is the
+            For map-type arguments (``.map_option()``), each entry is the
             raw ``key=value`` string (e.g. ``["DEBUG=1", "VERSION=2"]``).
             Use ``get_map()`` instead to retrieve the parsed dict.
         """

--- a/src/argmojo/utils.mojo
+++ b/src/argmojo/utils.mojo
@@ -27,8 +27,9 @@ comptime _DEFAULT_ERROR_COLOR = _RED
 fn _looks_like_number(token: String) -> Bool:
     """Returns True if *token* is a negative-number literal.
 
-    Recognises the forms `-N`, `-N.N`, `-.N`, `-NeX`, `-N.NeX`, `-N.NEX`,
-    `-.NE+X`, and the corresponding `-Ne+X`, `-Ne-X`, `-NE+X`, `-NE-X` variants.
+    Recognises the forms ``-N``, ``-N.N``, ``-.N``, ``-NeX``, ``-N.NeX``,
+    ``-N.NEX``, ``-.NE+X``, and the corresponding ``-Ne+X``, ``-Ne-X``,
+    ``-NE+X``, ``-NE-X`` variants.
     """
     if len(token) < 2 or token[0:1] != "-":
         return False
@@ -161,7 +162,7 @@ fn _levenshtein(a: String, b: String) -> Int:
 fn _suggest_similar(input: String, candidates: List[String]) -> String:
     """Returns a 'Did you mean ...?' hint for the closest candidate.
 
-    Uses Levenshtein distance with a threshold of `max(len(input)/2, 2)`.
+    Uses Levenshtein distance with a threshold of ``max(len(input)/2, 2)``.
     If no candidate is close enough, returns an empty string.
 
     Args:
@@ -169,8 +170,8 @@ fn _suggest_similar(input: String, candidates: List[String]) -> String:
         candidates: Valid option / subcommand names to compare against.
 
     Returns:
-        A non-empty hint string such as `". Did you mean '--verbose'?"`
-        or `""` when there is no good match.
+        A non-empty hint string such as ``". Did you mean '--verbose'?"``
+        or ``""`` when there is no good match.
     """
     if len(candidates) == 0:
         return ""

--- a/tests/test_completion.mojo
+++ b/tests/test_completion.mojo
@@ -530,13 +530,16 @@ fn test_count_option_no_value() raises:
     # Fish: should NOT have -r
     var fish = command.generate_completion("fish")
     var lines = fish.split("\n")
+    var found = False
     for i in range(len(lines)):
         if "-l verbose" in lines[i]:
+            found = True
             assert_false(
                 " -r" in lines[i],
                 msg="Count option should not have -r in Fish",
             )
             break
+    assert_true(found, msg="Fish script should contain '-l verbose' line")
     print("  ✓ test_count_option_no_value")
 
 

--- a/tests/test_completion.mojo
+++ b/tests/test_completion.mojo
@@ -1,0 +1,928 @@
+"""Tests for argmojo — shell completion script generation (bash, zsh, fish)."""
+
+from testing import assert_true, assert_false, assert_equal, TestSuite
+import argmojo
+from argmojo import Argument, Command
+
+
+# ── generate_completion() dispatch ───────────────────────────────────────────
+
+
+fn test_fish_dispatch() raises:
+    """Tests that generate_completion('fish') returns Fish syntax."""
+    var command = Command("myapp", "A test app")
+    command.add_argument(
+        Argument("verbose", help="Enable verbose output")
+        .long("verbose")
+        .short("v")
+        .flag()
+    )
+    var script = command.generate_completion("fish")
+    assert_true(
+        "complete -c myapp" in script,
+        msg="Fish script should contain 'complete -c myapp'",
+    )
+    print("  ✓ test_fish_dispatch")
+
+
+fn test_zsh_dispatch() raises:
+    """Tests that generate_completion('zsh') returns Zsh syntax."""
+    var command = Command("myapp", "A test app")
+    command.add_argument(
+        Argument("verbose", help="Enable verbose output")
+        .long("verbose")
+        .short("v")
+        .flag()
+    )
+    var script = command.generate_completion("zsh")
+    assert_true(
+        "#compdef myapp" in script,
+        msg="Zsh script should start with '#compdef myapp'",
+    )
+    assert_true(
+        "compdef _myapp myapp" in script,
+        msg="Zsh script should register with 'compdef'",
+    )
+    print("  ✓ test_zsh_dispatch")
+
+
+fn test_bash_dispatch() raises:
+    """Tests that generate_completion('bash') returns Bash syntax."""
+    var command = Command("myapp", "A test app")
+    command.add_argument(
+        Argument("verbose", help="Enable verbose output")
+        .long("verbose")
+        .short("v")
+        .flag()
+    )
+    var script = command.generate_completion("bash")
+    assert_true(
+        "complete -F _myapp_completion myapp" in script,
+        msg="Bash script should register with 'complete -F'",
+    )
+    print("  ✓ test_bash_dispatch")
+
+
+fn test_case_insensitive_shell() raises:
+    """Tests that shell name is case-insensitive."""
+    var command = Command("myapp", "A test app")
+    var fish_upper = command.generate_completion("FISH")
+    assert_true(
+        "complete -c myapp" in fish_upper,
+        msg="FISH (uppercase) should work",
+    )
+    var zsh_mixed = command.generate_completion("Zsh")
+    assert_true(
+        "#compdef myapp" in zsh_mixed,
+        msg="Zsh (mixed case) should work",
+    )
+    var bash_mixed = command.generate_completion("Bash")
+    assert_true(
+        "complete -F" in bash_mixed,
+        msg="Bash (mixed case) should work",
+    )
+    print("  ✓ test_case_insensitive_shell")
+
+
+fn test_unknown_shell_raises() raises:
+    """Tests that an unknown shell name raises an error."""
+    var command = Command("myapp", "A test app")
+    var raised = False
+    try:
+        _ = command.generate_completion("powershell")
+    except:
+        raised = True
+    assert_true(raised, msg="Unknown shell should raise an error")
+    print("  ✓ test_unknown_shell_raises")
+
+
+# ── Fish completion details ──────────────────────────────────────────────────
+
+
+fn test_fish_long_option() raises:
+    """Tests that Fish script includes long options."""
+    var command = Command("myapp", "A test app")
+    command.add_argument(
+        Argument("output", help="Output file").long("output").short("o")
+    )
+    var script = command.generate_completion("fish")
+    assert_true(
+        "-l output" in script,
+        msg="Fish script should contain '-l output'",
+    )
+    assert_true(
+        "-s o" in script,
+        msg="Fish script should contain '-s o'",
+    )
+    print("  ✓ test_fish_long_option")
+
+
+fn test_fish_flag_no_require_value() raises:
+    """Tests that Fish flags do NOT have -r (require value)."""
+    var command = Command("myapp", "A test app")
+    command.add_argument(
+        Argument("verbose", help="Verbose").long("verbose").flag()
+    )
+    var script = command.generate_completion("fish")
+    # Find the line with --verbose
+    var lines = script.split("\n")
+    for i in range(len(lines)):
+        if "-l verbose" in lines[i]:
+            assert_false(
+                " -r" in lines[i],
+                msg="Flag should not have -r in Fish completion",
+            )
+            print("  ✓ test_fish_flag_no_require_value")
+            return
+    assert_true(False, msg="Should have found --verbose in Fish output")
+
+
+fn test_fish_value_option_has_require() raises:
+    """Tests that Fish value-taking options have -r (require value)."""
+    var command = Command("myapp", "A test app")
+    command.add_argument(Argument("output", help="Output file").long("output"))
+    var script = command.generate_completion("fish")
+    var lines = script.split("\n")
+    for i in range(len(lines)):
+        if "-l output" in lines[i]:
+            assert_true(
+                " -r" in lines[i],
+                msg="Value option should have -r in Fish completion",
+            )
+            print("  ✓ test_fish_value_option_has_require")
+            return
+    assert_true(False, msg="Should have found --output in Fish output")
+
+
+fn test_fish_choices() raises:
+    """Tests that Fish script includes choices with -a."""
+    var command = Command("myapp", "A test app")
+    var choices: List[String] = ["json", "csv", "table"]
+    command.add_argument(
+        Argument("format", help="Output format")
+        .long("format")
+        .choices(choices^)
+    )
+    var script = command.generate_completion("fish")
+    assert_true(
+        "-a 'json csv table'" in script,
+        msg="Fish script should list choices with -a",
+    )
+    print("  ✓ test_fish_choices")
+
+
+fn test_fish_help_text() raises:
+    """Tests that Fish script includes description with -d."""
+    var command = Command("myapp", "A test app")
+    command.add_argument(Argument("output", help="Output file").long("output"))
+    var script = command.generate_completion("fish")
+    assert_true(
+        "-d 'Output file'" in script,
+        msg="Fish script should include help text with -d",
+    )
+    print("  ✓ test_fish_help_text")
+
+
+fn test_fish_hidden_excluded() raises:
+    """Tests that hidden args are excluded from Fish completion."""
+    var command = Command("myapp", "A test app")
+    command.add_argument(
+        Argument("internal", help="Internal flag")
+        .long("internal")
+        .flag()
+        .hidden()
+    )
+    command.add_argument(
+        Argument("visible", help="Visible flag").long("visible").flag()
+    )
+    var script = command.generate_completion("fish")
+    assert_false(
+        "-l internal" in script,
+        msg="Hidden args should not appear in Fish completion",
+    )
+    assert_true(
+        "-l visible" in script,
+        msg="Visible args should appear in Fish completion",
+    )
+    print("  ✓ test_fish_hidden_excluded")
+
+
+fn test_fish_builtin_help_version() raises:
+    """Tests that Fish script includes built-in --help and --version."""
+    var command = Command("myapp", "A test app")
+    var script = command.generate_completion("fish")
+    assert_true(
+        "-l help" in script,
+        msg="Fish script should include --help",
+    )
+    assert_true(
+        "-l version" in script,
+        msg="Fish script should include --version",
+    )
+    print("  ✓ test_fish_builtin_help_version")
+
+
+fn test_fish_subcommands() raises:
+    """Tests that Fish script registers subcommand completions."""
+    var app = Command("myapp", "A test app")
+    var sub = Command("search", "Search for patterns")
+    sub.add_argument(
+        Argument("query", help="Search query").positional().required()
+    )
+    sub.add_argument(
+        Argument("max-depth", help="Maximum depth").long("max-depth")
+    )
+    app.add_subcommand(sub^)
+    var script = app.generate_completion("fish")
+    # Subcommand should be listed.
+    assert_true(
+        "-a 'search'" in script,
+        msg="Fish script should list 'search' subcommand",
+    )
+    # Subcommand-specific option scoped by condition.
+    assert_true(
+        "__fish_seen_subcommand_from search" in script,
+        msg="Fish script should scope subcommand options",
+    )
+    assert_true(
+        "-l max-depth" in script,
+        msg="Fish script should include subcommand options",
+    )
+    print("  ✓ test_fish_subcommands")
+
+
+fn test_fish_escape_single_quote() raises:
+    """Tests that single quotes in help text are escaped for Fish."""
+    var command = Command("myapp", "A test app")
+    command.add_argument(
+        Argument("test", help="It's a test").long("test").flag()
+    )
+    var script = command.generate_completion("fish")
+    assert_true(
+        "It\\'s a test" in script,
+        msg="Fish script should escape single quotes",
+    )
+    print("  ✓ test_fish_escape_single_quote")
+
+
+# ── Zsh completion details ───────────────────────────────────────────────────
+
+
+fn test_zsh_simple_flag() raises:
+    """Tests that Zsh script includes flag specs."""
+    var command = Command("myapp", "A test app")
+    command.add_argument(
+        Argument("verbose", help="Enable verbose output")
+        .long("verbose")
+        .short("v")
+        .flag()
+    )
+    var script = command.generate_completion("zsh")
+    assert_true(
+        "--verbose" in script,
+        msg="Zsh script should contain --verbose",
+    )
+    assert_true(
+        "-v" in script,
+        msg="Zsh script should contain -v",
+    )
+    print("  ✓ test_zsh_simple_flag")
+
+
+fn test_zsh_choices() raises:
+    """Tests that Zsh script includes choices in value spec."""
+    var command = Command("myapp", "A test app")
+    var choices: List[String] = ["json", "csv"]
+    command.add_argument(
+        Argument("format", help="Output format")
+        .long("format")
+        .choices(choices^)
+    )
+    var script = command.generate_completion("zsh")
+    assert_true(
+        "json csv" in script,
+        msg="Zsh script should include choice values",
+    )
+    print("  ✓ test_zsh_choices")
+
+
+fn test_zsh_subcommands() raises:
+    """Tests that Zsh script handles subcommand dispatch."""
+    var app = Command("myapp", "A test app")
+    var sub = Command("build", "Build the project")
+    sub.add_argument(
+        Argument("release", help="Release mode").long("release").flag()
+    )
+    app.add_subcommand(sub^)
+    var script = app.generate_completion("zsh")
+    assert_true(
+        "'build:" in script,
+        msg="Zsh script should list subcommand 'build'",
+    )
+    assert_true(
+        "case $words[1] in" in script,
+        msg="Zsh script should dispatch on subcommand",
+    )
+    assert_true(
+        "--release" in script,
+        msg="Zsh script should include subcommand options",
+    )
+    print("  ✓ test_zsh_subcommands")
+
+
+fn test_zsh_escape_brackets() raises:
+    """Tests that brackets in help text are escaped for Zsh specs."""
+    var command = Command("myapp", "A test app")
+    command.add_argument(
+        Argument("test", help="Test [option]").long("test").flag()
+    )
+    var script = command.generate_completion("zsh")
+    assert_true(
+        "Test \\[option\\]" in script,
+        msg="Zsh script should escape brackets",
+    )
+    print("  ✓ test_zsh_escape_brackets")
+
+
+fn test_zsh_escape_colon() raises:
+    """Tests that colons in help text are escaped for Zsh specs."""
+    var command = Command("myapp", "A test app")
+    command.add_argument(
+        Argument("test", help="Key: value").long("test").flag()
+    )
+    var script = command.generate_completion("zsh")
+    assert_true(
+        "Key\\: value" in script,
+        msg="Zsh script should escape colons",
+    )
+    print("  ✓ test_zsh_escape_colon")
+
+
+fn test_zsh_builtin_help() raises:
+    """Tests that Zsh script includes built-in help/version."""
+    var command = Command("myapp", "A test app")
+    var script = command.generate_completion("zsh")
+    assert_true(
+        "--help" in script,
+        msg="Zsh script should include --help",
+    )
+    assert_true(
+        "--version" in script,
+        msg="Zsh script should include --version",
+    )
+    print("  ✓ test_zsh_builtin_help")
+
+
+# ── Bash completion details ──────────────────────────────────────────────────
+
+
+fn test_bash_simple_options() raises:
+    """Tests that Bash script includes all options in COMPREPLY."""
+    var command = Command("myapp", "A test app")
+    command.add_argument(
+        Argument("verbose", help="Verbose").long("verbose").short("v").flag()
+    )
+    command.add_argument(
+        Argument("output", help="Output file").long("output").short("o")
+    )
+    var script = command.generate_completion("bash")
+    assert_true(
+        "--verbose" in script,
+        msg="Bash script should contain --verbose",
+    )
+    assert_true(
+        "--output" in script,
+        msg="Bash script should contain --output",
+    )
+    assert_true(
+        "-v" in script,
+        msg="Bash script should contain -v",
+    )
+    assert_true(
+        "-o" in script,
+        msg="Bash script should contain -o",
+    )
+    print("  ✓ test_bash_simple_options")
+
+
+fn test_bash_subcommands() raises:
+    """Tests that Bash script handles subcommand detection."""
+    var app = Command("myapp", "A test app")
+    var sub = Command("deploy", "Deploy the app")
+    sub.add_argument(Argument("target", help="Deploy target").long("target"))
+    app.add_subcommand(sub^)
+    var script = app.generate_completion("bash")
+    assert_true(
+        "deploy" in script,
+        msg="Bash script should reference 'deploy' subcommand",
+    )
+    assert_true(
+        "--target" in script,
+        msg="Bash script should include subcommand options",
+    )
+    assert_true(
+        "subcmd" in script,
+        msg="Bash script should detect subcommand",
+    )
+    print("  ✓ test_bash_subcommands")
+
+
+fn test_bash_choices_prev() raises:
+    """Tests that Bash script completes choices based on $prev."""
+    var command = Command("myapp", "A test app")
+    var choices: List[String] = ["debug", "info", "warn"]
+    command.add_argument(
+        Argument("level", help="Log level").long("level").choices(choices^)
+    )
+    var script = command.generate_completion("bash")
+    assert_true(
+        "case $prev in" in script,
+        msg="Bash script should have case $prev block",
+    )
+    assert_true(
+        "debug info warn" in script,
+        msg="Bash script should include choice values",
+    )
+    print("  ✓ test_bash_choices_prev")
+
+
+fn test_bash_hidden_excluded() raises:
+    """Tests that hidden args are excluded from Bash completion."""
+    var command = Command("myapp", "A test app")
+    command.add_argument(
+        Argument("secret", help="Secret").long("secret").flag().hidden()
+    )
+    command.add_argument(
+        Argument("public", help="Public").long("public").flag()
+    )
+    var script = command.generate_completion("bash")
+    assert_false(
+        "--secret" in script,
+        msg="Hidden args should not appear in Bash completion",
+    )
+    assert_true(
+        "--public" in script,
+        msg="Visible args should appear in Bash completion",
+    )
+    print("  ✓ test_bash_hidden_excluded")
+
+
+fn test_bash_builtin_help_version() raises:
+    """Tests that Bash script includes --help and --version."""
+    var command = Command("myapp", "A test app")
+    var script = command.generate_completion("bash")
+    assert_true(
+        "--help" in script,
+        msg="Bash script should include --help",
+    )
+    assert_true(
+        "--version" in script,
+        msg="Bash script should include --version",
+    )
+    print("  ✓ test_bash_builtin_help_version")
+
+
+# ── Cross-shell consistency ──────────────────────────────────────────────────
+
+
+fn test_all_shells_include_same_options() raises:
+    """Tests that all three shells list the same user-defined options."""
+    var command = Command("myapp", "A test app")
+    command.add_argument(
+        Argument("verbose", help="Verbose").long("verbose").short("v").flag()
+    )
+    command.add_argument(
+        Argument("output", help="Output file").long("output").short("o")
+    )
+    var choices: List[String] = ["json", "csv"]
+    command.add_argument(
+        Argument("format", help="Format").long("format").choices(choices^)
+    )
+
+    var fish = command.generate_completion("fish")
+    var zsh = command.generate_completion("zsh")
+    var bash = command.generate_completion("bash")
+
+    # Fish uses -l/--long form syntax, not --verbose directly.
+    assert_true("-l verbose" in fish, msg="fish should include -l verbose")
+    assert_true("-l output" in fish, msg="fish should include -l output")
+    assert_true("-l format" in fish, msg="fish should include -l format")
+    # Zsh
+    assert_true("--verbose" in zsh, msg="zsh should include --verbose")
+    assert_true("--output" in zsh, msg="zsh should include --output")
+    assert_true("--format" in zsh, msg="zsh should include --format")
+    # Bash
+    assert_true("--verbose" in bash, msg="bash should include --verbose")
+    assert_true("--output" in bash, msg="bash should include --output")
+    assert_true("--format" in bash, msg="bash should include --format")
+    print("  ✓ test_all_shells_include_same_options")
+
+
+fn test_count_option_no_value() raises:
+    """Tests that count options are treated like flags (no value required)."""
+    var command = Command("myapp", "A test app")
+    command.add_argument(
+        Argument("verbose", help="Verbosity level")
+        .long("verbose")
+        .short("v")
+        .count()
+    )
+    # Fish: should NOT have -r
+    var fish = command.generate_completion("fish")
+    var lines = fish.split("\n")
+    for i in range(len(lines)):
+        if "-l verbose" in lines[i]:
+            assert_false(
+                " -r" in lines[i],
+                msg="Count option should not have -r in Fish",
+            )
+            break
+    print("  ✓ test_count_option_no_value")
+
+
+fn test_persistent_flags_in_root() raises:
+    """Tests that persistent flags appear in root-level completion."""
+    var app = Command("myapp", "A test app")
+    app.add_argument(
+        Argument("debug", help="Debug mode").long("debug").flag().persistent()
+    )
+    var sub = Command("run", "Run something")
+    app.add_subcommand(sub^)
+
+    var fish = app.generate_completion("fish")
+    assert_true(
+        "-l debug" in fish,
+        msg="Persistent flag should appear in Fish root completions",
+    )
+    print("  ✓ test_persistent_flags_in_root")
+
+
+fn test_positional_excluded() raises:
+    """Tests that positional args are NOT listed as completable options."""
+    var command = Command("myapp", "A test app")
+    command.add_argument(
+        Argument("pattern", help="Search pattern").positional().required()
+    )
+    command.add_argument(
+        Argument("verbose", help="Verbose").long("verbose").flag()
+    )
+    var fish = command.generate_completion("fish")
+    var zsh = command.generate_completion("zsh")
+    var bash = command.generate_completion("bash")
+    # Positional should not appear as -l or -- option.
+    assert_false(
+        "-l pattern" in fish,
+        msg="Positional args should not appear as Fish options",
+    )
+    assert_false(
+        "--pattern" in bash,
+        msg="Positional args should not appear as Bash options",
+    )
+    print("  ✓ test_positional_excluded")
+
+
+fn test_generated_by_comment() raises:
+    """Tests that all scripts have 'Generated by ArgMojo' comment."""
+    var command = Command("myapp", "A test app")
+    var fish = command.generate_completion("fish")
+    var zsh = command.generate_completion("zsh")
+    var bash = command.generate_completion("bash")
+    assert_true(
+        "Generated by ArgMojo" in fish,
+        msg="Fish script should have ArgMojo attribution",
+    )
+    assert_true(
+        "Generated by ArgMojo" in zsh,
+        msg="Zsh script should have ArgMojo attribution",
+    )
+    assert_true(
+        "Generated by ArgMojo" in bash,
+        msg="Bash script should have ArgMojo attribution",
+    )
+    print("  ✓ test_generated_by_comment")
+
+
+# ── Built-in --completions flag ───────────────────────────────────────────────
+
+
+fn test_fish_builtin_completions() raises:
+    """Tests that Fish script includes the built-in --completions option."""
+    var command = Command("myapp", "A test app")
+    var script = command.generate_completion("fish")
+    assert_true(
+        "-l completions" in script,
+        msg="Fish script should include -l completions",
+    )
+    assert_true(
+        "bash zsh fish" in script,
+        msg="Fish script should list 'bash zsh fish' as completion choices",
+    )
+    print("  ✓ test_fish_builtin_completions")
+
+
+fn test_zsh_builtin_completions() raises:
+    """Tests that Zsh script includes the built-in --completions option."""
+    var command = Command("myapp", "A test app")
+    var script = command.generate_completion("zsh")
+    assert_true(
+        "--completions" in script,
+        msg="Zsh script should include --completions",
+    )
+    assert_true(
+        "(bash zsh fish)" in script,
+        msg="Zsh script should list '(bash zsh fish)' as choices",
+    )
+    print("  ✓ test_zsh_builtin_completions")
+
+
+fn test_bash_builtin_completions() raises:
+    """Tests that Bash script includes the built-in --completions option."""
+    var command = Command("myapp", "A test app")
+    var script = command.generate_completion("bash")
+    assert_true(
+        "--completions" in script,
+        msg="Bash script should include --completions",
+    )
+    assert_true(
+        "bash zsh fish" in script,
+        msg="Bash script should list 'bash zsh fish' as prev-case choices",
+    )
+    print("  ✓ test_bash_builtin_completions")
+
+
+fn test_disable_default_completions_not_in_script() raises:
+    """Tests that disable_default_completions() removes --completions from all scripts.
+    """
+    var command = Command("myapp", "A test app")
+    command.disable_default_completions()
+    var fish = command.generate_completion("fish")
+    var zsh = command.generate_completion("zsh")
+    var bash = command.generate_completion("bash")
+    assert_false(
+        "-l completions" in fish,
+        msg=(
+            "Fish script should NOT include -l completions after"
+            " disable_default_completions()"
+        ),
+    )
+    assert_false(
+        "--completions" in zsh,
+        msg=(
+            "Zsh script should NOT include --completions after"
+            " disable_default_completions()"
+        ),
+    )
+    assert_false(
+        "--completions" in bash,
+        msg=(
+            "Bash script should NOT include --completions after"
+            " disable_default_completions()"
+        ),
+    )
+    print("  ✓ test_disable_default_completions_not_in_script")
+
+
+fn test_disable_default_completions_not_in_help() raises:
+    """Tests that disable_default_completions() hides --completions from help.
+    """
+    var command = Command("myapp", "A test app")
+    command.disable_default_completions()
+    var help_text = command._generate_help(color=False)
+    assert_false(
+        "--completions" in help_text,
+        msg=(
+            "Help text should NOT include --completions after"
+            " disable_default_completions()"
+        ),
+    )
+    print("  ✓ test_disable_default_completions_not_in_help")
+
+
+fn test_completions_in_help_by_default() raises:
+    """Tests that --completions appears in the Options section of help by default.
+    """
+    var command = Command("myapp", "A test app")
+    var help_text = command._generate_help(color=False)
+    assert_true(
+        "--completions" in help_text,
+        msg="Help text should include --completions by default",
+    )
+    assert_true(
+        "bash,zsh,fish" in help_text or "{bash,zsh,fish}" in help_text,
+        msg="Help text should show shell choices for --completions",
+    )
+    print("  ✓ test_completions_in_help_by_default")
+
+
+# ── completions_name() ──────────────────────────────────────────────────────
+
+
+fn test_completions_custom_name_in_scripts() raises:
+    """Tests that completions_name() changes the trigger in all scripts."""
+    var command = Command("myapp", "A test app")
+    command.completions_name("autocomp")
+    var fish = command.generate_completion("fish")
+    var zsh = command.generate_completion("zsh")
+    var bash = command.generate_completion("bash")
+    assert_true(
+        "-l autocomp" in fish,
+        msg="Fish script should use '-l autocomp' after completions_name()",
+    )
+    assert_false(
+        "-l completions" in fish,
+        msg="Fish script should NOT have '-l completions' after rename",
+    )
+    assert_true(
+        "--autocomp[" in zsh,
+        msg="Zsh script should use '--autocomp[' after completions_name()",
+    )
+    assert_true(
+        "--autocomp" in bash,
+        msg="Bash script should use '--autocomp' after completions_name()",
+    )
+    assert_false(
+        "--completions" in bash,
+        msg="Bash script should NOT have '--completions' after rename",
+    )
+    print("  ✓ test_completions_custom_name_in_scripts")
+
+
+fn test_completions_custom_name_in_help() raises:
+    """Tests that completions_name() changes the trigger shown in help."""
+    var command = Command("myapp", "A test app")
+    command.completions_name("autocomp")
+    var help_text = command._generate_help(color=False)
+    assert_true(
+        "--autocomp" in help_text,
+        msg="Help text should show '--autocomp' after completions_name()",
+    )
+    assert_false(
+        "--completions" in help_text,
+        msg="Help text should NOT show '--completions' after rename",
+    )
+    print("  ✓ test_completions_custom_name_in_help")
+
+
+fn test_completions_custom_name_in_bash_prev() raises:
+    """Tests that completions_name() updates bash prev-case pattern."""
+    var command = Command("myapp", "A test app")
+    command.completions_name("gen-comp")
+    var bash = command.generate_completion("bash")
+    assert_true(
+        "--gen-comp)" in bash,
+        msg="Bash prev-case should use '--gen-comp)' after rename",
+    )
+    assert_false(
+        "--completions)" in bash,
+        msg="Bash prev-case should NOT have '--completions)' after rename",
+    )
+    print("  ✓ test_completions_custom_name_in_bash_prev")
+
+
+# ── completions_as_subcommand() ─────────────────────────────────────────────
+
+
+fn test_completions_as_subcommand_in_help() raises:
+    """Tests that completions_as_subcommand() shows it in Commands, not Options.
+    """
+    var command = Command("myapp", "A test app")
+    var sub = Command("serve", "Start the server")
+    command.add_subcommand(sub^)
+    command.completions_as_subcommand()
+    var help_text = command._generate_help(color=False)
+    # Should NOT appear in Options section as --completions.
+    assert_false(
+        "--completions" in help_text,
+        msg=(
+            "Help text should NOT show '--completions' in Options"
+            " when using subcommand mode"
+        ),
+    )
+    # Should appear in Commands section.
+    assert_true(
+        "completions" in help_text,
+        msg=(
+            "Help text should show 'completions' in Commands section"
+            " when using subcommand mode"
+        ),
+    )
+    print("  ✓ test_completions_as_subcommand_in_help")
+
+
+fn test_completions_as_subcommand_in_fish() raises:
+    """Tests that completions_as_subcommand() appears as subcommand in Fish."""
+    var command = Command("myapp", "A test app")
+    var sub = Command("serve", "Start the server")
+    command.add_subcommand(sub^)
+    command.completions_as_subcommand()
+    var fish = command.generate_completion("fish")
+    # Should NOT appear as an option.
+    assert_false(
+        "-l completions" in fish,
+        msg=(
+            "Fish script should NOT have '-l completions' option"
+            " in subcommand mode"
+        ),
+    )
+    # Should appear as a subcommand candidate.
+    assert_true(
+        "-a 'completions'" in fish,
+        msg=(
+            "Fish script should include '-a completions' as subcommand"
+            " in subcommand mode"
+        ),
+    )
+    print("  ✓ test_completions_as_subcommand_in_fish")
+
+
+fn test_completions_as_subcommand_in_zsh() raises:
+    """Tests that completions_as_subcommand() appears as subcommand in Zsh."""
+    var command = Command("myapp", "A test app")
+    var sub = Command("serve", "Start the server")
+    command.add_subcommand(sub^)
+    command.completions_as_subcommand()
+    var zsh = command.generate_completion("zsh")
+    # Should appear in commands array.
+    assert_true(
+        "'completions:" in zsh,
+        msg="Zsh script should include completions in commands array",
+    )
+    # Should NOT appear as an option.
+    assert_false(
+        "'--completions[" in zsh,
+        msg="Zsh script should NOT have '--completions[' option in sub mode",
+    )
+    # Should have a subcommand handler.
+    assert_true(
+        "completions)" in zsh,
+        msg="Zsh script should have completions) case handler",
+    )
+    print("  ✓ test_completions_as_subcommand_in_zsh")
+
+
+fn test_completions_as_subcommand_in_bash() raises:
+    """Tests that completions_as_subcommand() appears as subcommand in Bash."""
+    var command = Command("myapp", "A test app")
+    var sub = Command("serve", "Start the server")
+    command.add_subcommand(sub^)
+    command.completions_as_subcommand()
+    var bash = command.generate_completion("bash")
+    # Should NOT appear as --completions option.
+    assert_false(
+        " --completions" in bash,
+        msg=(
+            "Bash script should NOT list '--completions' option"
+            " in subcommand mode"
+        ),
+    )
+    # Subcommand names should include completions.
+    assert_true(
+        "completions" in bash,
+        msg=(
+            "Bash script should include 'completions' in subcommand"
+            " names in subcommand mode"
+        ),
+    )
+    print("  ✓ test_completions_as_subcommand_in_bash")
+
+
+fn test_completions_custom_name_with_subcommand() raises:
+    """Tests combining completions_name() with completions_as_subcommand()."""
+    var command = Command("myapp", "A test app")
+    var sub = Command("serve", "Start the server")
+    command.add_subcommand(sub^)
+    command.completions_name("comp")
+    command.completions_as_subcommand()
+    var help_text = command._generate_help(color=False)
+    var fish = command.generate_completion("fish")
+    var zsh = command.generate_completion("zsh")
+    var bash = command.generate_completion("bash")
+    # Help: 'comp' in Commands, not '--comp' in Options.
+    assert_true(
+        "comp" in help_text,
+        msg="Help should show 'comp' in commands with custom name + sub mode",
+    )
+    assert_false(
+        "--comp" in help_text,
+        msg="Help should NOT show '--comp' in options in sub mode",
+    )
+    # Fish: subcommand entry.
+    assert_true(
+        "-a 'comp'" in fish,
+        msg="Fish should include '-a comp' as subcommand with custom name",
+    )
+    # Zsh: commands array.
+    assert_true(
+        "'comp:" in zsh,
+        msg="Zsh should include comp in commands array with custom name",
+    )
+    # Bash: subcommand name.
+    assert_true(
+        "comp)" in bash,
+        msg="Bash should have 'comp)' case handler with custom name",
+    )
+    print("  ✓ test_completions_custom_name_with_subcommand")
+
+
+fn main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
This PR adds first-class shell completion support to ArgMojo, including built-in completion triggering during parsing and generators for Bash/Zsh/Fish, with accompanying tests and documentation updates.

**Changes:**
- Add `Command.generate_completion("bash"|"zsh"|"fish")` plus shell-specific script generators.
- Add built-in completion trigger support (`--<name> <shell>` and optional subcommand mode) and expose configuration APIs (`disable_default_completions`, `completions_name`, `completions_as_subcommand`).
- Add a comprehensive completion test suite and update docs/README/examples to describe the new feature.