### PR TITLE
[core] Implement command aliases

### DIFF
--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -189,7 +189,7 @@ examples/
 | Append / collect action (`--tag x --tag y` → list)                                                 | ✓      | ✓     |
 | One-required groups (`command.one_required(["json", "yaml"])`)                                     | ✓      | ✓     |
 | Value delimiter (`.delimiter(",")` → split into list)                                              | ✓      | ✓     |
-| Nargs (`.nargs(N)` → consume N values per occurrence)                                              | ✓      | ✓     |
+| Nargs (`.number_of_values(N)` → consume N values per occurrence)                                   | ✓      | ✓     |
 | Conditional requirements (`command.required_if("output", "save")`)                                 | ✓      | ✓     |
 | Numeric range validation (`.range(1, 65535)`)                                                      | ✓      | ✓     |
 | Key-value map option (`.map_option()` → `Dict[String, String]`)                                    | ✓      | ✓     |
@@ -296,11 +296,11 @@ The practical view — both dimensions checked together at parse time:
 
 #### Effect of `help_on_no_arguments()`
 
-| Scenario                          | Default (off)                                                  | With `help_on_no_arguments()`    |
-| --------------------------------- | -------------------------------------------------------------- | --------------------------- |
-| Zero args (only program name)     | Validation runs → error if requirements exist; proceed if none | **Show full help** (exit 0) |
-| Some args provided (insufficient) | ✗ Error + usage                                                | ✗ Error + usage *(same)*    |
-| All requirements satisfied        | ✓ Proceed                                                      | ✓ Proceed *(same)*          |
+| Scenario                          | Default (off)                                                  | With `help_on_no_arguments()` |
+| --------------------------------- | -------------------------------------------------------------- | ----------------------------- |
+| Zero args (only program name)     | Validation runs → error if requirements exist; proceed if none | **Show full help** (exit 0)   |
+| Some args provided (insufficient) | ✗ Error + usage                                                | ✗ Error + usage *(same)*      |
+| All requirements satisfied        | ✓ Proceed                                                      | ✓ Proceed *(same)*            |
 
 > **Key:** `help_on_no_arguments()` only overrides the **zero-argument** case. Once any argument is provided, normal validation takes over regardless.
 
@@ -541,9 +541,9 @@ Before adding Phase 5 features, further decompose `parse_arguments()` for readab
 - [ ] **Hidden subcommands** — `sub.hidden()` — exclude from the "Commands:" section in help, still dispatchable by exact name (clap `Command::hide`, cobra `Hidden`)
 - [ ] **`NO_COLOR` env variable** — honour the [no-color.org](https://no-color.org/) standard: if env `NO_COLOR` is set, suppress all ANSI colour output; lower priority than explicit `.color(False)` API call
 
-### Explicitly Out of Scope
+#### Explicitly Out of Scope in This Phase
 
-These will **NOT** be implemented (but who knows :D maybe in the future if there's demand):
+These will **NOT** be implemented in this phase, but will be considered in future.
 
 - Derive/decorator-based API (no macros in Mojo)
 - Usage-string-driven parsing (docopt style)
@@ -722,18 +722,13 @@ ArgMojo follows a consistent naming philosophy. When in doubt, apply these prior
 
 ### Decisions made
 
-| Abbreviation (rejected) | Full form (adopted) | Rationale |
-|---|---|---|
-| `Arg` | `Argument` | Internal struct name; aligns with `add_argument()` |
-| `parse_args()` | `parse_arguments()` | Consistent with `Argument` naming; `parse_args` was an argparse legacy |
-| `help_on_no_args()` | `help_on_no_arguments()` | Same reason |
-| `_aliases` | `_command_aliases` | Disambiguates from `Argument.aliases()` (option-level aliases) |
-
-### Open questions
-
-| Current name | Alternative | Notes |
-|---|---|---|
-| `nargs()` | `num_args()` | clap uses `num_args`; argparse coined `nargs`. Keep for now — very widely recognised |
+| Abbreviation (rejected)   | Full form (adopted)                 | Rationale                                                                                      |
+| ------------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `Arg`                     | `Argument`                          | Internal struct name; aligns with `add_argument()`                                             |
+| `parse_args()`            | `parse_arguments()`                 | Consistent with `Argument` naming; `parse_args` was an argparse legacy                         |
+| `help_on_no_args()`       | `help_on_no_arguments()`            | Same reason                                                                                    |
+| `_aliases`                | `_command_aliases`                  | Disambiguates from `Argument.aliases()` (option-level aliases)                                 |
+| `nargs()` / `nargs_count` | `number_of_values()` / `num_values` | Method uses full descriptive name; field uses short form to avoid Mojo field/method name clash |
 
 ## 8. Notes on Mojo versions
 

--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -59,9 +59,10 @@ These features appear across multiple libraries and depend only on string operat
 | Subcommands                        | ✓        | ✓     | ✓     | ✓    |                        | **Done**      |
 | Auto-added `help` subcommand       | —        | —     | ✓     | ✓    | git, cargo, kubectl    | **Done**      |
 | Persistent (global) flags          | —        | —     | ✓     | ✓    | git `--no-pager` etc.  | **Done**      |
-| Subcommand aliases                 | —        | —     | ✓     | ✓    |                        | Phase 5       |
+| Suggest on typo (Levenshtein)      | ✓ (3.14) | —     | ✓     | ✓    |                        | **Done**      |
+| Subcommand aliases                 | —        | —     | ✓     | ✓    | ✅ Done                 | Phase 5       |
 | Hidden subcommands                 | —        | —     | ✓     | ✓    |                        | Phase 5       |
-| `NO_COLOR` env variable            | —        | —     | —     | —    | no-color.org standard  | Phase 5       |
+| `NO_COLOR` env variable            | —        | —     | —     | —    | I need it personally   | Phase 5       |
 | Response file (`@args.txt`)        | ✓        | —     | —     | —    | javac, MSBuild         | Phase 5       |
 | Argument parents (shared args)     | ✓        | —     | —     | —    |                        | Phase 5       |
 | Interactive prompting              | —        | ✓     | —     | —    |                        | Phase 5       |
@@ -72,13 +73,12 @@ These features appear across multiple libraries and depend only on string operat
 | Partial parsing (known args)       | ✓        | —     | —     | ✓    |                        | Phase 5       |
 | Require equals syntax              | —        | —     | —     | ✓    |                        | Phase 5       |
 | Default-if-present (const)         | ✓        | —     | —     | ✓    |                        | Phase 5       |
-| Suggest on typo (Levenshtein)      | ✓ (3.14) | —     | ✓     | ✓    |                        | **Done**      |
 | Mutual implication (`implies`)     | —        | —     | —     | —    | ArgMojo unique feature | Phase 5       |
 | Stdin value (`-` convention)       | —        | —     | ✓     | —    | Unix convention        | Phase 5       |
 | Shell completion script generation | —        | ✓     | ✓     | ✓    | bash / zsh / fish      | Phase 5       |
-| CJK-aware help formatting          | —        | —     | —     | —    | ArgMojo unique feature | Phase 6       |
-| CJK full-to-half-width correction  | —        | —     | —     | —    | ArgMojo unique feature | Phase 6       |
-| CJK punctuation detection          | —        | —     | —     | —    | ArgMojo unique feature | Phase 6       |
+| CJK-aware help formatting          | —        | —     | —     | —    | I need it personally   | Phase 6       |
+| CJK full-to-half-width correction  | —        | —     | —     | —    | I need it personally   | Phase 6       |
+| CJK punctuation detection          | —        | —     | —     | —    | I need it personally   | Phase 6       |
 | Typed retrieval (`get_int()` etc.) | ✓        | ✓     | ✓     | ✓    |                        | **Done**      |
 | `Parseable` trait for type params  | —        | —     | —     | ✓    |                        | Phase 7       |
 | Derive / struct-based schema       | —        | —     | —     | ✓    | Requires Mojo macros   | Phase unknown |
@@ -537,7 +537,7 @@ Before adding Phase 5 features, further decompose `parse_args()` for readability
 - [ ] **Regex validation** — `.pattern(r"^\d{4}-\d{2}-\d{2}$")` validates value format (no major library has this)
 - [ ] **Mutual implication** — `command.implies("debug", "verbose")` — after parsing, if the trigger flag is set, automatically set the implied flag; support chained implication (`debug → verbose → log`); detect circular cycles at registration time (no major library has this built-in)
 - [ ] **Stdin value** — `.stdin_value()` on `Argument` — when parsed value is `"-"`, read from stdin; Unix convention (`cat file.txt | mytool --input -`) (cobra supports; depends on Mojo stdin API)
-- [ ] **Subcommand aliases** — `sub.alias("co")` registers a shorthand name; typo suggestions search aliases too (cobra `Command.Aliases`, clap `Command::alias`)
+- [x] **Subcommand aliases** — `sub.command_aliases(["co"])` registers shorthand names; typo suggestions and completions search aliases too (cobra `Command.Aliases`, clap `Command::alias`)
 - [ ] **Hidden subcommands** — `sub.hidden()` — exclude from the "Commands:" section in help, still dispatchable by exact name (clap `Command::hide`, cobra `Hidden`)
 - [ ] **`NO_COLOR` env variable** — honour the [no-color.org](https://no-color.org/) standard: if env `NO_COLOR` is set, suppress all ANSI colour output; lower priority than explicit `.color(False)` API call
 

--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -292,23 +292,23 @@ The practical view — both dimensions checked together at parse time:
 | No requirements               | ✓ Proceed        | ✓ Proceed              | ✓ Proceed              | ✓ Proceed  |
 | Has subcommands (group)       | ✓ Proceed *      | —                      | —                      | ✓ Dispatch |
 
-\* Group commands with subcommands typically do nothing useful with no input — `help_on_no_args()` is recommended.
+\* Group commands with subcommands typically do nothing useful with no input — `help_on_no_arguments()` is recommended.
 
-#### Effect of `help_on_no_args()`
+#### Effect of `help_on_no_arguments()`
 
-| Scenario                          | Default (off)                                                  | With `help_on_no_args()`    |
+| Scenario                          | Default (off)                                                  | With `help_on_no_arguments()`    |
 | --------------------------------- | -------------------------------------------------------------- | --------------------------- |
 | Zero args (only program name)     | Validation runs → error if requirements exist; proceed if none | **Show full help** (exit 0) |
 | Some args provided (insufficient) | ✗ Error + usage                                                | ✗ Error + usage *(same)*    |
 | All requirements satisfied        | ✓ Proceed                                                      | ✓ Proceed *(same)*          |
 
-> **Key:** `help_on_no_args()` only overrides the **zero-argument** case. Once any argument is provided, normal validation takes over regardless.
+> **Key:** `help_on_no_arguments()` only overrides the **zero-argument** case. Once any argument is provided, normal validation takes over regardless.
 
 #### Industry Consensus (clap / cobra / argparse / click / docker / git / kubectl)
 
 1. **Error, not help.** When the user provides a partial or incorrect invocation, the standard is a *short error message* naming the missing argument + a compact *usage line*. Full help is reserved for `--help` or bare group commands. This is the dominant pattern across clap, argparse, click, commander.js, cargo.
 
-2. **No special-casing "zero args" by default.** The vast majority of frameworks do NOT treat "provided nothing" differently from "provided some but not all." clap's `arg_required_else_help(true)` is the only first-class opt-in — ArgMojo's `help_on_no_args()` mirrors this.
+2. **No special-casing "zero args" by default.** The vast majority of frameworks do NOT treat "provided nothing" differently from "provided some but not all." clap's `arg_required_else_help(true)` is the only first-class opt-in — ArgMojo's `help_on_no_arguments()` mirrors this.
 
 3. **Two-tier pattern for subcommands.** Every tool examined follows the same convention:
    - **Group/parent command** with no subcommand given → **show full help** (list available subcommands)
@@ -360,7 +360,7 @@ The practical view — both dimensions checked together at parse time:
 - [x] **One-required group** — `command.one_required(["json", "yaml"])` requires at least one from the group (cobra `MarkFlagsOneRequired`, clap `ArgGroup::required`)
 - [x] **Value delimiter** — `--tag a,b,c` splits by delimiter into `["a", "b", "c"]` (cobra `StringSliceVar`, clap `value_delimiter`)
 - [x] **`-?` help alias** — `-?` accepted as an alias for `-h` / `--help` (common in Windows CLI tools, Java, MySQL, curl)
-- [x] **Help on no args** — `command.help_on_no_args()` shows help when invoked with no arguments (like git/docker/cargo)
+- [x] **Help on no args** — `command.help_on_no_arguments()` shows help when invoked with no arguments (like git/docker/cargo)
 - [x] **Dynamic help padding** — help column alignment is computed from the longest option line instead of a fixed width
 - [x] **colored help output** — ANSI colors (bold+underline headers, colored arg names), with `color=False` opt-out and customisable colors via `header_color()` / `arg_color()`
 - [x] **nargs (multi-value)** — `--point 1 2 3` consumes N values for one option (argparse `nargs`, clap `num_args`)
@@ -372,17 +372,17 @@ The practical view — both dimensions checked together at parse time:
 
 ### Phase 4: Subcommands (for v0.2 or v0.3 depending on complexity)
 
-Subcommands (`app <subcommand> [args]`) are the first feature that turns ArgMojo from a single-parser into a parser tree. The core insight is that **a subcommand is just another `Command` instance** — it already has `parse_args()`, `_generate_help()`, and all validation logic. No new parser, tokenizer, or separate module files are needed.
+Subcommands (`app <subcommand> [args]`) are the first feature that turns ArgMojo from a single-parser into a parser tree. The core insight is that **a subcommand is just another `Command` instance** — it already has `parse_arguments()`, `_generate_help()`, and all validation logic. No new parser, tokenizer, or separate module files are needed.
 
 #### Architecture: composition inside `Command`
 
 - **No file split.** Core logic stays in `command.mojo`. Mojo has no partial structs, so splitting would force free functions + parameter threading for little gain at ~2250 lines. ANSI colour constants and small utility functions live in `utils.mojo` (internal-only, all symbols `_`-prefixed).
-- **No tokenizer.** The single-pass cursor walk (`startswith` checks) is sufficient. Token types are trivially identified inline. The parsing logic in `parse_args()` delegates to four sub-methods (`_parse_long_option`, `_parse_short_single`, `_parse_short_merged`, `_dispatch_subcommand`) for readability, but the overall flow is still a simple cursor walk.
-- **Composition-based.** `Command` gains a child command list. When `parse_args()` hits a non-option token matching a registered subcommand, it delegates the remaining argv slice to the child's own `parse_args()`. 100% logic reuse, zero duplication.
+- **No tokenizer.** The single-pass cursor walk (`startswith` checks) is sufficient. Token types are trivially identified inline. The parsing logic in `parse_arguments()` delegates to four sub-methods (`_parse_long_option`, `_parse_short_single`, `_parse_short_merged`, `_dispatch_subcommand`) for readability, but the overall flow is still a simple cursor walk.
+- **Composition-based.** `Command` gains a child command list. When `parse_arguments()` hits a non-option token matching a registered subcommand, it delegates the remaining argv slice to the child's own `parse_arguments()`. 100% logic reuse, zero duplication.
 
 #### Pre-requisite refactor (Step 0)
 
-Before adding subcommand routing, clean up `parse_args()` so root and child can each call the same validation/defaults path:
+Before adding subcommand routing, clean up `parse_arguments()` so root and child can each call the same validation/defaults path:
 
 - [x] Extract `_apply_defaults(mut result)` — move the ~20-line defaults block into a private method
 - [x] Extract `_validate(result)` — move the ~130-line validation block (required, exclusive, together, one-required, conditional, range) into a private method
@@ -419,8 +419,8 @@ if result.subcommand == "search":
 
 #### Step 2 — Parse routing (I need to be very careful)
 
-- [x] In `parse_args()`, when the current token is not an option and subcommands are registered, check if it matches a subcommand name
-- [x] On match: record `result.subcommand = name`, build child argv (remaining tokens), call `child.parse_args(child_argv)`, store child result
+- [x] In `parse_arguments()`, when the current token is not an option and subcommands are registered, check if it matches a subcommand name
+- [x] On match: record `result.subcommand = name`, build child argv (remaining tokens), call `child.parse_arguments(child_argv)`, store child result
 - [x] On no match and subcommands exist: treat as positional (existing behavior)
 - [x] `--` before subcommand boundary: all subsequent tokens are positional for root, no subcommand dispatch
 - [x] Handle `app help <sub>` as equivalent to `app <sub> --help` via auto-registered `help` subcommand (strategy B); `_is_help_subcommand` flag; `.disable_help_subcommand()` opt-out API
@@ -458,7 +458,7 @@ if result.subcommand == "search":
 - [x] Step 1: `ParseResult.subcommand` defaults to `""`
 - [x] Step 1: `has_subcommand_result()` / `get_subcommand_result()` lifecycle
 - [x] Step 1: `ParseResult.__copyinit__` preserves subcommand data
-- [x] Step 1: `parse_args()` unchanged when no subcommands registered
+- [x] Step 1: `parse_arguments()` unchanged when no subcommands registered
 - [x] Step 2: Basic dispatch: `app search pattern` → subcommand="search", positionals=["pattern"]
 - [x] Step 2: Root flag: `app --verbose search pattern` → root flag verbose=true, child positional
 - [x] Step 2: Child flag: `app search --max-depth 3 pattern` → child value max-depth=3
@@ -500,7 +500,7 @@ if result.subcommand == "search":
 
 #### Pre-requisite refactor
 
-Before adding Phase 5 features, further decompose `parse_args()` for readability and maintainability:
+Before adding Phase 5 features, further decompose `parse_arguments()` for readability and maintainability:
 
 - [x] Extract `_parse_long_option()` — long option parsing (`--key`, `--key=value`, `--no-X` negation, prefix matching, count/flag/nargs/value)
 - [x] Extract `_parse_short_single()` — single-character short option parsing (`-k`, `-k value`)
@@ -589,7 +589,7 @@ ArgMojo's differentiating features — no other CLI library addresses CJK-specif
 - [ ] Implement `_fullwidth_to_halfwidth(token: String) -> String` in `utils.mojo`:
   - Full-width ASCII range: `U+FF01`–`U+FF5E` → subtract `0xFEE0` to get half-width
   - Full-width space `U+3000` → half-width space `U+0020`
-- [ ] In `parse_args()`, scan each token before parsing; if full-width characters are detected in option tokens (`--` or `-` prefixed), auto-correct and print a coloured warning:
+- [ ] In `parse_arguments()`, scan each token before parsing; if full-width characters are detected in option tokens (`--` or `-` prefixed), auto-correct and print a coloured warning:
 
   ```bash
   warning: detected full-width characters in '－－ｖｅｒｂｏｓｅ', auto-corrected to '--verbose'
@@ -652,7 +652,7 @@ These features represent the "next generation" of CLI parser design, inspired by
 Input: ["demo", "yuhao", "./src", "--ling", "-i", "--max-depth", "3"]
 
 1. Initialize ParseResult and register positional names
-2. If `help_on_no_args` is enabled and only argv[0] exists:
+2. If `help_on_no_arguments` is enabled and only argv[0] exists:
     print help and exit
 3. Loop from argv[1] with cursor i:
     ├─ If args[i] == "--":
@@ -693,7 +693,7 @@ Input: ["demo", "yuhao", "./src", "--ling", "-i", "--max-depth", "3"]
 ```txt
 Input: ["app", "--verbose", "search", "pattern", "--max-depth", "3"]
 
-1. Root parse_args() begins normal cursor walk from argv[1]
+1. Root parse_arguments() begins normal cursor walk from argv[1]
 2. "--verbose" → starts with "--" → parsed as root-level long option (flag)
 3. "search" → no "-" prefix → check registered subcommands:
     ├─ match found → record subcommand = "search"
@@ -702,7 +702,7 @@ Input: ["app", "--verbose", "search", "pattern", "--max-depth", "3"]
 4. Build child argv: ["app search", "pattern", "--max-depth", "3"]
    (argv[0] = command path for child help/error messages)
 5. Inject persistent args from root into child's arg list
-6. Call child.parse_args(child_argv) → child runs its own full parse loop
+6. Call child.parse_arguments(child_argv) → child runs its own full parse loop
    (same code path: long/short/merged/positional/defaults/validation)
 7. Store child ParseResult in root result:
     ├─ result.subcommand = "search"
@@ -711,6 +711,29 @@ Input: ["app", "--verbose", "search", "pattern", "--max-depth", "3"]
    (child already validated itself in step 6)
 9. Return root ParseResult to application code
 ```
+
+## 7. Naming Conventions
+
+ArgMojo follows a consistent naming philosophy. When in doubt, apply these priorities **in order**:
+
+1. **Internal consistency** — every name within ArgMojo should follow the same pattern. If we use `Argument`, then methods that refer to arguments should also spell out the word.
+2. **Mojo / Python style consistency** — prefer `snake_case` for functions and methods, `PascalCase` for types. Follow Mojo stdlib conventions where they exist.
+3. **Cross-language familiarity** — when a concept is well-known across CLI libraries (cobra, clap, Click, argparse), keep the name recognisable, but do **not** import abbreviations that conflict with priority 1.
+
+### Decisions made
+
+| Abbreviation (rejected) | Full form (adopted) | Rationale |
+|---|---|---|
+| `Arg` | `Argument` | Internal struct name; aligns with `add_argument()` |
+| `parse_args()` | `parse_arguments()` | Consistent with `Argument` naming; `parse_args` was an argparse legacy |
+| `help_on_no_args()` | `help_on_no_arguments()` | Same reason |
+| `_aliases` | `_command_aliases` | Disambiguates from `Argument.aliases()` (option-level aliases) |
+
+### Open questions
+
+| Current name | Alternative | Notes |
+|---|---|---|
+| `nargs()` | `num_args()` | clap uses `num_args`; argparse coined `nargs`. Keep for now — very widely recognised |
 
 ## 8. Notes on Mojo versions
 

--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -60,7 +60,7 @@ These features appear across multiple libraries and depend only on string operat
 | Auto-added `help` subcommand       | —        | —     | ✓     | ✓    | git, cargo, kubectl    | **Done**      |
 | Persistent (global) flags          | —        | —     | ✓     | ✓    | git `--no-pager` etc.  | **Done**      |
 | Suggest on typo (Levenshtein)      | ✓ (3.14) | —     | ✓     | ✓    |                        | **Done**      |
-| Subcommand aliases                 | —        | —     | ✓     | ✓    | ✅ Done                 | Phase 5       |
+| Subcommand aliases                 | —        | —     | ✓     | ✓    | cobra, clap            | **Done**      |
 | Hidden subcommands                 | —        | —     | ✓     | ✓    |                        | Phase 5       |
 | `NO_COLOR` env variable            | —        | —     | —     | —    | I need it personally   | Phase 5       |
 | Response file (`@args.txt`)        | ✓        | —     | —     | —    | javac, MSBuild         | Phase 5       |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,7 @@ ArgMojo v0.2.0 is compatible with Mojo v0.26.1.
 1. Auto-register a `help` subcommand so that `app help <command>` works out of the box; opt out with `disable_help_subcommand()`.
 1. Add `allow_positional_with_subcommands()` guard — prevents accidental mixing of positional args and subcommands on the same `Command`, following the cobra/clap convention. Requires explicit opt-in.
 1. Add `subcommand` and `subcommand_result` fields on `ParseResult` with `has_subcommand_result()` / `get_subcommand_result()` accessors.
+1. Add `command_aliases()` builder method for subcommand short names (e.g., `clone` → `cl`). Aliases dispatch to the canonical subcommand, appear in help output, shell completions, and typo suggestions.
 
 **Persistent flags:**
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -103,7 +103,7 @@ ArgMojo v0.1.0 is compatible with Mojo v0.26.1.
 
 1. Append / collect action — `--tag x --tag y` collects repeated options into a list with `.append()`.
 1. Value delimiter — `--env dev,staging,prod` splits by delimiter into a list with `.delimiter(",")`.
-1. Multi-value options (nargs) — `--point 10 20` consumes N consecutive values with `.nargs(N)`.
+1. Multi-value options (nargs) — `--point 10 20` consumes N consecutive values with `.number_of_values(N)`.
 1. Key-value map option — `--define key=value` builds a `Dict` with `.key_value()`.
 
 **Help & display:**

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -1490,6 +1490,37 @@ app.disable_help_subcommand()
 
 This can be called before or after `add_subcommand()`. If called after, the auto-added `help` entry is removed.
 
+### Subcommand Aliases
+
+You can register short aliases for subcommands with `command_aliases()`. When the user types an alias, ArgMojo dispatches to the canonical subcommand and stores the **canonical name** (not the alias) in `result.subcommand`.
+
+```mojo
+var clone = Command("clone", "Clone a repository")
+var aliases: List[String] = ["cl"]
+clone.command_aliases(aliases^)
+app.add_subcommand(clone^)
+```
+
+```bash
+app cl https://example.com/repo.git   # dispatches to "clone"
+app clone https://example.com/repo.git # still works
+```
+
+```mojo
+var result = app.parse()
+print(result.subcommand)  # always "clone", even if user typed "cl"
+```
+
+Aliases appear in help output alongside the primary name:
+
+```
+Commands:
+  clone, cl    Clone a repository
+  commit, ci   Record changes to the repository
+```
+
+Aliases are also included in shell-completion scripts and typo suggestions.
+
 ### Unknown Subcommand Error
 
 When the root command has subcommands registered **and `allow_positional_with_subcommands()` has not been called**, an unrecognised token triggers an error listing available commands:

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -87,14 +87,14 @@ fn main() raises:
 
 ---
 
-**`parse()` vs `parse_args()`**
+**`parse()` vs `parse_arguments()`**
 
 - **`command.parse()`** reads the real command-line via `sys.argv()`.
-- **`command.parse_args(args)`** accepts a `List[String]` — useful for testing without a real binary. Note that `args[0]` is expected to be the program name and will be skipped, so the actual arguments should start from index 1.
+- **`command.parse_arguments(args)`** accepts a `List[String]` — useful for testing without a real binary. Note that `args[0]` is expected to be the program name and will be skipped, so the actual arguments should start from index 1.
 
 ### Reading Parsed Results
 
-After calling `command.parse()` or `command.parse_args()`, you get a `ParseResult` with these typed accessors:
+After calling `command.parse()` or `command.parse_arguments()`, you get a `ParseResult` with these typed accessors:
 
 | Method                      | Returns        | Description                                       |
 | --------------------------- | -------------- | ------------------------------------------------- |
@@ -1562,7 +1562,7 @@ app.add_argument(Argument("fallback", help="Fallback").positional())
 
 # "foo" doesn't match any subcommand → treated as positional
 var args: List[String] = ["app", "foo"]
-var result = app.parse_args(args)
+var result = app.parse_arguments(args)
 print(result.positionals[0])  # "foo"
 ```
 
@@ -1790,13 +1790,13 @@ After printing help, the program exits cleanly with exit code 0.
 
 **Show Help When No Arguments Provided**
 
-Use `help_on_no_args()` to automatically display help when the user invokes
+Use `help_on_no_arguments()` to automatically display help when the user invokes
 the command with no arguments (like `git`, `docker`, or `cargo`):
 
 ```mojo
 var command = Command("myapp", "My application")
 command.add_argument(Argument("file", help="Input file").long("file").required())
-command.help_on_no_args()
+command.help_on_no_arguments()
 var result = command.parse()
 ```
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -659,14 +659,14 @@ This is similar to Python argparse's `nargs=N` and Rust clap's `num_args`.
 
 **Defining a multi-value option**
 
-Use `.nargs(N)` to specify how many values the option consumes:
+Use `.number_of_values(N)` to specify how many values the option consumes:
 
 ```mojo
-command.add_argument(Argument("point", help="X Y coordinates").long("point").nargs(2))
-command.add_argument(Argument("rgb", help="RGB colour").long("rgb").short("c").nargs(3))
+command.add_argument(Argument("point", help="X Y coordinates").long("point").number_of_values(2))
+command.add_argument(Argument("rgb", help="RGB colour").long("rgb").short("c").number_of_values(3))
 ```
 
-`.nargs(N)` automatically implies `.append()` — values are stored in
+`.number_of_values(N)` automatically implies `.append()` — values are stored in
 `ParseResult.lists` and retrieved with `get_list()`.
 
 ---
@@ -720,7 +720,7 @@ Choices are validated for **each** value individually:
 ```mojo
 var dirs: List[String] = ["north", "south", "east", "west"]
 command.add_argument(
-    Argument("route", help="Start and end").long("route").nargs(2).choices(dirs^)
+    Argument("route", help="Start and end").long("route").number_of_values(2).choices(dirs^)
 )
 ```
 

--- a/examples/mgit.mojo
+++ b/examples/mgit.mojo
@@ -93,7 +93,7 @@ fn main() raises:
         .long("recurse-submodules")
         .flag()
     )
-    clone.help_on_no_args()
+    clone.help_on_no_arguments()
     var clone_aliases: List[String] = ["cl"]
     clone.command_aliases(clone_aliases^)
     app.add_subcommand(clone^)
@@ -324,14 +324,14 @@ fn main() raises:
         .short("f")
         .flag()
     )
-    remote_add.help_on_no_args()
+    remote_add.help_on_no_arguments()
     remote.add_subcommand(remote_add^)
 
     var remote_remove = Command("remove", "Remove a remote")
     remote_remove.add_argument(
         Argument("name", help="Remote name to remove").positional().required()
     )
-    remote_remove.help_on_no_args()
+    remote_remove.help_on_no_arguments()
     remote.add_subcommand(remote_remove^)
 
     var remote_rename = Command("rename", "Rename a remote")
@@ -341,17 +341,17 @@ fn main() raises:
     remote_rename.add_argument(
         Argument("new", help="New remote name").positional().required()
     )
-    remote_rename.help_on_no_args()
+    remote_rename.help_on_no_arguments()
     remote.add_subcommand(remote_rename^)
 
     var remote_show = Command("show", "Show information about a remote")
     remote_show.add_argument(
         Argument("name", help="Remote name").positional().required()
     )
-    remote_show.help_on_no_args()
+    remote_show.help_on_no_arguments()
     remote.add_subcommand(remote_show^)
 
-    remote.help_on_no_args()
+    remote.help_on_no_arguments()
     app.add_subcommand(remote^)
 
     # ── branch ───────────────────────────────────────────────────────────
@@ -479,7 +479,7 @@ fn main() raises:
     app.add_subcommand(stash^)
 
     # ── Show help when invoked with no arguments ─────────────────────────
-    app.help_on_no_args()
+    app.help_on_no_arguments()
 
     # ── Parse & display ──────────────────────────────────────────────────
     var result = app.parse()

--- a/examples/mgit.mojo
+++ b/examples/mgit.mojo
@@ -94,6 +94,8 @@ fn main() raises:
         .flag()
     )
     clone.help_on_no_args()
+    var clone_aliases: List[String] = ["cl"]
+    clone.command_aliases(clone_aliases^)
     app.add_subcommand(clone^)
 
     # ── init ─────────────────────────────────────────────────────────────
@@ -184,6 +186,8 @@ fn main() raises:
         .long("cleanup-mode")
         .deprecated("Use --cleanup instead")
     )
+    var commit_aliases: List[String] = ["ci"]
+    commit.command_aliases(commit_aliases^)
     app.add_subcommand(commit^)
 
     # ── push ─────────────────────────────────────────────────────────────
@@ -352,6 +356,8 @@ fn main() raises:
 
     # ── branch ───────────────────────────────────────────────────────────
     var branch = Command("branch", "List, create, or delete branches")
+    var branch_aliases: List[String] = ["br"]
+    branch.command_aliases(branch_aliases^)
     branch.add_argument(Argument("name", help="Branch name").positional())
     branch.add_argument(
         Argument("delete", help="Delete a branch")
@@ -381,6 +387,8 @@ fn main() raises:
 
     # ── diff ─────────────────────────────────────────────────────────────
     var diff = Command("diff", "Show changes between commits, trees, etc.")
+    var diff_aliases: List[String] = ["di"]
+    diff.command_aliases(diff_aliases^)
     diff.add_argument(Argument("path", help="Path to diff").positional())
     diff.add_argument(
         Argument("staged", help="Show staged changes").long("staged").flag()
@@ -449,6 +457,8 @@ fn main() raises:
 
     # ── stash ────────────────────────────────────────────────────────────
     var stash = Command("stash", "Stash changes in working directory")
+    var stash_aliases: List[String] = ["st"]
+    stash.command_aliases(stash_aliases^)
     stash.add_argument(
         Argument("stash-message", help="Stash message")
         .long("message")

--- a/examples/mgrep.mojo
+++ b/examples/mgrep.mojo
@@ -148,7 +148,7 @@ fn main() raises:
         Argument("context", help="Print B lines before and A lines after match")
         .long("context")
         .short("C")
-        .nargs(2)
+        .number_of_values(2)
         .metavar("N")
     )
 

--- a/examples/mgrep.mojo
+++ b/examples/mgrep.mojo
@@ -242,7 +242,7 @@ fn main() raises:
     app.add_tip('Use quotes for patterns with spaces: grep "fn main" ./src')
 
     # ── Show help when invoked with no arguments ─────────────────────────
-    app.help_on_no_args()
+    app.help_on_no_arguments()
 
     # ── Parse & display ──────────────────────────────────────────────────
     var result = app.parse()

--- a/src/argmojo/argument.mojo
+++ b/src/argmojo/argument.mojo
@@ -417,7 +417,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
             n: Number of values to consume (must be ≥ 2).
 
         Returns:
-            Self with nargs and append mode set.
+            Self with num_values and append mode set.
         """
         self.num_values = n
         self.is_append = True

--- a/src/argmojo/argument.mojo
+++ b/src/argmojo/argument.mojo
@@ -44,7 +44,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
     _ = Argument("env", help="...").long("env").delimiter(",")
 
     # Multi-value  (--point 1 2 → ["1","2"])  →  result.get_list("point")
-    _ = Argument("point", help="...").long("point").nargs(2)
+    _ = Argument("point", help="...").long("point").number_of_values(2)
 
     # Numeric range validation  →  result.get_int("port")
     _ = Argument("port", help="...").long("port").range(1, 65535)
@@ -96,7 +96,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
     """If True, repeated uses collect values into a list (e.g., --tag x --tag y)."""
     var delimiter_char: String
     """If non-empty, each value is split by this delimiter into multiple list entries."""
-    var nargs_count: Int
+    var num_values: Int
     """Number of values to consume per occurrence (0 means single-value mode)."""
     var range_min: Int
     """Minimum allowed value (inclusive) for numeric range validation."""
@@ -143,7 +143,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         self.is_negatable = False
         self.is_append = False
         self.delimiter_char = ""
-        self.nargs_count = 0
+        self.num_values = 0
         self.range_min = 0
         self.range_max = 0
         self.has_range = False
@@ -176,7 +176,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         self.is_negatable = copy.is_negatable
         self.is_append = copy.is_append
         self.delimiter_char = copy.delimiter_char
-        self.nargs_count = copy.nargs_count
+        self.num_values = copy.num_values
         self.range_min = copy.range_min
         self.range_max = copy.range_max
         self.has_range = copy.has_range
@@ -209,7 +209,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         self.is_negatable = move.is_negatable
         self.is_append = move.is_append
         self.delimiter_char = move.delimiter_char^
-        self.nargs_count = move.nargs_count
+        self.num_values = move.num_values
         self.range_min = move.range_min
         self.range_max = move.range_max
         self.has_range = move.has_range
@@ -404,11 +404,11 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         self.is_append = True
         return self^
 
-    fn nargs(var self, n: Int) -> Self:
+    fn number_of_values(var self, n: Int) -> Self:
         """Sets the number of values consumed per occurrence.
 
         When set, each use of the option consumes exactly ``n``
-        consecutive arguments.  For example, ``.nargs(2)`` on
+        consecutive arguments.  For example, ``.number_of_values(2)`` on
         ``--point`` causes ``--point 1 2`` to collect ``["1", "2"]``.
         Implies ``.append()`` so values are stored in
         ``ParseResult.lists``.
@@ -419,7 +419,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         Returns:
             Self with nargs and append mode set.
         """
-        self.nargs_count = n
+        self.num_values = n
         self.is_append = True
         return self^
 

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -89,6 +89,10 @@ struct Command(Copyable, Movable, Stringable, Writable):
     """When True, the completion trigger is a subcommand instead of an
     option.  Default False → ``--completions``.  Call
     ``completions_as_subcommand()`` to switch to ``myapp completions bash``."""
+    var _aliases: List[String]
+    """Alternate names for this command when used as a subcommand.
+    Add entries via ``command_aliases()``.  Aliases are matched during
+    subcommand dispatch but are not shown as separate entries in help."""
     var _tips: List[String]
     """User-defined tips shown at the bottom of the help message.
     Add entries via ``add_tip()``.  Each tip is printed on its own line
@@ -128,6 +132,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         self._completions_enabled = True
         self._completions_name = String("completions")
         self._completions_is_subcommand = False
+        self._aliases = List[String]()
         self._tips = List[String]()
         self._header_color = _DEFAULT_HEADER_COLOR
         self._arg_color = _DEFAULT_ARG_COLOR
@@ -159,6 +164,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         self._completions_enabled = move._completions_enabled
         self._completions_name = move._completions_name^
         self._completions_is_subcommand = move._completions_is_subcommand
+        self._aliases = move._aliases^
         self._tips = move._tips^
         self._header_color = move._header_color^
         self._arg_color = move._arg_color^
@@ -205,6 +211,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         self._completions_enabled = copy._completions_enabled
         self._completions_name = copy._completions_name
         self._completions_is_subcommand = copy._completions_is_subcommand
+        self._aliases = copy._aliases.copy()
         self._tips = copy._tips.copy()
         self._header_color = copy._header_color
         self._arg_color = copy._arg_color
@@ -524,6 +531,30 @@ struct Command(Copyable, Movable, Stringable, Writable):
         """
         self._tips.append(tip)
 
+    fn command_aliases(mut self, var names: List[String]):
+        """Registers alternate names for this command when used as a subcommand.
+
+        Aliases are matched during subcommand dispatch and included in
+        shell completion scripts, but they do **not** appear as separate
+        entries in the ``Commands:`` help section.  Instead, aliases are
+        shown inline next to the primary name.
+
+        Args:
+            names: The list of alias strings.
+
+        Example:
+
+        ```mojo
+        from argmojo import Command
+        var clone = Command("clone", "Clone a repository")
+        var aliases: List[String] = ["cl"]
+        clone.command_aliases(aliases^)
+        # Now: mgit cl ... is equivalent to mgit clone ...
+        ```
+        """
+        for i in range(len(names)):
+            self._aliases.append(names[i])
+
     fn mutually_exclusive(mut self, var names: List[String]):
         """Declares a group of mutually exclusive arguments.
 
@@ -725,45 +756,6 @@ struct Command(Copyable, Movable, Stringable, Writable):
         """
         self._error_color = _resolve_color(name)
 
-    # Here is a high-level outline of the parsing algorithm implemented in
-    # ``parse_args``:
-    #
-    # 1. Initialize ParseResult and register positional names.
-    # 2. If ``help_on_no_args`` is enabled and only argv[0] is present:
-    #    print help and exit.
-    # 3. Iterate from argv[1] with cursor ``i``:
-    #    ├─ If token is "--": enter positional-only mode.
-    #    ├─ If in positional-only mode: append token to positionals.
-    #    ├─ If token is --help / -h / -?: print help and exit.
-    #    ├─ If token is --version / -V: print version and exit.
-    #    ├─ If token starts with "--":
-    #    │  Parse long option
-    #    │   ├─ Support --key=value split.
-    #    │   ├─ Support --no-key for negatable flags (with prefix matching).
-    #    │   ├─ Resolve by exact long name → exact alias → prefix match.
-    #    │   ├─ Emit deprecation warning if the matched arg is deprecated.
-    #    │   ├─ Handle count / flag / nargs / map / value-taking variants.
-    #    │   └─ For append args, store via delimiter-aware append logic.
-    #    ├─ If token starts with "-" and len > 1:
-    #    │  Parse short option(s)
-    #    │   ├─ Single short: deprecation warning / count / flag / nargs / map / value.
-    #    │   └─ Multi-short: merged flags and attached value forms.
-    #    └─ Otherwise (bare word):
-    #       ├─ Subcommands registered + "help <sub>": print child help & exit.
-    #       ├─ Subcommands registered + token matches subcommand name:
-    #       │   build child argv, call child.parse_args(), store result, break.
-    #       └─ Otherwise: treat as positional argument.
-    # 4. Apply defaults for missing args (named + positional slots).
-    # 5. Validate:
-    #    ├─ Required args
-    #    ├─ Positional count (too many)
-    #    ├─ Mutually-exclusive groups
-    #    ├─ Required-together groups
-    #    ├─ One-required groups
-    #    ├─ Conditional requirements
-    #    └─ Numeric range constraints
-    # 6. Return ParseResult.
-
     # ===------------------------------------------------------------------=== #
     # Private output helpers
     # ===------------------------------------------------------------------=== #
@@ -876,6 +868,46 @@ struct Command(Copyable, Movable, Stringable, Writable):
         prevents contamination and conflicts between multiple parses, e.g.,
         in testing scenarios, REPL usage, and autocompletion.
         """
+
+        # Here is a high-level outline of the parsing algorithm implemented in
+        # ``parse_args``:
+        #
+        # 1. Initialize ParseResult and register positional names.
+        # 2. If ``help_on_no_args`` is enabled and only argv[0] is present:
+        #    print help and exit.
+        # 3. Iterate from argv[1] with cursor ``i``:
+        #    ├─ If token is "--": enter positional-only mode.
+        #    ├─ If in positional-only mode: append token to positionals.
+        #    ├─ If token is --help / -h / -?: print help and exit.
+        #    ├─ If token is --version / -V: print version and exit.
+        #    ├─ If token starts with "--":
+        #    │  Parse long option
+        #    │   ├─ Support --key=value split.
+        #    │   ├─ Support --no-key for negatable flags (with prefix matching).
+        #    │   ├─ Resolve by exact long name → exact alias → prefix match.
+        #    │   ├─ Emit deprecation warning if the matched arg is deprecated.
+        #    │   ├─ Handle count / flag / nargs / map / value-taking variants.
+        #    │   └─ For append args, store via delimiter-aware append logic.
+        #    ├─ If token starts with "-" and len > 1:
+        #    │  Parse short option(s)
+        #    │   ├─ Single short: deprecation warning / count / flag / nargs / map / value.
+        #    │   └─ Multi-short: merged flags and attached value forms.
+        #    └─ Otherwise (bare word):
+        #       ├─ Subcommands registered + "help <sub>": print child help & exit.
+        #       ├─ Subcommands registered + token matches subcommand name:
+        #       │   build child argv, call child.parse_args(), store result, break.
+        #       └─ Otherwise: treat as positional argument.
+        # 4. Apply defaults for missing args (named + positional slots).
+        # 5. Validate:
+        #    ├─ Required args
+        #    ├─ Positional count (too many)
+        #    ├─ Mutually-exclusive groups
+        #    ├─ Required-together groups
+        #    ├─ One-required groups
+        #    ├─ Conditional requirements
+        #    └─ Numeric range constraints
+        # 6. Return ParseResult.
+
         var result = ParseResult()
 
         # Register positional argument names in order.
@@ -1365,9 +1397,11 @@ struct Command(Copyable, Movable, Stringable, Writable):
         # Exact subcommand name match → dispatch.
         var sub_idx = self._find_subcommand(arg)
         if sub_idx >= 0:
+            # Resolve canonical name (alias → real name).
+            var canon = self.subcommands[sub_idx].name
             # Build child argv: ["parent sub", remaining tokens...].
             var child_argv = List[String]()
-            child_argv.append(self.name + " " + arg)
+            child_argv.append(self.name + " " + canon)
             for k in range(i + 1, len(raw_args)):
                 child_argv.append(raw_args[k])
             # Auto-registered 'help' subcommand: display sibling help.
@@ -1387,7 +1421,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
             # are recognised wherever the user places them on the line.
             var child_copy = self.subcommands[sub_idx].copy()
             # Set full command path so child help/errors show "app sub".
-            child_copy.name = self.name + " " + arg
+            child_copy.name = self.name + " " + canon
             for _pi in range(len(self.args)):
                 if self.args[_pi].is_persistent:
                     child_copy.args.append(self.args[_pi].copy())
@@ -1417,7 +1451,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                     child_result.values[_pn] = result.values[_pn]
                 if _pn in result.counts and _pn not in child_result.counts:
                     child_result.counts[_pn] = result.counts[_pn]
-            result.subcommand = arg
+            result.subcommand = canon
             result._subcommand_results.append(child_result^)
             # All remaining tokens were consumed by the child.
             return len(raw_args)
@@ -1434,12 +1468,19 @@ struct Command(Copyable, Movable, Stringable, Writable):
                         if not first:
                             avail += ", "
                         avail += self.subcommands[_si].name
+                        # Append aliases to available list.
+                        for _ai in range(len(self.subcommands[_si]._aliases)):
+                            avail += ", " + self.subcommands[_si]._aliases[_ai]
                         first = False
                 # Try typo suggestion for subcommand names.
                 var sub_names = List[String]()
                 for _si2 in range(len(self.subcommands)):
                     if not self.subcommands[_si2]._is_help_subcommand:
                         sub_names.append(self.subcommands[_si2].name)
+                        for _ai2 in range(len(self.subcommands[_si2]._aliases)):
+                            sub_names.append(
+                                self.subcommands[_si2]._aliases[_ai2]
+                            )
                 var suggestion = _suggest_similar(arg, sub_names)
                 var hint = String("")
                 if suggestion != "":
@@ -1787,15 +1828,23 @@ struct Command(Copyable, Movable, Stringable, Writable):
     fn _find_subcommand(self, name: String) -> Int:
         """Returns the index of the registered subcommand matching ``name``.
 
+        Checks primary names first, then aliases.
+
         Args:
-            name: Subcommand name to look up.
+            name: Subcommand name or alias to look up.
 
         Returns:
             The index into ``self.subcommands``, or ``-1`` if not found.
         """
+        # 1. Exact match on primary name.
         for i in range(len(self.subcommands)):
             if self.subcommands[i].name == name:
                 return i
+        # 2. Match on aliases.
+        for i in range(len(self.subcommands)):
+            for j in range(len(self.subcommands[i]._aliases)):
+                if self.subcommands[i]._aliases[j] == name:
+                    return i
         return -1
 
     fn _display_name(self, name: String) -> String:
@@ -2336,13 +2385,12 @@ struct Command(Copyable, Movable, Stringable, Writable):
         var cmd_helps = List[String]()
         for i in range(len(self.subcommands)):
             if not self.subcommands[i]._is_help_subcommand:
-                var plain = String("  ") + self.subcommands[i].name
-                var colored = (
-                    String("  ")
-                    + arg_color
-                    + self.subcommands[i].name
-                    + reset_code
-                )
+                # Build label: "name" or "name, alias1, alias2".
+                var label = self.subcommands[i].name
+                for _ai in range(len(self.subcommands[i]._aliases)):
+                    label += ", " + self.subcommands[i]._aliases[_ai]
+                var plain = String("  ") + label
+                var colored = String("  ") + arg_color + label + reset_code
                 cmd_plains.append(plain)
                 cmd_colors.append(colored)
                 cmd_helps.append(self.subcommands[i].description)
@@ -2621,6 +2669,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
                     if sub_names:
                         sub_names += " "
                     sub_names += self.subcommands[i].name
+                    for _ai in range(len(self.subcommands[i]._aliases)):
+                        sub_names += " " + self.subcommands[i]._aliases[_ai]
             if _comp_is_sub:
                 if sub_names:
                     sub_names += " "
@@ -2645,9 +2695,26 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 if sub.description:
                     s += " -d '" + self._fish_escape(sub.description) + "'"
                 s += "\n"
+                # Register each alias as a completable name.
+                for _ai in range(len(sub._aliases)):
+                    s += (
+                        "complete -c "
+                        + self.name
+                        + " -n 'not "
+                        + no_sub_cond
+                        + "'"
+                        + " -f -a '"
+                        + sub._aliases[_ai]
+                        + "'"
+                    )
+                    if sub.description:
+                        s += " -d '" + self._fish_escape(sub.description) + "'"
+                    s += "\n"
 
                 # Subcommand-specific options.
                 var sub_cond = "__fish_seen_subcommand_from " + sub.name
+                for _ai in range(len(sub._aliases)):
+                    sub_cond += " " + sub._aliases[_ai]
                 s += self._fish_options_for(
                     self.name, sub_cond, persistent_only=True
                 )
@@ -2832,6 +2899,9 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 sub.description
             ) if sub.description else ""
             s += "    '" + sub.name + ":" + desc + "'\n"
+            # Add aliases as separate entries pointing to same description.
+            for _ai in range(len(sub._aliases)):
+                s += "    '" + sub._aliases[_ai] + ":" + desc + "'\n"
         if self._completions_enabled and self._completions_is_subcommand:
             s += (
                 "    '"
@@ -2869,7 +2939,11 @@ struct Command(Copyable, Movable, Stringable, Writable):
             if self.subcommands[i]._is_help_subcommand:
                 continue
             var sub = self.subcommands[i].copy()
-            s += "        " + sub.name + ")\n"
+            # Build pattern: name|alias1|alias2
+            var zsh_pat = sub.name
+            for _ai in range(len(sub._aliases)):
+                zsh_pat += "|" + sub._aliases[_ai]
+            s += "        " + zsh_pat + ")\n"
             s += "          _arguments \\\n"
             for j in range(len(sub.args)):
                 var arg = sub.args[j].copy()
@@ -3056,6 +3130,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
             if sub_names:
                 sub_names += " "
             sub_names += self.subcommands[i].name
+            for _ai in range(len(self.subcommands[i]._aliases)):
+                sub_names += " " + self.subcommands[i]._aliases[_ai]
         if self._completions_enabled and self._completions_is_subcommand:
             if sub_names:
                 sub_names += " "
@@ -3113,7 +3189,11 @@ struct Command(Copyable, Movable, Stringable, Writable):
                     sub_words += " --" + arg.long_name
                 if arg.short_name:
                     sub_words += " -" + arg.short_name
-            s += "    " + sub.name + ")\n"
+            # Build pattern: name|alias1|alias2
+            var bash_pat = sub.name
+            for _ai in range(len(sub._aliases)):
+                bash_pat += "|" + sub._aliases[_ai]
+            s += "    " + bash_pat + ")\n"
             # Subcommand-level $prev choices completion.
             s += self._bash_prev_cases_for_args(sub.args, "      ")
             s += (

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -1136,26 +1136,26 @@ struct Command(Copyable, Movable, Stringable, Writable):
             result.counts[matched.name] = cur + 1
         elif matched.is_flag and not has_eq:
             result.flags[matched.name] = True
-        elif matched.nargs_count > 0:
+        elif matched.num_values > 0:
             # nargs: consume exactly N values.
             if has_eq:
                 self._error(
                     "Option '--"
                     + key
                     + "' takes "
-                    + String(matched.nargs_count)
+                    + String(matched.num_values)
                     + " values; '=' syntax is not supported"
                 )
             if matched.name not in result.lists:
                 result.lists[matched.name] = List[String]()
-            for _n in range(matched.nargs_count):
+            for _n in range(matched.num_values):
                 i += 1
                 if i >= len(raw_args):
                     self._error(
                         "Option '--"
                         + key
                         + "' requires "
-                        + String(matched.nargs_count)
+                        + String(matched.num_values)
                         + " values"
                     )
                 self._validate_choices(matched, raw_args[i])
@@ -1210,18 +1210,18 @@ struct Command(Copyable, Movable, Stringable, Writable):
             result.counts[matched.name] = cur + 1
         elif matched.is_flag:
             result.flags[matched.name] = True
-        elif matched.nargs_count > 0:
+        elif matched.num_values > 0:
             # nargs: consume exactly N values.
             if matched.name not in result.lists:
                 result.lists[matched.name] = List[String]()
-            for _n in range(matched.nargs_count):
+            for _n in range(matched.num_values):
                 i += 1
                 if i >= len(raw_args):
                     self._error(
                         "Option '-"
                         + key
                         + "' requires "
-                        + String(matched.nargs_count)
+                        + String(matched.num_values)
                         + " values"
                     )
                 self._validate_choices(matched, raw_args[i])
@@ -1294,19 +1294,19 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 elif m.is_flag:
                     result.flags[m.name] = True
                     j += 1
-                elif m.nargs_count > 0:
+                elif m.num_values > 0:
                     # nargs in merged flags: rest of string is
                     # ignored; consume N values from argv.
                     if m.name not in result.lists:
                         result.lists[m.name] = List[String]()
-                    for _n in range(m.nargs_count):
+                    for _n in range(m.num_values):
                         i += 1
                         if i >= len(raw_args):
                             self._error(
                                 "Option '-"
                                 + ch
                                 + "' requires "
-                                + String(m.nargs_count)
+                                + String(m.num_values)
                                 + " values"
                             )
                         self._validate_choices(m, raw_args[i])
@@ -1340,18 +1340,18 @@ struct Command(Copyable, Movable, Stringable, Writable):
                     + "' is deprecated: "
                     + first_match.deprecated_msg
                 )
-            if first_match.nargs_count > 0:
+            if first_match.num_values > 0:
                 # nargs: consume N values from argv (ignore attached).
                 if first_match.name not in result.lists:
                     result.lists[first_match.name] = List[String]()
-                for _n in range(first_match.nargs_count):
+                for _n in range(first_match.num_values):
                     i += 1
                     if i >= len(raw_args):
                         self._error(
                             "Option '-"
                             + first_char
                             + "' requires "
-                            + String(first_match.nargs_count)
+                            + String(first_match.num_values)
                             + " values"
                         )
                     self._validate_choices(first_match, raw_args[i])
@@ -2202,7 +2202,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
 
                 # Show metavar or choices for value-taking options.
                 if not self.args[i].is_flag:
-                    var ncount = self.args[i].nargs_count
+                    var ncount = self.args[i].num_values
                     var repeat = ncount if ncount > 0 else 1
                     var append_dots = self.args[i].is_append and ncount == 0
                     if self.args[i].metavar_name:

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -89,7 +89,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
     """When True, the completion trigger is a subcommand instead of an
     option.  Default False → ``--completions``.  Call
     ``completions_as_subcommand()`` to switch to ``myapp completions bash``."""
-    var _aliases: List[String]
+    var _command_aliases: List[String]
     """Alternate names for this command when used as a subcommand.
     Add entries via ``command_aliases()``.  Aliases are matched during
     subcommand dispatch but are not shown as separate entries in help."""
@@ -132,7 +132,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         self._completions_enabled = True
         self._completions_name = String("completions")
         self._completions_is_subcommand = False
-        self._aliases = List[String]()
+        self._command_aliases = List[String]()
         self._tips = List[String]()
         self._header_color = _DEFAULT_HEADER_COLOR
         self._arg_color = _DEFAULT_ARG_COLOR
@@ -164,7 +164,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         self._completions_enabled = move._completions_enabled
         self._completions_name = move._completions_name^
         self._completions_is_subcommand = move._completions_is_subcommand
-        self._aliases = move._aliases^
+        self._command_aliases = move._command_aliases^
         self._tips = move._tips^
         self._header_color = move._header_color^
         self._arg_color = move._arg_color^
@@ -211,7 +211,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         self._completions_enabled = copy._completions_enabled
         self._completions_name = copy._completions_name
         self._completions_is_subcommand = copy._completions_is_subcommand
-        self._aliases = copy._aliases.copy()
+        self._command_aliases = copy._command_aliases.copy()
         self._tips = copy._tips.copy()
         self._header_color = copy._header_color
         self._arg_color = copy._arg_color
@@ -553,7 +553,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         ```
         """
         for i in range(len(names)):
-            self._aliases.append(names[i])
+            self._command_aliases.append(names[i])
 
     fn mutually_exclusive(mut self, var names: List[String]):
         """Declares a group of mutually exclusive arguments.
@@ -1469,17 +1469,24 @@ struct Command(Copyable, Movable, Stringable, Writable):
                             avail += ", "
                         avail += self.subcommands[_si].name
                         # Append aliases to available list.
-                        for _ai in range(len(self.subcommands[_si]._aliases)):
-                            avail += ", " + self.subcommands[_si]._aliases[_ai]
+                        for _ai in range(
+                            len(self.subcommands[_si]._command_aliases)
+                        ):
+                            avail += (
+                                ", "
+                                + self.subcommands[_si]._command_aliases[_ai]
+                            )
                         first = False
                 # Try typo suggestion for subcommand names.
                 var sub_names = List[String]()
                 for _si2 in range(len(self.subcommands)):
                     if not self.subcommands[_si2]._is_help_subcommand:
                         sub_names.append(self.subcommands[_si2].name)
-                        for _ai2 in range(len(self.subcommands[_si2]._aliases)):
+                        for _ai2 in range(
+                            len(self.subcommands[_si2]._command_aliases)
+                        ):
                             sub_names.append(
-                                self.subcommands[_si2]._aliases[_ai2]
+                                self.subcommands[_si2]._command_aliases[_ai2]
                             )
                 var suggestion = _suggest_similar(arg, sub_names)
                 var hint = String("")
@@ -1842,8 +1849,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 return i
         # 2. Match on aliases.
         for i in range(len(self.subcommands)):
-            for j in range(len(self.subcommands[i]._aliases)):
-                if self.subcommands[i]._aliases[j] == name:
+            for j in range(len(self.subcommands[i]._command_aliases)):
+                if self.subcommands[i]._command_aliases[j] == name:
                     return i
         return -1
 
@@ -2387,8 +2394,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
             if not self.subcommands[i]._is_help_subcommand:
                 # Build label: "name" or "name, alias1, alias2".
                 var label = self.subcommands[i].name
-                for _ai in range(len(self.subcommands[i]._aliases)):
-                    label += ", " + self.subcommands[i]._aliases[_ai]
+                for _ai in range(len(self.subcommands[i]._command_aliases)):
+                    label += ", " + self.subcommands[i]._command_aliases[_ai]
                 var plain = String("  ") + label
                 var colored = String("  ") + arg_color + label + reset_code
                 cmd_plains.append(plain)
@@ -2669,8 +2676,10 @@ struct Command(Copyable, Movable, Stringable, Writable):
                     if sub_names:
                         sub_names += " "
                     sub_names += self.subcommands[i].name
-                    for _ai in range(len(self.subcommands[i]._aliases)):
-                        sub_names += " " + self.subcommands[i]._aliases[_ai]
+                    for _ai in range(len(self.subcommands[i]._command_aliases)):
+                        sub_names += (
+                            " " + self.subcommands[i]._command_aliases[_ai]
+                        )
             if _comp_is_sub:
                 if sub_names:
                     sub_names += " "
@@ -2696,7 +2705,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                     s += " -d '" + self._fish_escape(sub.description) + "'"
                 s += "\n"
                 # Register each alias as a completable name.
-                for _ai in range(len(sub._aliases)):
+                for _ai in range(len(sub._command_aliases)):
                     s += (
                         "complete -c "
                         + self.name
@@ -2704,7 +2713,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                         + no_sub_cond
                         + "'"
                         + " -f -a '"
-                        + sub._aliases[_ai]
+                        + sub._command_aliases[_ai]
                         + "'"
                     )
                     if sub.description:
@@ -2713,8 +2722,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
 
                 # Subcommand-specific options.
                 var sub_cond = "__fish_seen_subcommand_from " + sub.name
-                for _ai in range(len(sub._aliases)):
-                    sub_cond += " " + sub._aliases[_ai]
+                for _ai in range(len(sub._command_aliases)):
+                    sub_cond += " " + sub._command_aliases[_ai]
                 s += self._fish_options_for(
                     self.name, sub_cond, persistent_only=True
                 )
@@ -2900,8 +2909,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
             ) if sub.description else ""
             s += "    '" + sub.name + ":" + desc + "'\n"
             # Add aliases as separate entries pointing to same description.
-            for _ai in range(len(sub._aliases)):
-                s += "    '" + sub._aliases[_ai] + ":" + desc + "'\n"
+            for _ai in range(len(sub._command_aliases)):
+                s += "    '" + sub._command_aliases[_ai] + ":" + desc + "'\n"
         if self._completions_enabled and self._completions_is_subcommand:
             s += (
                 "    '"
@@ -2941,8 +2950,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
             var sub = self.subcommands[i].copy()
             # Build pattern: name|alias1|alias2
             var zsh_pat = sub.name
-            for _ai in range(len(sub._aliases)):
-                zsh_pat += "|" + sub._aliases[_ai]
+            for _ai in range(len(sub._command_aliases)):
+                zsh_pat += "|" + sub._command_aliases[_ai]
             s += "        " + zsh_pat + ")\n"
             s += "          _arguments \\\n"
             for j in range(len(sub.args)):
@@ -3130,8 +3139,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
             if sub_names:
                 sub_names += " "
             sub_names += self.subcommands[i].name
-            for _ai in range(len(self.subcommands[i]._aliases)):
-                sub_names += " " + self.subcommands[i]._aliases[_ai]
+            for _ai in range(len(self.subcommands[i]._command_aliases)):
+                sub_names += " " + self.subcommands[i]._command_aliases[_ai]
         if self._completions_enabled and self._completions_is_subcommand:
             if sub_names:
                 sub_names += " "
@@ -3191,8 +3200,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
                     sub_words += " -" + arg.short_name
             # Build pattern: name|alias1|alias2
             var bash_pat = sub.name
-            for _ai in range(len(sub._aliases)):
-                bash_pat += "|" + sub._aliases[_ai]
+            for _ai in range(len(sub._command_aliases)):
+                bash_pat += "|" + sub._command_aliases[_ai]
             s += "    " + bash_pat + ")\n"
             # Subcommand-level $prev choices completion.
             s += self._bash_prev_cases_for_args(sub.args, "      ")

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -92,7 +92,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
     var _command_aliases: List[String]
     """Alternate names for this command when used as a subcommand.
     Add entries via ``command_aliases()``.  Aliases are matched during
-    subcommand dispatch but are not shown as separate entries in help."""
+    subcommand dispatch and appear inline next to the primary name in
+    help (e.g., "clone, cl"), but are not shown as separate entries."""
     var _tips: List[String]
     """User-defined tips shown at the bottom of the help message.
     Add entries via ``add_tip()``.  Each tip is printed on its own line
@@ -1394,7 +1395,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
             subcommand matched and the caller should fall through to
             positional argument handling.
         """
-        # Exact subcommand name match → dispatch.
+        # Exact subcommand (name or alias) match → dispatch.
         var sub_idx = self._find_subcommand(arg)
         if sub_idx >= 0:
             # Resolve canonical name (alias → real name).

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -48,7 +48,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
     """Groups where at least one argument must be provided."""
     var _conditional_reqs: List[List[String]]
     """Pairs [target, condition]: target is required when condition is present."""
-    var _help_on_no_args: Bool
+    var _help_on_no_arguments: Bool
     """When True, show help and exit if no arguments are provided."""
     var _header_color: String
     """ANSI code for section headers (Usage, Arguments, Options)."""
@@ -124,7 +124,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         self._required_groups = List[List[String]]()
         self._one_required_groups = List[List[String]]()
         self._conditional_reqs = List[List[String]]()
-        self._help_on_no_args = False
+        self._help_on_no_arguments = False
         self._is_help_subcommand = False
         self._help_subcommand_enabled = True
         self._allow_negative_numbers = False
@@ -154,7 +154,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         self._required_groups = move._required_groups^
         self._one_required_groups = move._one_required_groups^
         self._conditional_reqs = move._conditional_reqs^
-        self._help_on_no_args = move._help_on_no_args
+        self._help_on_no_arguments = move._help_on_no_arguments
         self._is_help_subcommand = move._is_help_subcommand
         self._help_subcommand_enabled = move._help_subcommand_enabled
         self._allow_negative_numbers = move._allow_negative_numbers
@@ -201,7 +201,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         self._conditional_reqs = List[List[String]]()
         for i in range(len(copy._conditional_reqs)):
             self._conditional_reqs.append(copy._conditional_reqs[i].copy())
-        self._help_on_no_args = copy._help_on_no_args
+        self._help_on_no_arguments = copy._help_on_no_arguments
         self._is_help_subcommand = copy._is_help_subcommand
         self._help_subcommand_enabled = copy._help_subcommand_enabled
         self._allow_negative_numbers = copy._allow_negative_numbers
@@ -644,7 +644,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         var pair: List[String] = [target, condition]
         self._conditional_reqs.append(pair^)
 
-    fn help_on_no_args(mut self):
+    fn help_on_no_arguments(mut self):
         """Enables showing help when invoked with no arguments.
 
         When enabled, calling the command with no arguments (only the
@@ -656,10 +656,10 @@ struct Command(Copyable, Movable, Stringable, Writable):
         from argmojo import Command, Argument
         var command = Command("myapp", "A sample application")
         command.add_argument(Argument("file", help="Input file").long("file").required())
-        command.help_on_no_args()
+        command.help_on_no_arguments()
         ```
         """
-        self._help_on_no_args = True
+        self._help_on_no_arguments = True
 
     fn header_color(mut self, name: String) raises:
         """Sets the colour for section headers (Usage, Arguments, Options).
@@ -768,7 +768,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         """Prints a coloured error message to stderr then raises.
 
         All parse-time errors funnel through this method so that callers
-        of both ``parse()`` and ``parse_args()`` always see coloured output
+        of both ``parse()`` and ``parse_arguments()`` always see coloured output
         while tests can still catch the raised ``Error`` normally.
         The command name is included in the stderr output so that errors
         from subcommands show the full path (e.g. ``app search: ...``).
@@ -828,7 +828,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         are printed in colour to stderr and the process exits with code 2.
         This matches the behaviour of Python's ``argparse``.
 
-        Use ``parse_args()`` directly if you want to catch errors yourself.
+        Use ``parse_arguments()`` directly if you want to catch errors yourself.
 
         Returns:
             A ParseResult containing all parsed values.
@@ -838,7 +838,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         for i in range(len(raw_variadic)):
             raw.append(String(raw_variadic[i]))
         try:
-            return self.parse_args(raw)
+            return self.parse_arguments(raw)
         except:
             # Error message was already printed to stderr by _error().
             exit(2)
@@ -846,7 +846,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
             # compiler does not model exit() as @noreturn yet.
             return ParseResult()
 
-    fn parse_args(self, raw_args: List[String]) raises -> ParseResult:
+    fn parse_arguments(self, raw_args: List[String]) raises -> ParseResult:
         """Parses the given argument list.
 
         The first element, e.g., ``argv[0]``, is expected to be the program name
@@ -870,10 +870,10 @@ struct Command(Copyable, Movable, Stringable, Writable):
         """
 
         # Here is a high-level outline of the parsing algorithm implemented in
-        # ``parse_args``:
+        # ``parse_arguments``:
         #
         # 1. Initialize ParseResult and register positional names.
-        # 2. If ``help_on_no_args`` is enabled and only argv[0] is present:
+        # 2. If ``help_on_no_arguments`` is enabled and only argv[0] is present:
         #    print help and exit.
         # 3. Iterate from argv[1] with cursor ``i``:
         #    ├─ If token is "--": enter positional-only mode.
@@ -895,7 +895,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         #    └─ Otherwise (bare word):
         #       ├─ Subcommands registered + "help <sub>": print child help & exit.
         #       ├─ Subcommands registered + token matches subcommand name:
-        #       │   build child argv, call child.parse_args(), store result, break.
+        #       │   build child argv, call child.parse_arguments(), store result, break.
         #       └─ Otherwise: treat as positional argument.
         # 4. Apply defaults for missing args (named + positional slots).
         # 5. Validate:
@@ -920,7 +920,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         var stop_parsing_options = False
 
         # Show help when invoked with no arguments (if enabled).
-        if self._help_on_no_args and len(raw_args) <= 1:
+        if self._help_on_no_arguments and len(raw_args) <= 1:
             print(self._generate_help())
             exit(0)
 
@@ -1042,7 +1042,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         return result^
 
     # ===------------------------------------------------------------------=== #
-    # Parsing sub-methods (extracted from parse_args for readability)
+    # Parsing sub-methods (extracted from parse_arguments for readability)
     # ===------------------------------------------------------------------=== #
 
     fn _parse_long_option(
@@ -1379,7 +1379,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         """Attempts to dispatch to a matching subcommand.
 
         If a subcommand matches, it builds a child argv, injects
-        persistent args, parses via the child's ``parse_args()``,
+        persistent args, parses via the child's ``parse_arguments()``,
         and performs bidirectional sync of persistent values.
 
         Args:
@@ -1425,7 +1425,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
             for _pi in range(len(self.args)):
                 if self.args[_pi].is_persistent:
                     child_copy.args.append(self.args[_pi].copy())
-            var child_result = child_copy.parse_args(child_argv)
+            var child_result = child_copy.parse_arguments(child_argv)
             # Bubble up persistent values from child to root result so
             # that root_result.get_flag("x") always works regardless of
             # whether the flag appeared before or after the subcommand
@@ -2503,7 +2503,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         were actually provided.
 
         Args:
-            result: The ParseResult returned by ``parse()`` or ``parse_args()``.
+            result: The ParseResult returned by ``parse()`` or ``parse_arguments()``.
         """
         print("=== Parsed Arguments ===")
 

--- a/tests/test_collect.mojo
+++ b/tests/test_collect.mojo
@@ -413,32 +413,34 @@ fn test_delimiter_trailing_comma() raises:
 
 
 fn test_nargs_basic() raises:
-    """Tests that nargs(2) consumes exactly 2 values."""
+    """Tests that number_of_values(2) consumes exactly 2 values."""
     var command = Command("test", "Test app")
     command.add_argument(
-        Argument("point", help="X Y coordinates").long("point").nargs(2)
+        Argument("point", help="X Y coordinates")
+        .long("point")
+        .number_of_values(2)
     )
 
     var args: List[String] = ["test", "--point", "10", "20"]
     var result = command.parse_arguments(args)
     var lst = result.get_list("point")
-    assert_equal(len(lst), 2, msg="nargs(2) should produce 2 values")
+    assert_equal(len(lst), 2, msg="number_of_values(2) should produce 2 values")
     assert_equal(lst[0], "10", msg="First value should be '10'")
     assert_equal(lst[1], "20", msg="Second value should be '20'")
     print("  ✓ test_nargs_basic")
 
 
 fn test_nargs_three() raises:
-    """Tests that nargs(3) consumes exactly 3 values."""
+    """Tests that number_of_values(3) consumes exactly 3 values."""
     var command = Command("test", "Test app")
     command.add_argument(
-        Argument("rgb", help="RGB colour").long("rgb").nargs(3)
+        Argument("rgb", help="RGB colour").long("rgb").number_of_values(3)
     )
 
     var args: List[String] = ["test", "--rgb", "255", "128", "0"]
     var result = command.parse_arguments(args)
     var lst = result.get_list("rgb")
-    assert_equal(len(lst), 3, msg="nargs(3) should produce 3 values")
+    assert_equal(len(lst), 3, msg="number_of_values(3) should produce 3 values")
     assert_equal(lst[0], "255", msg="First = 255")
     assert_equal(lst[1], "128", msg="Second = 128")
     assert_equal(lst[2], "0", msg="Third = 0")
@@ -449,13 +451,18 @@ fn test_nargs_short_option() raises:
     """Tests nargs with a short option (-p 1 2)."""
     var command = Command("test", "Test app")
     command.add_argument(
-        Argument("point", help="X Y").long("point").short("p").nargs(2)
+        Argument("point", help="X Y")
+        .long("point")
+        .short("p")
+        .number_of_values(2)
     )
 
     var args: List[String] = ["test", "-p", "3", "4"]
     var result = command.parse_arguments(args)
     var lst = result.get_list("point")
-    assert_equal(len(lst), 2, msg="Short nargs(2) should produce 2 values")
+    assert_equal(
+        len(lst), 2, msg="Short number_of_values(2) should produce 2 values"
+    )
     assert_equal(lst[0], "3", msg="First = 3")
     assert_equal(lst[1], "4", msg="Second = 4")
     print("  ✓ test_nargs_short_option")
@@ -464,7 +471,9 @@ fn test_nargs_short_option() raises:
 fn test_nargs_repeated() raises:
     """Tests that nargs collects across repeated occurrences."""
     var command = Command("test", "Test app")
-    command.add_argument(Argument("point", help="X Y").long("point").nargs(2))
+    command.add_argument(
+        Argument("point", help="X Y").long("point").number_of_values(2)
+    )
 
     var args: List[String] = [
         "test",
@@ -477,7 +486,9 @@ fn test_nargs_repeated() raises:
     ]
     var result = command.parse_arguments(args)
     var lst = result.get_list("point")
-    assert_equal(len(lst), 4, msg="Two nargs(2) calls should produce 4 values")
+    assert_equal(
+        len(lst), 4, msg="Two number_of_values(2) calls should produce 4 values"
+    )
     assert_equal(lst[0], "1", msg="1st = 1")
     assert_equal(lst[1], "2", msg="2nd = 2")
     assert_equal(lst[2], "3", msg="3rd = 3")
@@ -488,7 +499,9 @@ fn test_nargs_repeated() raises:
 fn test_nargs_too_few_values() raises:
     """Tests that nargs raises when not enough values are available."""
     var command = Command("test", "Test app")
-    command.add_argument(Argument("point", help="X Y").long("point").nargs(2))
+    command.add_argument(
+        Argument("point", help="X Y").long("point").number_of_values(2)
+    )
 
     var args: List[String] = ["test", "--point", "10"]
     var caught = False
@@ -508,7 +521,9 @@ fn test_nargs_too_few_values() raises:
 fn test_nargs_too_few_short() raises:
     """Tests that nargs raises with short option when not enough values."""
     var command = Command("test", "Test app")
-    command.add_argument(Argument("point", help="X Y").short("p").nargs(2))
+    command.add_argument(
+        Argument("point", help="X Y").short("p").number_of_values(2)
+    )
 
     var args: List[String] = ["test", "-p", "10"]
     var caught = False
@@ -532,7 +547,7 @@ fn test_nargs_with_choices() raises:
     command.add_argument(
         Argument("dir", help="Two directions")
         .long("dir")
-        .nargs(2)
+        .number_of_values(2)
         .choices(dirs^)
     )
 
@@ -562,7 +577,9 @@ fn test_nargs_with_other_args() raises:
     command.add_argument(
         Argument("verbose", help="Verbose").long("verbose").short("v").flag()
     )
-    command.add_argument(Argument("point", help="X Y").long("point").nargs(2))
+    command.add_argument(
+        Argument("point", help="X Y").long("point").number_of_values(2)
+    )
     command.add_argument(
         Argument("output", help="File").long("output").short("o")
     )
@@ -591,7 +608,9 @@ fn test_nargs_with_other_args() raises:
 fn test_nargs_equals_syntax_rejected() raises:
     """Tests that = syntax is rejected for nargs options."""
     var command = Command("test", "Test app")
-    command.add_argument(Argument("point", help="X Y").long("point").nargs(2))
+    command.add_argument(
+        Argument("point", help="X Y").long("point").number_of_values(2)
+    )
 
     var args: List[String] = ["test", "--point=10", "20"]
     var caught = False
@@ -612,7 +631,7 @@ fn test_nargs_prefix_match() raises:
     """Tests that prefix matching works with nargs options."""
     var command = Command("test", "Test app")
     command.add_argument(
-        Argument("position", help="X Y").long("position").nargs(2)
+        Argument("position", help="X Y").long("position").number_of_values(2)
     )
 
     var args: List[String] = ["test", "--pos", "7", "8"]

--- a/tests/test_collect.mojo
+++ b/tests/test_collect.mojo
@@ -15,7 +15,7 @@ fn test_append_single() raises:
     )
 
     var args: List[String] = ["test", "--tag", "alpha"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     var tags = result.get_list("tag")
     assert_equal(len(tags), 1)
     assert_equal(tags[0], "alpha")
@@ -39,7 +39,7 @@ fn test_append_multiple() raises:
         "--tag",
         "gamma",
     ]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     var tags = result.get_list("tag")
     assert_equal(len(tags), 3)
     assert_equal(tags[0], "alpha")
@@ -56,7 +56,7 @@ fn test_append_short_option() raises:
     )
 
     var args: List[String] = ["test", "-t", "alpha", "-t", "beta"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     var tags = result.get_list("tag")
     assert_equal(len(tags), 2)
     assert_equal(tags[0], "alpha")
@@ -72,7 +72,7 @@ fn test_append_equals_syntax() raises:
     )
 
     var args: List[String] = ["test", "--tag=alpha", "--tag=beta"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     var tags = result.get_list("tag")
     assert_equal(len(tags), 2)
     assert_equal(tags[0], "alpha")
@@ -88,7 +88,7 @@ fn test_append_attached_short() raises:
     )
 
     var args: List[String] = ["test", "-talpha", "-tbeta"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     var tags = result.get_list("tag")
     assert_equal(len(tags), 2)
     assert_equal(tags[0], "alpha")
@@ -104,7 +104,7 @@ fn test_append_mixed_syntax() raises:
     )
 
     var args: List[String] = ["test", "--tag", "a", "-t", "b", "--tag=c", "-td"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     var tags = result.get_list("tag")
     assert_equal(len(tags), 4)
     assert_equal(tags[0], "a")
@@ -122,7 +122,7 @@ fn test_append_empty() raises:
     )
 
     var args: List[String] = ["test"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     var tags = result.get_list("tag")
     assert_equal(len(tags), 0)
     assert_false(result.has("tag"), msg="tag should not be present")
@@ -139,7 +139,7 @@ fn test_append_with_choices() raises:
 
     # Valid choices
     var args: List[String] = ["test", "--env", "dev", "--env", "prod"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     var envlist = result.get_list("env")
     assert_equal(len(envlist), 2)
     assert_equal(envlist[0], "dev")
@@ -154,7 +154,7 @@ fn test_append_with_choices() raises:
     var args2: List[String] = ["test", "--env", "local"]
     var caught = False
     try:
-        _ = command2.parse_args(args2)
+        _ = command2.parse_arguments(args2)
     except e:
         caught = True
         var msg = String(e)
@@ -188,7 +188,7 @@ fn test_append_with_other_args() raises:
         "--include",
         "/opt/lib",
     ]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_true(result.get_flag("verbose"), msg="verbose should be True")
     assert_equal(result.get_string("output"), "out.txt")
     var includes = result.get_list("include")
@@ -211,7 +211,7 @@ fn test_delimiter_comma() raises:
     )
 
     var args: List[String] = ["test", "--tag", "a,b,c"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     var tags = result.get_list("tag")
     assert_equal(len(tags), 3)
     assert_equal(tags[0], "a")
@@ -228,7 +228,7 @@ fn test_delimiter_equals_syntax() raises:
     )
 
     var args: List[String] = ["test", "--tag=x,y,z"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     var tags = result.get_list("tag")
     assert_equal(len(tags), 3)
     assert_equal(tags[0], "x")
@@ -245,7 +245,7 @@ fn test_delimiter_short_option() raises:
     )
 
     var args: List[String] = ["test", "-t", "foo,bar"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     var tags = result.get_list("tag")
     assert_equal(len(tags), 2)
     assert_equal(tags[0], "foo")
@@ -265,7 +265,7 @@ fn test_delimiter_attached_short() raises:
 
     # -vta,b means -v -t a,b (v is flag, t takes value)
     var args: List[String] = ["test", "-vta,b"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_true(result.get_flag("verbose"), msg="-v should be True")
     var tags = result.get_list("tag")
     assert_equal(len(tags), 2)
@@ -282,7 +282,7 @@ fn test_delimiter_repeated() raises:
     )
 
     var args: List[String] = ["test", "--tag", "a,b", "--tag", "c,d"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     var tags = result.get_list("tag")
     assert_equal(len(tags), 4)
     assert_equal(tags[0], "a")
@@ -300,7 +300,7 @@ fn test_delimiter_single_value() raises:
     )
 
     var args: List[String] = ["test", "--tag", "single"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     var tags = result.get_list("tag")
     assert_equal(len(tags), 1)
     assert_equal(tags[0], "single")
@@ -320,7 +320,7 @@ fn test_delimiter_with_choices() raises:
 
     # Valid — all pieces are in choices.
     var args1: List[String] = ["test", "--env", "dev,prod"]
-    var result = command.parse_args(args1)
+    var result = command.parse_arguments(args1)
     var envlist = result.get_list("env")
     assert_equal(len(envlist), 2)
     assert_equal(envlist[0], "dev")
@@ -330,7 +330,7 @@ fn test_delimiter_with_choices() raises:
     var caught = False
     var args2: List[String] = ["test", "--env", "dev,local"]
     try:
-        _ = command.parse_args(args2)
+        _ = command.parse_arguments(args2)
     except e:
         caught = True
         var msg = String(e)
@@ -350,7 +350,7 @@ fn test_delimiter_semicolon() raises:
     )
 
     var args: List[String] = ["test", "--path", "/usr/lib;/opt/lib;/home/lib"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     var paths = result.get_list("path")
     assert_equal(len(paths), 3)
     assert_equal(paths[0], "/usr/lib")
@@ -368,7 +368,7 @@ fn test_delimiter_implies_append() raises:
     )
 
     var args: List[String] = ["test", "--tag", "x,y"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_true(result.has("tag"), msg="tag should be present")
     var tags = result.get_list("tag")
     assert_equal(len(tags), 2)
@@ -385,7 +385,7 @@ fn test_delimiter_empty_not_provided() raises:
     )
 
     var args: List[String] = ["test"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     var tags = result.get_list("tag")
     assert_equal(len(tags), 0)
     print("  ✓ test_delimiter_empty_not_provided")
@@ -399,7 +399,7 @@ fn test_delimiter_trailing_comma() raises:
     )
 
     var args: List[String] = ["test", "--tag", "a,b,"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     var tags = result.get_list("tag")
     assert_equal(len(tags), 2)
     assert_equal(tags[0], "a")
@@ -420,7 +420,7 @@ fn test_nargs_basic() raises:
     )
 
     var args: List[String] = ["test", "--point", "10", "20"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     var lst = result.get_list("point")
     assert_equal(len(lst), 2, msg="nargs(2) should produce 2 values")
     assert_equal(lst[0], "10", msg="First value should be '10'")
@@ -436,7 +436,7 @@ fn test_nargs_three() raises:
     )
 
     var args: List[String] = ["test", "--rgb", "255", "128", "0"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     var lst = result.get_list("rgb")
     assert_equal(len(lst), 3, msg="nargs(3) should produce 3 values")
     assert_equal(lst[0], "255", msg="First = 255")
@@ -453,7 +453,7 @@ fn test_nargs_short_option() raises:
     )
 
     var args: List[String] = ["test", "-p", "3", "4"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     var lst = result.get_list("point")
     assert_equal(len(lst), 2, msg="Short nargs(2) should produce 2 values")
     assert_equal(lst[0], "3", msg="First = 3")
@@ -475,7 +475,7 @@ fn test_nargs_repeated() raises:
         "3",
         "4",
     ]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     var lst = result.get_list("point")
     assert_equal(len(lst), 4, msg="Two nargs(2) calls should produce 4 values")
     assert_equal(lst[0], "1", msg="1st = 1")
@@ -493,7 +493,7 @@ fn test_nargs_too_few_values() raises:
     var args: List[String] = ["test", "--point", "10"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)
@@ -513,7 +513,7 @@ fn test_nargs_too_few_short() raises:
     var args: List[String] = ["test", "-p", "10"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)
@@ -538,7 +538,7 @@ fn test_nargs_with_choices() raises:
 
     # Valid.
     var args: List[String] = ["test", "--dir", "north", "east"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     var lst = result.get_list("dir")
     assert_equal(lst[0], "north", msg="First direction")
     assert_equal(lst[1], "east", msg="Second direction")
@@ -547,7 +547,7 @@ fn test_nargs_with_choices() raises:
     var bad_args: List[String] = ["test", "--dir", "north", "up"]
     var caught = False
     try:
-        _ = command.parse_args(bad_args)
+        _ = command.parse_arguments(bad_args)
     except e:
         caught = True
         var msg = String(e)
@@ -576,7 +576,7 @@ fn test_nargs_with_other_args() raises:
         "-o",
         "out.txt",
     ]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_true(result.get_flag("verbose"), msg="verbose should be True")
     var lst = result.get_list("point")
     assert_equal(len(lst), 2, msg="point should have 2 values")
@@ -596,7 +596,7 @@ fn test_nargs_equals_syntax_rejected() raises:
     var args: List[String] = ["test", "--point=10", "20"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)
@@ -616,7 +616,7 @@ fn test_nargs_prefix_match() raises:
     )
 
     var args: List[String] = ["test", "--pos", "7", "8"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     var lst = result.get_list("position")
     assert_equal(len(lst), 2, msg="prefix --pos should resolve to --position")
     assert_equal(lst[0], "7", msg="First = 7")

--- a/tests/test_completion.mojo
+++ b/tests/test_completion.mojo
@@ -927,5 +927,71 @@ fn test_completions_custom_name_with_subcommand() raises:
     print("  ✓ test_completions_custom_name_with_subcommand")
 
 
+# ── Alias in completion scripts ──────────────────────────────────────────────
+
+
+fn test_fish_completion_includes_alias() raises:
+    """Tests that Fish completion lists alias as a completable name."""
+    var app = Command("myapp", "A test app")
+    var clone = Command("clone", "Clone a repository")
+    var aliases: List[String] = ["cl"]
+    clone.command_aliases(aliases^)
+    app.add_subcommand(clone^)
+    var script = app.generate_completion("fish")
+    assert_true(
+        "-a 'cl'" in script,
+        msg="Fish script should list alias 'cl' as completable",
+    )
+    assert_true(
+        "-a 'clone'" in script,
+        msg="Fish script should still list primary name 'clone'",
+    )
+    # Alias should also be in the seen_subcommand_from condition.
+    assert_true(
+        "__fish_seen_subcommand_from clone cl" in script,
+        msg="Fish should include alias in seen_subcommand_from",
+    )
+    print("  ✓ test_fish_completion_includes_alias")
+
+
+fn test_zsh_completion_includes_alias() raises:
+    """Tests that Zsh completion lists alias entries."""
+    var app = Command("myapp", "A test app")
+    var clone = Command("clone", "Clone a repository")
+    var aliases: List[String] = ["cl"]
+    clone.command_aliases(aliases^)
+    app.add_subcommand(clone^)
+    var script = app.generate_completion("zsh")
+    assert_true(
+        "'cl:" in script,
+        msg="Zsh script should list alias 'cl' in commands array",
+    )
+    assert_true(
+        "clone|cl)" in script,
+        msg="Zsh script should dispatch clone|cl pattern",
+    )
+    print("  ✓ test_zsh_completion_includes_alias")
+
+
+fn test_bash_completion_includes_alias() raises:
+    """Tests that Bash completion includes alias in dispatch pattern."""
+    var app = Command("myapp", "A test app")
+    var clone = Command("clone", "Clone a repository")
+    var aliases: List[String] = ["cl"]
+    clone.command_aliases(aliases^)
+    app.add_subcommand(clone^)
+    var script = app.generate_completion("bash")
+    assert_true(
+        "clone|cl)" in script,
+        msg="Bash script should have clone|cl) case pattern",
+    )
+    # Alias should also appear in the subcommand list for root completion.
+    assert_true(
+        "clone cl" in script,
+        msg="Bash should list alias in subcommand names",
+    )
+    print("  ✓ test_bash_completion_includes_alias")
+
+
 fn main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_extras.mojo
+++ b/tests/test_extras.mojo
@@ -15,7 +15,7 @@ fn test_range_valid_value() raises:
     )
 
     var args: List[String] = ["test", "--port", "8080"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("port"), "8080")
     print("  ✓ test_range_valid_value")
 
@@ -28,7 +28,7 @@ fn test_range_boundary_min() raises:
     )
 
     var args: List[String] = ["test", "--port", "1"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("port"), "1")
     print("  ✓ test_range_boundary_min")
 
@@ -41,7 +41,7 @@ fn test_range_boundary_max() raises:
     )
 
     var args: List[String] = ["test", "--port", "65535"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("port"), "65535")
     print("  ✓ test_range_boundary_max")
 
@@ -56,7 +56,7 @@ fn test_range_below_min() raises:
     var args: List[String] = ["test", "--port", "0"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)
@@ -78,7 +78,7 @@ fn test_range_above_max() raises:
     var args: List[String] = ["test", "--port", "70000"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)
@@ -97,7 +97,7 @@ fn test_range_not_provided_ok() raises:
     )
 
     var args: List[String] = ["test"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_false(result.has("port"), msg="port should not be set")
     print("  ✓ test_range_not_provided_ok")
 
@@ -112,7 +112,7 @@ fn test_range_with_append() raises:
     var args: List[String] = ["test", "--port", "50", "--port", "101"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)
@@ -132,7 +132,7 @@ fn test_range_with_short_option() raises:
     )
 
     var args: List[String] = ["test", "-l", "3"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("level"), "3")
     print("  ✓ test_range_with_short_option")
 
@@ -151,7 +151,7 @@ fn test_map_single_pair() raises:
     )
 
     var args: List[String] = ["test", "--define", "CC=gcc"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     var m = result.get_map("define")
     assert_equal(m["CC"], "gcc")
     print("  ✓ test_map_single_pair")
@@ -168,7 +168,7 @@ fn test_map_multiple_pairs() raises:
     )
 
     var args: List[String] = ["test", "--define", "CC=gcc", "-D", "CXX=g++"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     var m = result.get_map("define")
     assert_equal(m["CC"], "gcc")
     assert_equal(m["CXX"], "g++")
@@ -183,7 +183,7 @@ fn test_map_equals_syntax() raises:
     )
 
     var args: List[String] = ["test", "--define=CC=gcc"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     var m = result.get_map("define")
     assert_equal(m["CC"], "gcc")
     print("  ✓ test_map_equals_syntax")
@@ -201,7 +201,7 @@ fn test_map_with_delimiter() raises:
     )
 
     var args: List[String] = ["test", "--define", "CC=gcc,CXX=g++"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     var m = result.get_map("define")
     assert_equal(m["CC"], "gcc")
     assert_equal(m["CXX"], "g++")
@@ -218,7 +218,7 @@ fn test_map_invalid_no_equals() raises:
     var args: List[String] = ["test", "--define", "NOEQUALS"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)
@@ -235,7 +235,7 @@ fn test_map_has_check() raises:
     )
 
     var args: List[String] = ["test", "--define", "A=1"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_true(result.has("define"), msg="has() should be True for map arg")
     print("  ✓ test_map_has_check")
 
@@ -248,7 +248,7 @@ fn test_map_empty_value() raises:
     )
 
     var args: List[String] = ["test", "--define", "KEY="]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     var m = result.get_map("define")
     assert_equal(m["KEY"], "")
     print("  ✓ test_map_empty_value")
@@ -262,7 +262,7 @@ fn test_map_value_with_equals() raises:
     )
 
     var args: List[String] = ["test", "--env", "PATH=/usr/bin:/bin"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     var m = result.get_map("env")
     assert_equal(m["PATH"], "/usr/bin:/bin")
     print("  ✓ test_map_value_with_equals")
@@ -282,7 +282,7 @@ fn test_alias_basic() raises:
     )
 
     var args: List[String] = ["test", "--color", "red"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("colour"), "red")
     print("  ✓ test_alias_basic")
 
@@ -298,7 +298,7 @@ fn test_alias_primary_still_works() raises:
     )
 
     var args: List[String] = ["test", "--colour", "blue"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("colour"), "blue")
     print("  ✓ test_alias_primary_still_works")
 
@@ -314,11 +314,11 @@ fn test_alias_multiple() raises:
     )
 
     var args: List[String] = ["test", "--fmt", "json"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("output"), "json")
 
     var args2: List[String] = ["test", "--out", "yaml"]
-    var result2 = command.parse_args(args2)
+    var result2 = command.parse_arguments(args2)
     assert_equal(result2.get_string("output"), "yaml")
     print("  ✓ test_alias_multiple")
 
@@ -334,7 +334,7 @@ fn test_alias_prefix_match() raises:
     )
 
     var args: List[String] = ["test", "--colo", "green"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("colour"), "green")
     print("  ✓ test_alias_prefix_match")
 
@@ -351,7 +351,7 @@ fn test_alias_with_flag() raises:
     )
 
     var args: List[String] = ["test", "--debug"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_true(
         result.get_flag("verbose"), msg="--debug alias should set verbose flag"
     )
@@ -371,7 +371,7 @@ fn test_deprecated_still_parses() raises:
     )
 
     var args: List[String] = ["test", "--format-old", "csv"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("format_old"), "csv")
     print("  ✓ test_deprecated_still_parses")
 
@@ -388,7 +388,7 @@ fn test_deprecated_short_option() raises:
     )
 
     var args: List[String] = ["test", "-C"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_true(result.get_flag("compat"), msg="-C should still set the flag")
     print("  ✓ test_deprecated_short_option")
 
@@ -404,7 +404,7 @@ fn test_deprecated_not_provided_ok() raises:
     command.add_argument(Argument("new", help="New option").long("new"))
 
     var args: List[String] = ["test", "--new", "val"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_false(result.has("old"), msg="old should not be present")
     assert_equal(result.get_string("new"), "val")
     print("  ✓ test_deprecated_not_provided_ok")
@@ -422,7 +422,7 @@ fn test_deprecated_with_alias() raises:
     )
 
     var args: List[String] = ["test", "--out", "json"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("output"), "json")
     print("  ✓ test_deprecated_with_alias")
 

--- a/tests/test_groups.mojo
+++ b/tests/test_groups.mojo
@@ -23,7 +23,7 @@ fn test_exclusive_one_provided() raises:
     command.mutually_exclusive(group^)
 
     var args: List[String] = ["test", "--json"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_true(result.get_flag("json"), msg="--json should be True")
     assert_false(result.get_flag("yaml"), msg="--yaml should be False")
     print("  ✓ test_exclusive_one_provided")
@@ -42,7 +42,7 @@ fn test_exclusive_none_provided() raises:
     command.mutually_exclusive(group^)
 
     var args: List[String] = ["test"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_false(result.get_flag("json"), msg="--json should be False")
     assert_false(result.get_flag("yaml"), msg="--yaml should be False")
     print("  ✓ test_exclusive_none_provided")
@@ -66,7 +66,7 @@ fn test_exclusive_conflict() raises:
     var args: List[String] = ["test", "--json", "--yaml"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)
@@ -99,7 +99,7 @@ fn test_exclusive_value_args() raises:
     var args: List[String] = ["test", "--input", "file.txt", "--stdin"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)
@@ -133,7 +133,7 @@ fn test_required_together_all_provided() raises:
         "--password",
         "secret",
     ]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("username"), "admin")
     assert_equal(result.get_string("password"), "secret")
     print("  ✓ test_required_together_all_provided")
@@ -152,7 +152,7 @@ fn test_required_together_none_provided() raises:
     command.required_together(group^)
 
     var args: List[String] = ["test"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_false(result.has("username"), msg="username should not be set")
     assert_false(result.has("password"), msg="password should not be set")
     print("  ✓ test_required_together_none_provided")
@@ -174,7 +174,7 @@ fn test_required_together_partial() raises:
     var args: List[String] = ["test", "--username", "admin"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)
@@ -202,7 +202,7 @@ fn test_required_together_three_args() raises:
     var args: List[String] = ["test", "--host", "localhost"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)
@@ -239,7 +239,7 @@ fn test_one_required_one_provided() raises:
     command.one_required(group^)
 
     var args: List[String] = ["test", "--yaml"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_true(result.get_flag("yaml"), msg="--yaml should be True")
     assert_false(result.get_flag("json"), msg="--json should be False")
     assert_false(result.get_flag("toml"), msg="--toml should be False")
@@ -260,7 +260,7 @@ fn test_one_required_multiple_provided() raises:
 
     # Both provided — one_required is satisfied (it only requires at least one).
     var args: List[String] = ["test", "--json", "--yaml"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_true(result.get_flag("json"), msg="--json should be True")
     assert_true(result.get_flag("yaml"), msg="--yaml should be True")
     print("  ✓ test_one_required_multiple_provided")
@@ -281,7 +281,7 @@ fn test_one_required_none_provided() raises:
     var args: List[String] = ["test"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)
@@ -315,7 +315,7 @@ fn test_one_required_with_value_args() raises:
 
     # Providing --input satisfies the group.
     var args: List[String] = ["test", "--input", "data.txt"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("input"), "data.txt")
     print("  ✓ test_one_required_with_value_args")
 
@@ -333,7 +333,7 @@ fn test_one_required_with_short_option() raises:
     command.one_required(group^)
 
     var args: List[String] = ["test", "-j"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_true(result.get_flag("json"), msg="-j should satisfy one_required")
     print("  ✓ test_one_required_with_short_option")
 
@@ -354,7 +354,7 @@ fn test_one_required_error_shows_display_names() raises:
     var args: List[String] = ["test"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)
@@ -383,14 +383,14 @@ fn test_one_required_combined_with_exclusive() raises:
 
     # Providing one is fine.
     var args1: List[String] = ["test", "--json"]
-    var result1 = command.parse_args(args1)
+    var result1 = command.parse_arguments(args1)
     assert_true(result1.get_flag("json"), msg="--json should be True")
 
     # Providing none fails (one-required).
     var caught_none = False
     var args2: List[String] = ["test"]
     try:
-        _ = command.parse_args(args2)
+        _ = command.parse_arguments(args2)
     except:
         caught_none = True
     assert_true(caught_none, msg="Should error when none provided")
@@ -399,7 +399,7 @@ fn test_one_required_combined_with_exclusive() raises:
     var caught_both = False
     var args3: List[String] = ["test", "--json", "--yaml"]
     try:
-        _ = command.parse_args(args3)
+        _ = command.parse_arguments(args3)
     except:
         caught_both = True
     assert_true(caught_both, msg="Should error when both provided")
@@ -422,7 +422,7 @@ fn test_one_required_multiple_groups() raises:
 
     # Satisfying both groups.
     var args1: List[String] = ["test", "--yaml", "--input", "f.txt"]
-    var result1 = command.parse_args(args1)
+    var result1 = command.parse_arguments(args1)
     assert_true(result1.get_flag("yaml"), msg="--yaml should be True")
     assert_equal(result1.get_string("input"), "f.txt")
 
@@ -430,7 +430,7 @@ fn test_one_required_multiple_groups() raises:
     var caught = False
     var args2: List[String] = ["test", "--json"]
     try:
-        _ = command.parse_args(args2)
+        _ = command.parse_arguments(args2)
     except e:
         caught = True
         var msg = String(e)
@@ -454,7 +454,7 @@ fn test_one_required_with_append_arg() raises:
 
     # Providing --tag satisfies the group.
     var args: List[String] = ["test", "--tag", "v1"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     var tags = result.get_list("tag")
     assert_equal(len(tags), 1)
     assert_equal(tags[0], "v1")
@@ -478,7 +478,7 @@ fn test_conditional_req_satisfied() raises:
     command.required_if("output", "save")
 
     var args: List[String] = ["test", "--save", "--output", "out.txt"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_true(result.get_flag("save"), msg="--save should be True")
     assert_equal(result.get_string("output"), "out.txt")
     print("  ✓ test_conditional_req_satisfied")
@@ -498,7 +498,7 @@ fn test_conditional_req_condition_absent() raises:
 
     # --save not provided → --output not required → should pass
     var args: List[String] = ["test"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_false(result.has("save"), msg="save should not be present")
     assert_false(result.has("output"), msg="output should not be present")
     print("  ✓ test_conditional_req_condition_absent")
@@ -519,7 +519,7 @@ fn test_conditional_req_violated() raises:
     var args: List[String] = ["test", "--save"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)
@@ -552,7 +552,7 @@ fn test_conditional_req_target_alone_ok() raises:
 
     # --output provided without --save → should be fine
     var args: List[String] = ["test", "--output", "out.txt"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("output"), "out.txt")
     assert_false(result.has("save"), msg="save should not be present")
     print("  ✓ test_conditional_req_target_alone_ok")
@@ -585,7 +585,7 @@ fn test_conditional_req_multiple_rules() raises:
         "--format",
         "gzip",
     ]
-    var result1 = command.parse_args(args1)
+    var result1 = command.parse_arguments(args1)
     assert_equal(result1.get_string("output"), "out.txt")
     assert_equal(result1.get_string("format"), "gzip")
 
@@ -607,7 +607,7 @@ fn test_conditional_req_multiple_rules() raises:
     var args2: List[String] = ["test", "--compress"]
     var caught = False
     try:
-        _ = command2.parse_args(args2)
+        _ = command2.parse_arguments(args2)
     except e:
         caught = True
         var msg = String(e)
@@ -638,7 +638,7 @@ fn test_conditional_req_with_short_option() raises:
     var args: List[String] = ["test", "-s"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)
@@ -650,7 +650,7 @@ fn test_conditional_req_with_short_option() raises:
 
     # Using -s -o file.txt satisfies it
     var args2: List[String] = ["test", "-s", "-o", "out.txt"]
-    var result = command.parse_args(args2)
+    var result = command.parse_arguments(args2)
     assert_true(result.get_flag("save"), msg="-s should set save")
     assert_equal(result.get_string("output"), "out.txt")
     print("  ✓ test_conditional_req_with_short_option")
@@ -669,7 +669,7 @@ fn test_conditional_req_with_value_condition() raises:
     var args: List[String] = ["test", "--format", "json"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)
@@ -694,7 +694,7 @@ fn test_conditional_req_error_uses_display_names() raises:
     var args: List[String] = ["test", "--save"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)

--- a/tests/test_help.mojo
+++ b/tests/test_help.mojo
@@ -42,7 +42,7 @@ fn test_hidden_still_works() raises:
     )
 
     var args: List[String] = ["test", "--debug"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_true(result.get_flag("debug"), msg="hidden --debug should work")
     print("  ✓ test_hidden_still_works")
 
@@ -252,8 +252,9 @@ fn test_help_and_version_aligned() raises:
     print("  ✓ test_help_and_version_aligned")
 
 
-fn test_help_on_no_args_disabled_by_default() raises:
-    """Tests that parse_args works with no args when help_on_no_args is off."""
+fn test_help_on_no_arguments_disabled_by_default() raises:
+    """Tests that parse_arguments works with no args when help_on_no_arguments is off.
+    """
     var command = Command("test", "Test app")
     command.add_argument(
         Argument("verbose", help="Verbose").long("verbose").short("v").flag()
@@ -261,9 +262,9 @@ fn test_help_on_no_args_disabled_by_default() raises:
 
     var args: List[String] = ["test"]
     # Should NOT exit — just parse with defaults.
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_false(result.get_flag("verbose"), msg="verbose should be False")
-    print("  ✓ test_help_on_no_args_disabled_by_default")
+    print("  ✓ test_help_on_no_arguments_disabled_by_default")
 
 
 fn test_positional_args_aligned_in_help() raises:
@@ -714,8 +715,8 @@ fn test_child_help_shows_full_command_path() raises:
     # Simulate: app search --help
     # The child copy gets name set to "app search", so --help would
     # show "Usage: app search ..." in help.
-    # We test indirectly by checking what parse_args sets on the child copy.
-    # Create the child copy as parse_args would.
+    # We test indirectly by checking what parse_arguments sets on the child copy.
+    # Create the child copy as parse_arguments would.
     # Note: subcommands[0] is auto-added 'help'; search is at index 1.
     var search_idx = app._find_subcommand("search")
     var child_copy = app.subcommands[search_idx].copy()

--- a/tests/test_help.mojo
+++ b/tests/test_help.mojo
@@ -794,5 +794,40 @@ fn test_add_tip_appears_in_help() raises:
     print("  ✓ test_add_tip_appears_in_help")
 
 
+# ── Alias in help output ──────────────────────────────────────────────────────
+
+
+fn test_alias_shown_inline_in_help() raises:
+    """Tests that subcommand aliases appear inline in help output."""
+    var app = Command("app", "Test app")
+    var clone = Command("clone", "Clone a repo")
+    var aliases: List[String] = ["cl"]
+    clone.command_aliases(aliases^)
+    app.add_subcommand(clone^)
+
+    var help = app._generate_help(color=False)
+    assert_true(
+        "clone, cl" in help,
+        msg="Help should show alias inline: 'clone, cl'",
+    )
+    print("  ✓ test_alias_shown_inline_in_help")
+
+
+fn test_multiple_aliases_shown_in_help() raises:
+    """Tests that multiple aliases are all shown inline in help."""
+    var app = Command("app", "Test app")
+    var commit = Command("commit", "Record changes")
+    var aliases: List[String] = ["ci", "cm"]
+    commit.command_aliases(aliases^)
+    app.add_subcommand(commit^)
+
+    var help = app._generate_help(color=False)
+    assert_true(
+        "commit, ci, cm" in help,
+        msg="Help should show all aliases: 'commit, ci, cm'",
+    )
+    print("  ✓ test_multiple_aliases_shown_in_help")
+
+
 fn main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_help.mojo
+++ b/tests/test_help.mojo
@@ -500,21 +500,25 @@ fn test_nargs_in_help() raises:
     """Tests that nargs options show repeated placeholders in help."""
     var command = Command("test", "Test app")
     command.add_argument(
-        Argument("point", help="X Y coords").long("point").nargs(2)
+        Argument("point", help="X Y coords").long("point").number_of_values(2)
     )
     command.add_argument(
-        Argument("rgb", help="RGB colour").long("rgb").nargs(3).metavar("N")
+        Argument("rgb", help="RGB colour")
+        .long("rgb")
+        .number_of_values(3)
+        .metavar("N")
     )
 
     var help = command._generate_help(color=False)
     # --point should show <point> <point>
     assert_true(
         "<point> <point>" in help,
-        msg="nargs(2) should show '<point> <point>' in help",
+        msg="number_of_values(2) should show '<point> <point>' in help",
     )
     # --rgb should show N N N
     assert_true(
-        "N N N" in help, msg="nargs(3) with metavar should show 'N N N'"
+        "N N N" in help,
+        msg="number_of_values(3) with metavar should show 'N N N'",
     )
     # Neither should have "..." since they are nargs, not plain append.
     assert_false(
@@ -530,14 +534,14 @@ fn test_nargs_with_metavar() raises:
     command.add_argument(
         Argument("size", help="Width and height")
         .long("size")
-        .nargs(2)
+        .number_of_values(2)
         .metavar("PX")
     )
 
     var help = command._generate_help(color=False)
     assert_true(
         "PX PX" in help,
-        msg="nargs(2) with metavar PX should show 'PX PX'",
+        msg="number_of_values(2) with metavar PX should show 'PX PX'",
     )
     print("  ✓ test_nargs_with_metavar")
 

--- a/tests/test_negative_numbers.mojo
+++ b/tests/test_negative_numbers.mojo
@@ -28,7 +28,7 @@ fn test_negative_integer_auto_detect() raises:
     )
 
     var args: List[String] = ["test", "-9876543"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.positionals[0], "-9876543")
     print("  ✓ test_negative_integer_auto_detect")
 
@@ -41,7 +41,7 @@ fn test_negative_float_auto_detect() raises:
     )
 
     var args: List[String] = ["test", "-3.14"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.positionals[0], "-3.14")
     print("  ✓ test_negative_float_auto_detect")
 
@@ -54,7 +54,7 @@ fn test_negative_leading_dot_auto_detect() raises:
     )
 
     var args: List[String] = ["test", "-.5"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.positionals[0], "-.5")
     print("  ✓ test_negative_leading_dot_auto_detect")
 
@@ -68,7 +68,7 @@ fn test_negative_scientific_auto_detect() raises:
     )
 
     var args: List[String] = ["test", "-1.5e10"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.positionals[0], "-1.5e10")
     print("  ✓ test_negative_scientific_auto_detect")
 
@@ -81,7 +81,7 @@ fn test_negative_scientific_negative_exp_auto_detect() raises:
     )
 
     var args: List[String] = ["test", "-2.0e-3"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.positionals[0], "-2.0e-3")
     print("  ✓ test_negative_scientific_negative_exp_auto_detect")
 
@@ -97,7 +97,7 @@ fn test_multiple_negative_positionals() raises:
     )
 
     var args: List[String] = ["test", "-1", "-2.5"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(len(result.positionals), 2)
     assert_equal(result.positionals[0], "-1")
     assert_equal(result.positionals[1], "-2.5")
@@ -115,7 +115,7 @@ fn test_mixed_negative_and_options() raises:
     )
 
     var args: List[String] = ["test", "--verbose", "-10.18"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_true(result.get_flag("verbose"))
     assert_equal(result.positionals[0], "-10.18")
     print("  ✓ test_mixed_negative_and_options")
@@ -140,7 +140,7 @@ fn test_explicit_allow_negative_numbers() raises:
 
     # "-3.14" should still pass through as a positional.
     var args: List[String] = ["test", "-3.14"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.positionals[0], "-3.14")
     print("  ✓ test_explicit_allow_negative_numbers")
 
@@ -161,7 +161,7 @@ fn test_explicit_allow_keeps_digit_short_option() raises:
 
     # With allow_negative_numbers set, even bare "-3" becomes a positional.
     var args: List[String] = ["test", "-3"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.positionals[0], "-3")
     print("  ✓ test_explicit_allow_keeps_digit_short_option")
 
@@ -179,7 +179,7 @@ fn test_digit_short_suppresses_auto_detect() raises:
     )
 
     var args: List[String] = ["test", "-3"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     # The flag should be set; no positionals.
     assert_true(result.get_flag("triple"))
     assert_equal(len(result.positionals), 0)
@@ -198,7 +198,7 @@ fn test_double_dash_passes_negative_number() raises:
     )
 
     var args: List[String] = ["test", "--", "-10.18"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.positionals[0], "-10.18")
     print("  ✓ test_double_dash_passes_negative_number")
 
@@ -211,7 +211,7 @@ fn test_double_dash_passes_option_like_string() raises:
     )
 
     var args: List[String] = ["test", "--", "--foo"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.positionals[0], "--foo")
     print("  ✓ test_double_dash_passes_option_like_string")
 
@@ -228,7 +228,7 @@ fn test_unknown_short_option_still_errors() raises:
     var args: List[String] = ["test", "-x"]
     var raised = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except:
         raised = True
     assert_true(raised, msg="'-x' should raise Unknown option error")
@@ -243,7 +243,7 @@ fn test_invalid_numeric_form_still_errors() raises:
     var args: List[String] = ["test", "-1abc"]
     var raised = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except:
         raised = True
     assert_true(raised, msg="'-1abc' is not a number and should raise an error")

--- a/tests/test_parse.mojo
+++ b/tests/test_parse.mojo
@@ -16,7 +16,7 @@ fn test_flag_long() raises:
     )
 
     var args: List[String] = ["test", "--verbose"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_true(result.get_flag("verbose"), msg="--verbose should be True")
     print("  ✓ test_flag_long")
 
@@ -32,7 +32,7 @@ fn test_flag_short() raises:
     )
 
     var args: List[String] = ["test", "-v"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_true(result.get_flag("verbose"), msg="-v should be True")
     print("  ✓ test_flag_short")
 
@@ -48,7 +48,7 @@ fn test_flag_default_false() raises:
     )
 
     var args: List[String] = ["test"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_false(result.get_flag("verbose"), msg="unset flag should be False")
     print("  ✓ test_flag_default_false")
 
@@ -61,7 +61,7 @@ fn test_key_value_long_space() raises:
     )
 
     var args: List[String] = ["test", "--output", "file.txt"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("output"), "file.txt")
     print("  ✓ test_key_value_long_space")
 
@@ -74,7 +74,7 @@ fn test_key_value_long_equals() raises:
     )
 
     var args: List[String] = ["test", "--output=file.txt"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("output"), "file.txt")
     print("  ✓ test_key_value_long_equals")
 
@@ -87,7 +87,7 @@ fn test_key_value_short() raises:
     )
 
     var args: List[String] = ["test", "-o", "file.txt"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("output"), "file.txt")
     print("  ✓ test_key_value_short")
 
@@ -103,7 +103,7 @@ fn test_positional_args() raises:
     )
 
     var args: List[String] = ["test", "hello", "./src"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("pattern"), "hello")
     assert_equal(result.get_string("path"), "./src")
     print("  ✓ test_positional_args")
@@ -120,7 +120,7 @@ fn test_positional_with_default() raises:
     )
 
     var args: List[String] = ["test", "hello"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("pattern"), "hello")
     assert_equal(result.get_string("path"), ".")
     print("  ✓ test_positional_with_default")
@@ -162,7 +162,7 @@ fn test_mixed_args() raises:
         "--max-depth",
         "3",
     ]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("pattern"), "zhong")
     assert_equal(result.get_string("path"), "./src")
     assert_true(result.get_flag("ling"), msg="--ling should be True")
@@ -177,7 +177,7 @@ fn test_double_dash_stop() raises:
     command.add_argument(Argument("verbose").long("verbose").short("v").flag())
 
     var args: List[String] = ["test", "--", "--verbose"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_false(
         result.get_flag("verbose"),
         msg="--verbose after -- should not be parsed as flag",
@@ -194,7 +194,7 @@ fn test_has() raises:
     command.add_argument(Argument("output").long("output"))
 
     var args: List[String] = ["test", "--verbose"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_true(result.has("verbose"), msg="verbose should exist")
     assert_false(result.has("output"), msg="output should not exist")
     print("  ✓ test_has")
@@ -211,7 +211,7 @@ fn test_merged_short_flags() raises:
     command.add_argument(Argument("color", help="Color").short("c").flag())
 
     var args: List[String] = ["test", "-abc"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_true(result.get_flag("all"), msg="-a should be True from -abc")
     assert_true(result.get_flag("brief"), msg="-b should be True from -abc")
     assert_true(result.get_flag("color"), msg="-c should be True from -abc")
@@ -226,7 +226,7 @@ fn test_merged_flags_partial() raises:
     command.add_argument(Argument("color", help="Color").short("c").flag())
 
     var args: List[String] = ["test", "-ab"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_true(result.get_flag("all"), msg="-a should be True from -ab")
     assert_true(result.get_flag("brief"), msg="-b should be True from -ab")
     assert_false(result.get_flag("color"), msg="-c should be False (not given)")
@@ -241,7 +241,7 @@ fn test_merged_flags_with_trailing_value() raises:
     command.add_argument(Argument("output", help="Output").short("o"))
 
     var args: List[String] = ["test", "-avo", "file.txt"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_true(result.get_flag("all"), msg="-a should be True")
     assert_true(result.get_flag("verbose"), msg="-v should be True")
     assert_equal(result.get_string("output"), "file.txt")
@@ -257,7 +257,7 @@ fn test_attached_short_value() raises:
     command.add_argument(Argument("output", help="Output").short("o"))
 
     var args: List[String] = ["test", "-ofile.txt"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("output"), "file.txt")
     print("  ✓ test_attached_short_value")
 
@@ -270,7 +270,7 @@ fn test_merged_flags_with_attached_value() raises:
     command.add_argument(Argument("output", help="Output").short("o"))
 
     var args: List[String] = ["test", "-abofile.txt"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_true(result.get_flag("all"), msg="-a should be True")
     assert_true(result.get_flag("brief"), msg="-b should be True")
     assert_equal(result.get_string("output"), "file.txt")
@@ -292,7 +292,7 @@ fn test_choices_valid() raises:
     )
 
     var args: List[String] = ["test", "--format", "json"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("format"), "json")
     print("  ✓ test_choices_valid")
 
@@ -311,7 +311,7 @@ fn test_choices_invalid() raises:
     var args: List[String] = ["test", "--format", "xml"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)
@@ -338,7 +338,7 @@ fn test_choices_with_short_attached() raises:
     )
 
     var args: List[String] = ["test", "-fjson"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("format"), "json")
     print("  ✓ test_choices_with_short_attached")
 
@@ -357,7 +357,7 @@ fn test_count_single() raises:
     )
 
     var args: List[String] = ["test", "-v"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_count("verbose"), 1)
     print("  ✓ test_count_single")
 
@@ -373,7 +373,7 @@ fn test_count_triple() raises:
     )
 
     var args: List[String] = ["test", "-vvv"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_count("verbose"), 3)
     print("  ✓ test_count_triple")
 
@@ -389,7 +389,7 @@ fn test_count_long_repeated() raises:
     )
 
     var args: List[String] = ["test", "--verbose", "--verbose"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_count("verbose"), 2)
     print("  ✓ test_count_long_repeated")
 
@@ -405,7 +405,7 @@ fn test_count_mixed_short_long() raises:
     )
 
     var args: List[String] = ["test", "-vv", "--verbose"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_count("verbose"), 3)
     print("  ✓ test_count_mixed_short_long")
 
@@ -421,7 +421,7 @@ fn test_count_default_zero() raises:
     )
 
     var args: List[String] = ["test"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_count("verbose"), 0)
     print("  ✓ test_count_default_zero")
 
@@ -439,7 +439,7 @@ fn test_too_many_positionals() raises:
     var args: List[String] = ["test", "hello", "extra1", "extra2"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)
@@ -464,7 +464,7 @@ fn test_exact_positionals_ok() raises:
     )
 
     var args: List[String] = ["test", "hello", "./src"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("pattern"), "hello")
     assert_equal(result.get_string("path"), "./src")
     print("  ✓ test_exact_positionals_ok")
@@ -484,7 +484,7 @@ fn test_negatable_positive() raises:
     )
 
     var args: List[String] = ["test", "--color"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_true(result.get_flag("color"), msg="--color should be True")
     print("  ✓ test_negatable_positive")
 
@@ -500,7 +500,7 @@ fn test_negatable_negative() raises:
     )
 
     var args: List[String] = ["test", "--no-color"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_false(result.get_flag("color"), msg="--no-color should be False")
     assert_true(
         result.has("color"), msg="color should be present after --no-color"
@@ -519,7 +519,7 @@ fn test_negatable_default() raises:
     )
 
     var args: List[String] = ["test"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_false(
         result.get_flag("color"), msg="unset negatable should be False"
     )
@@ -539,7 +539,7 @@ fn test_non_negatable_rejects_no_prefix() raises:
     var args: List[String] = ["test", "--no-verbose"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)
@@ -567,7 +567,7 @@ fn test_prefix_match_unambiguous() raises:
     )
 
     var args: List[String] = ["test", "--verb"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_true(
         result.get_flag("verbose"), msg="--verb should resolve to --verbose"
     )
@@ -582,7 +582,7 @@ fn test_prefix_match_value() raises:
     )
 
     var args: List[String] = ["test", "--out", "file.txt"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("output"), "file.txt")
     print("  ✓ test_prefix_match_value")
 
@@ -595,7 +595,7 @@ fn test_prefix_match_equals() raises:
     )
 
     var args: List[String] = ["test", "--out=file.txt"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("output"), "file.txt")
     print("  ✓ test_prefix_match_equals")
 
@@ -618,7 +618,7 @@ fn test_prefix_match_ambiguous() raises:
     var args: List[String] = ["test", "--ver"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)
@@ -639,7 +639,7 @@ fn test_prefix_match_exact_preferred() raises:
 
     # --color should exactly match 'color', not be ambiguous.
     var args: List[String] = ["test", "--color"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_true(
         result.get_flag("color"),
         msg="--color should exactly match 'color'",
@@ -662,7 +662,7 @@ fn test_prefix_match_negatable() raises:
     )
 
     var args: List[String] = ["test", "--no-col"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_false(result.get_flag("color"), msg="--no-col should negate color")
     assert_true(
         result.has("color"), msg="color should be present after --no-col"

--- a/tests/test_persistent.mojo
+++ b/tests/test_persistent.mojo
@@ -36,7 +36,7 @@ fn test_persistent_flag_on_root_no_subcommand() raises:
         .flag()
         .persistent()
     )
-    var r = command.parse_args(["app", "--verbose"])
+    var r = command.parse_arguments(["app", "--verbose"])
     assert_true(r.get_flag("verbose"), msg="root verbose should be True")
     print("  ✓ test_persistent_flag_on_root_no_subcommand")
 
@@ -51,7 +51,7 @@ fn test_persistent_flag_absent_on_root() raises:
         .flag()
         .persistent()
     )
-    var r = command.parse_args(["app"])
+    var r = command.parse_arguments(["app"])
     assert_false(r.get_flag("verbose"), msg="absent verbose should be False")
     print("  ✓ test_persistent_flag_absent_on_root")
 
@@ -74,7 +74,7 @@ fn test_persistent_flag_before_subcommand_in_root_result() raises:
     search.add_argument(Argument("pattern", help="").positional().required())
     app.add_subcommand(search^)
 
-    var r = app.parse_args(["app", "--verbose", "search", "pattern"])
+    var r = app.parse_arguments(["app", "--verbose", "search", "pattern"])
     assert_true(r.get_flag("verbose"), msg="root verbose should be True")
     assert_equal(r.subcommand, "search")
     print("  ✓ test_persistent_flag_before_subcommand_in_root_result")
@@ -95,7 +95,7 @@ fn test_persistent_flag_before_subcommand_pushed_to_child() raises:
     search.add_argument(Argument("pattern", help="").positional().required())
     app.add_subcommand(search^)
 
-    var r = app.parse_args(["app", "--verbose", "search", "pattern"])
+    var r = app.parse_arguments(["app", "--verbose", "search", "pattern"])
     var sub = r.get_subcommand_result()
     assert_true(
         sub.get_flag("verbose"),
@@ -122,7 +122,7 @@ fn test_persistent_flag_after_subcommand_in_child_result() raises:
     search.add_argument(Argument("pattern", help="").positional().required())
     app.add_subcommand(search^)
 
-    var r = app.parse_args(["app", "search", "--verbose", "pattern"])
+    var r = app.parse_arguments(["app", "search", "--verbose", "pattern"])
     var sub = r.get_subcommand_result()
     assert_true(
         sub.get_flag("verbose"), msg="child result should have verbose=True"
@@ -145,7 +145,7 @@ fn test_persistent_flag_after_subcommand_bubbles_to_root() raises:
     search.add_argument(Argument("pattern", help="").positional().required())
     app.add_subcommand(search^)
 
-    var r = app.parse_args(["app", "search", "--verbose", "pattern"])
+    var r = app.parse_arguments(["app", "search", "--verbose", "pattern"])
     assert_true(
         r.get_flag("verbose"),
         msg="root result should have verbose=True via bubble-up",
@@ -168,7 +168,7 @@ fn test_persistent_short_flag_after_subcommand() raises:
     search.add_argument(Argument("pattern", help="").positional().required())
     app.add_subcommand(search^)
 
-    var r = app.parse_args(["app", "search", "-v", "pattern"])
+    var r = app.parse_arguments(["app", "search", "-v", "pattern"])
     assert_true(
         r.get_flag("verbose"), msg="root verbose via short form should be True"
     )
@@ -193,7 +193,9 @@ fn test_persistent_value_option_after_subcommand() raises:
     search.add_argument(Argument("pattern", help="").positional().required())
     app.add_subcommand(search^)
 
-    var r = app.parse_args(["app", "search", "--output", "json", "pattern"])
+    var r = app.parse_arguments(
+        ["app", "search", "--output", "json", "pattern"]
+    )
     assert_equal(r.get_string("output"), "json")
     assert_equal(r.get_subcommand_result().get_string("output"), "json")
     print("  ✓ test_persistent_value_option_after_subcommand")
@@ -214,7 +216,7 @@ fn test_persistent_flag_absent_defaults_false_in_both() raises:
     search.add_argument(Argument("pattern", help="").positional().required())
     app.add_subcommand(search^)
 
-    var r = app.parse_args(["app", "search", "pattern"])
+    var r = app.parse_arguments(["app", "search", "pattern"])
     assert_false(
         r.get_flag("verbose"), msg="root verbose should default to False"
     )
@@ -241,7 +243,7 @@ fn test_non_persistent_root_flag_not_injected_into_child() raises:
 
     var raised = False
     try:
-        _ = app.parse_args(["app", "search", "--root-only", "pattern"])
+        _ = app.parse_arguments(["app", "search", "--root-only", "pattern"])
     except:
         raised = True
     assert_true(

--- a/tests/test_subcommands.mojo
+++ b/tests/test_subcommands.mojo
@@ -1150,6 +1150,162 @@ fn test_non_positional_args_unaffected_by_guard() raises:
     print("  ✓ test_non_positional_args_unaffected_by_guard")
 
 
+# ── Step 5: Subcommand aliases ───────────────────────────────────────────────
+
+
+fn test_command_aliases_empty_by_default() raises:
+    """Tests that a fresh Command has no aliases registered."""
+    var sub = Command("clone", "Clone a repo")
+    assert_equal(len(sub._aliases), 0)
+    print("  ✓ test_command_aliases_empty_by_default")
+
+
+fn test_command_aliases_builder() raises:
+    """Tests that command_aliases() stores the provided names."""
+    var sub = Command("clone", "Clone a repo")
+    var names: List[String] = ["cl", "cln"]
+    sub.command_aliases(names^)
+    assert_equal(len(sub._aliases), 2)
+    assert_equal(sub._aliases[0], "cl")
+    assert_equal(sub._aliases[1], "cln")
+    print("  ✓ test_command_aliases_builder")
+
+
+fn test_alias_dispatch_basic() raises:
+    """Tests that typing an alias dispatches to the correct subcommand."""
+    var app = Command("app", "My app")
+    var clone = Command("clone", "Clone a repo")
+    clone.add_argument(
+        Argument("url", help="Repository URL").positional().required()
+    )
+    var aliases: List[String] = ["cl"]
+    clone.command_aliases(aliases^)
+    app.add_subcommand(clone^)
+
+    var args: List[String] = ["app", "cl", "https://example.com/repo.git"]
+    var result = app.parse_args(args)
+    assert_equal(result.subcommand, "clone")
+    var sub_result = result.get_subcommand_result()
+    assert_equal(sub_result.positionals[0], "https://example.com/repo.git")
+    print("  ✓ test_alias_dispatch_basic")
+
+
+fn test_alias_stores_canonical_name() raises:
+    """Tests that result.subcommand holds the canonical name, not the alias."""
+    var app = Command("app", "My app")
+    var commit = Command("commit", "Record changes")
+    var aliases: List[String] = ["ci", "cm"]
+    commit.command_aliases(aliases^)
+    app.add_subcommand(commit^)
+
+    # Use second alias.
+    var args: List[String] = ["app", "cm"]
+    var result = app.parse_args(args)
+    assert_equal(result.subcommand, "commit")
+    print("  ✓ test_alias_stores_canonical_name")
+
+
+fn test_alias_dispatch_with_child_flags() raises:
+    """Tests that child flags parse correctly when dispatched via alias."""
+    var app = Command("app", "My app")
+    var commit = Command("commit", "Record changes")
+    commit.add_argument(
+        Argument("message", help="Message").short("m").long("message")
+    )
+    commit.add_argument(Argument("amend", help="Amend").long("amend").flag())
+    var aliases: List[String] = ["ci"]
+    commit.command_aliases(aliases^)
+    app.add_subcommand(commit^)
+
+    var args: List[String] = ["app", "ci", "-m", "fix bug", "--amend"]
+    var result = app.parse_args(args)
+    assert_equal(result.subcommand, "commit")
+    var sub = result.get_subcommand_result()
+    assert_equal(sub.get_string("message"), "fix bug")
+    assert_true(sub.get_flag("amend"))
+    print("  ✓ test_alias_dispatch_with_child_flags")
+
+
+fn test_alias_primary_name_still_works() raises:
+    """Tests that the primary name still dispatches correctly alongside aliases.
+    """
+    var app = Command("app", "My app")
+    var clone = Command("clone", "Clone a repo")
+    var aliases: List[String] = ["cl"]
+    clone.command_aliases(aliases^)
+    app.add_subcommand(clone^)
+
+    var args: List[String] = ["app", "clone"]
+    var result = app.parse_args(args)
+    assert_equal(result.subcommand, "clone")
+    print("  ✓ test_alias_primary_name_still_works")
+
+
+fn test_alias_find_subcommand() raises:
+    """Tests that _find_subcommand() returns the correct index for aliases."""
+    var app = Command("app", "My app")
+    var search = Command("search", "Search")
+    var aliases: List[String] = ["s", "find"]
+    search.command_aliases(aliases^)
+    app.add_subcommand(search^)
+
+    var idx_name = app._find_subcommand("search")
+    var idx_alias1 = app._find_subcommand("s")
+    var idx_alias2 = app._find_subcommand("find")
+    var idx_none = app._find_subcommand("notexist")
+
+    assert_true(idx_name >= 0)
+    assert_equal(idx_name, idx_alias1)
+    assert_equal(idx_name, idx_alias2)
+    assert_equal(idx_none, -1)
+    print("  ✓ test_alias_find_subcommand")
+
+
+fn test_alias_copy_init() raises:
+    """Tests that aliases survive Command copy."""
+    var sub = Command("clone", "Clone")
+    var aliases: List[String] = ["cl"]
+    sub.command_aliases(aliases^)
+    var sub2 = sub.copy()
+    assert_equal(len(sub2._aliases), 1)
+    assert_equal(sub2._aliases[0], "cl")
+    print("  ✓ test_alias_copy_init")
+
+
+fn test_alias_multiple_subcommands() raises:
+    """Tests aliases with multiple subcommands don't interfere."""
+    var app = Command("app", "My app")
+    var clone = Command("clone", "Clone")
+    var clone_aliases: List[String] = ["cl"]
+    clone.command_aliases(clone_aliases^)
+    app.add_subcommand(clone^)
+
+    var commit = Command("commit", "Commit")
+    var commit_aliases: List[String] = ["ci"]
+    commit.command_aliases(commit_aliases^)
+    app.add_subcommand(commit^)
+
+    # Dispatch via clone alias.
+    var args1: List[String] = ["app", "cl"]
+    var r1 = app.parse_args(args1)
+    assert_equal(r1.subcommand, "clone")
+
+    # Dispatch via commit alias.
+    var args2: List[String] = ["app", "ci"]
+    var r2 = app.parse_args(args2)
+    assert_equal(r2.subcommand, "commit")
+
+    # Primary names still work.
+    var args3: List[String] = ["app", "clone"]
+    var r3 = app.parse_args(args3)
+    assert_equal(r3.subcommand, "clone")
+
+    var args4: List[String] = ["app", "commit"]
+    var r4 = app.parse_args(args4)
+    assert_equal(r4.subcommand, "commit")
+    print("  ✓ test_alias_multiple_subcommands")
+
+
 # ── main ─────────────────────────────────────────────────────────────────────
 
 

--- a/tests/test_subcommands.mojo
+++ b/tests/test_subcommands.mojo
@@ -1,8 +1,8 @@
 """Tests for argmojo subcommand support.
 
 Step 0: Validates that the _apply_defaults() and _validate() extraction
-from parse_args() preserves all existing behavior. These tests exercise
-the defaults and validation paths directly through parse_args(), ensuring
+from parse_arguments() preserves all existing behavior. These tests exercise
+the defaults and validation paths directly through parse_arguments(), ensuring
 no regression from the refactor.
 
 Step 1: Validates the data model & API surface for subcommand support:
@@ -10,10 +10,10 @@ Step 1: Validates the data model & API surface for subcommand support:
   - ParseResult.subcommand field (String, defaults to "")
   - ParseResult.has_subcommand_result() / get_subcommand_result()
   - ParseResult.__copyinit__ preserves subcommand data
-  - parse_args() unchanged when no subcommands are registered
+  - parse_arguments() unchanged when no subcommands are registered
 
 Step 2: Validates parse-time subcommand routing:
-  - Basic dispatch: subcommand token → child parse_args()
+  - Basic dispatch: subcommand token → child parse_arguments()
   - Root flags before subcommand parsed by root
   - Child flags/positionals parsed by child
   - ``--`` stops dispatch; subsequent tokens are root positionals
@@ -49,7 +49,7 @@ fn test_defaults_named_arg() raises:
     )
 
     var args: List[String] = ["test"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("format"), "json")
     print("  ✓ test_defaults_named_arg")
 
@@ -66,7 +66,7 @@ fn test_defaults_positional_arg() raises:
     )
 
     var args: List[String] = ["test", "hello"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("pattern"), "hello")
     assert_equal(result.get_string("path"), ".")
     print("  ✓ test_defaults_positional_arg")
@@ -80,7 +80,7 @@ fn test_defaults_not_applied_when_provided() raises:
     )
 
     var args: List[String] = ["test", "--format", "csv"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("format"), "csv")
     print("  ✓ test_defaults_not_applied_when_provided")
 
@@ -97,7 +97,7 @@ fn test_defaults_multiple_positional() raises:
 
     # Provide only the first positional.
     var args: List[String] = ["test", "input.txt"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("src"), "input.txt")
     assert_equal(result.get_string("dst"), "b.txt")
     print("  ✓ test_defaults_multiple_positional")
@@ -116,7 +116,7 @@ fn test_validate_required_missing() raises:
     var args: List[String] = ["test"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)
@@ -137,7 +137,7 @@ fn test_validate_required_provided() raises:
     )
 
     var args: List[String] = ["test", "--output", "out.txt"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("output"), "out.txt")
     print("  ✓ test_validate_required_provided")
 
@@ -153,7 +153,7 @@ fn test_validate_too_many_positionals() raises:
     var args: List[String] = ["test", "alice", "bob"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)
@@ -179,7 +179,7 @@ fn test_validate_exclusive_conflict() raises:
     var args: List[String] = ["test", "--json", "--yaml"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         assert_true(
@@ -199,7 +199,7 @@ fn test_validate_exclusive_ok() raises:
     command.mutually_exclusive(group^)
 
     var args: List[String] = ["test", "--json"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_true(result.get_flag("json"))
     print("  ✓ test_validate_exclusive_ok")
 
@@ -218,7 +218,7 @@ fn test_validate_together_partial() raises:
     var args: List[String] = ["test", "--user", "alice"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         assert_true(
@@ -244,7 +244,7 @@ fn test_validate_one_required_none() raises:
     var args: List[String] = ["test"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         assert_true(
@@ -268,7 +268,7 @@ fn test_validate_conditional_triggered() raises:
     var args: List[String] = ["test", "--save"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         assert_true(
@@ -287,7 +287,7 @@ fn test_validate_conditional_satisfied() raises:
     command.required_if("output", "save")
 
     var args: List[String] = ["test", "--save", "--output", "out.txt"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_true(result.get_flag("save"))
     assert_equal(result.get_string("output"), "out.txt")
     print("  ✓ test_validate_conditional_satisfied")
@@ -306,7 +306,7 @@ fn test_validate_range_out_of_bounds() raises:
     var args: List[String] = ["test", "--port", "200"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         assert_true(
@@ -325,7 +325,7 @@ fn test_validate_range_in_bounds() raises:
     )
 
     var args: List[String] = ["test", "--port", "50"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("port"), "50")
     print("  ✓ test_validate_range_in_bounds")
 
@@ -348,7 +348,7 @@ fn test_defaults_then_validation_combined() raises:
 
     # Providing neither — no error (required-together only fires if some present).
     var args1: List[String] = ["test"]
-    var result = command.parse_args(args1)
+    var result = command.parse_arguments(args1)
     assert_false(result.has("user"))
     assert_false(result.has("pass"))
     print("  ✓ test_defaults_then_validation_combined")
@@ -363,7 +363,7 @@ fn test_full_parse_with_defaults_and_range() raises:
 
     # Not providing --port should use default "50" which is in range.
     var args: List[String] = ["test"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_equal(result.get_string("port"), "50")
     print("  ✓ test_full_parse_with_defaults_and_range")
 
@@ -543,14 +543,14 @@ fn test_parseresult_copy_preserves_subcommand() raises:
 
 
 fn test_parse_without_subcommands_unaffected() raises:
-    """Tests that parse_args() results are unchanged when no subcommands exist.
+    """Tests that parse_arguments() results are unchanged when no subcommands exist.
     """
     var command = Command("app", "My app")
     command.add_argument(
         Argument("verbose", help="Verbose").long("verbose").short("v").flag()
     )
     var args: List[String] = ["app", "--verbose"]
-    var result = command.parse_args(args)
+    var result = command.parse_arguments(args)
     assert_true(result.get_flag("verbose"))
     assert_equal(result.subcommand, "")
     assert_false(result.has_subcommand_result())
@@ -570,7 +570,7 @@ fn test_dispatch_basic() raises:
     app.add_subcommand(search^)
 
     var args: List[String] = ["app", "search", "hello"]
-    var result = app.parse_args(args)
+    var result = app.parse_arguments(args)
     assert_equal(result.subcommand, "search")
     assert_true(result.has_subcommand_result())
     var sub = result.get_subcommand_result()
@@ -591,7 +591,7 @@ fn test_dispatch_root_flag_before_subcommand() raises:
     app.add_subcommand(search^)
 
     var args: List[String] = ["app", "--verbose", "search", "hello"]
-    var result = app.parse_args(args)
+    var result = app.parse_arguments(args)
     assert_true(result.get_flag("verbose"))
     assert_equal(result.subcommand, "search")
     var sub = result.get_subcommand_result()
@@ -612,7 +612,7 @@ fn test_dispatch_root_short_flag_before_subcommand() raises:
     app.add_subcommand(search^)
 
     var args: List[String] = ["app", "-v", "search", "hello"]
-    var result = app.parse_args(args)
+    var result = app.parse_arguments(args)
     assert_true(result.get_flag("verbose"))
     assert_equal(result.subcommand, "search")
     var sub = result.get_subcommand_result()
@@ -633,7 +633,7 @@ fn test_dispatch_child_flag() raises:
     app.add_subcommand(search^)
 
     var args: List[String] = ["app", "search", "--max-depth", "3", "hello"]
-    var result = app.parse_args(args)
+    var result = app.parse_arguments(args)
     assert_equal(result.subcommand, "search")
     var sub = result.get_subcommand_result()
     assert_equal(sub.get_string("max-depth"), "3")
@@ -654,7 +654,7 @@ fn test_dispatch_child_flag_short() raises:
     app.add_subcommand(search^)
 
     var args: List[String] = ["app", "search", "-d", "5", "hello"]
-    var result = app.parse_args(args)
+    var result = app.parse_arguments(args)
     assert_equal(result.subcommand, "search")
     var sub = result.get_subcommand_result()
     assert_equal(sub.get_string("max-depth"), "5")
@@ -673,7 +673,7 @@ fn test_dispatch_double_dash_stops_dispatch() raises:
     app.add_argument(Argument("arg1", help="First arg").positional())
 
     var args: List[String] = ["app", "--", "search"]
-    var result = app.parse_args(args)
+    var result = app.parse_arguments(args)
     assert_equal(result.subcommand, "")
     assert_false(result.has_subcommand_result())
     assert_equal(result.get_string("arg1"), "search")
@@ -690,7 +690,7 @@ fn test_dispatch_unknown_token_is_positional() raises:
     app.add_argument(Argument("name", help="Name").positional())
 
     var args: List[String] = ["app", "hello"]
-    var result = app.parse_args(args)
+    var result = app.parse_arguments(args)
     assert_equal(result.subcommand, "")
     assert_equal(result.get_string("name"), "hello")
     print("  ✓ test_dispatch_unknown_token_is_positional")
@@ -709,7 +709,7 @@ fn test_dispatch_two_subcommands_route_first() raises:
     app.add_subcommand(init^)
 
     var args: List[String] = ["app", "search", "foo"]
-    var result = app.parse_args(args)
+    var result = app.parse_arguments(args)
     assert_equal(result.subcommand, "search")
     assert_equal(result.get_subcommand_result().get_string("pattern"), "foo")
     print("  ✓ test_dispatch_two_subcommands_route_first")
@@ -728,7 +728,7 @@ fn test_dispatch_two_subcommands_route_second() raises:
     app.add_subcommand(init^)
 
     var args: List[String] = ["app", "init", "myproject"]
-    var result = app.parse_args(args)
+    var result = app.parse_arguments(args)
     assert_equal(result.subcommand, "init")
     assert_equal(result.get_subcommand_result().get_string("name"), "myproject")
     print("  ✓ test_dispatch_two_subcommands_route_second")
@@ -746,7 +746,7 @@ fn test_dispatch_child_validation_error() raises:
     var args: List[String] = ["app", "search"]
     var caught = False
     try:
-        _ = app.parse_args(args)
+        _ = app.parse_arguments(args)
     except e:
         caught = True
         assert_true(
@@ -772,7 +772,7 @@ fn test_dispatch_child_default_value() raises:
     app.add_subcommand(search^)
 
     var args: List[String] = ["app", "search", "hello"]
-    var result = app.parse_args(args)
+    var result = app.parse_arguments(args)
     var sub = result.get_subcommand_result()
     assert_equal(sub.get_string("pattern"), "hello")
     assert_equal(sub.get_string("path"), ".")
@@ -788,7 +788,7 @@ fn test_dispatch_no_subcommand_when_none_match() raises:
     app.add_argument(Argument("file", help="File").positional())
 
     var args: List[String] = ["app", "myfile.txt"]
-    var result = app.parse_args(args)
+    var result = app.parse_arguments(args)
     assert_equal(result.subcommand, "")
     assert_false(result.has_subcommand_result())
     print("  ✓ test_dispatch_no_subcommand_when_none_match")
@@ -809,7 +809,7 @@ fn test_dispatch_root_still_validates_own_required() raises:
     var args: List[String] = ["app", "search", "hello"]
     var caught = False
     try:
-        _ = app.parse_args(args)
+        _ = app.parse_arguments(args)
     except e:
         caught = True
         assert_true("Required argument" in String(e))
@@ -830,7 +830,7 @@ fn test_dispatch_child_receives_no_root_tokens() raises:
     app.add_subcommand(sub^)
 
     var args: List[String] = ["app", "--verbose", "run", "main.mojo"]
-    var result = app.parse_args(args)
+    var result = app.parse_arguments(args)
     assert_true(result.get_flag("verbose"))
     assert_equal(result.subcommand, "run")
     var child = result.get_subcommand_result()
@@ -938,7 +938,7 @@ fn test_dispatch_unaffected_by_help_sub() raises:
     app.add_subcommand(search^)
 
     var args: List[String] = ["app", "search", "TODO"]
-    var result = app.parse_args(args)
+    var result = app.parse_arguments(args)
     assert_equal(result.subcommand, "search")
     var child = result.get_subcommand_result()
     assert_equal(child.get_string("pattern"), "TODO")
@@ -956,7 +956,7 @@ fn test_help_sub_disabled_unknown_word_becomes_positional() raises:
 
     # "help" should be treated as a root positional, not dispatch.
     var args: List[String] = ["app", "help"]
-    var result = app.parse_args(args)
+    var result = app.parse_arguments(args)
     assert_equal(result.subcommand, "")
     assert_equal(result.positionals[0], "help")
     print("  ✓ test_help_sub_disabled_unknown_word_becomes_positional")
@@ -975,7 +975,7 @@ fn test_unknown_subcommand_error_no_positionals() raises:
     var args: List[String] = ["app", "foo"]
     var caught = False
     try:
-        _ = app.parse_args(args)
+        _ = app.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)
@@ -1000,7 +1000,7 @@ fn test_unknown_token_becomes_positional_when_positionals_defined() raises:
 
     # "foo" doesn't match any subcommand but root has positional args → positional.
     var args: List[String] = ["app", "foo"]
-    var result = app.parse_args(args)
+    var result = app.parse_arguments(args)
     assert_equal(result.subcommand, "")
     assert_equal(result.positionals[0], "foo")
     print("  ✓ test_unknown_token_becomes_positional_when_positionals_defined")
@@ -1019,7 +1019,7 @@ fn test_child_error_includes_command_path() raises:
     var args: List[String] = ["app", "search"]
     var caught = False
     try:
-        _ = app.parse_args(args)
+        _ = app.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)
@@ -1041,7 +1041,7 @@ fn test_unknown_subcommand_error_excludes_help_sub() raises:
     var args: List[String] = ["app", "foo"]
     var caught = False
     try:
-        _ = app.parse_args(args)
+        _ = app.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)
@@ -1132,7 +1132,7 @@ fn test_allow_positional_with_subcommands_opt_in() raises:
 
     # Verify parsing works: unknown token → positional.
     var args: List[String] = ["app", "hello"]
-    var result = app2.parse_args(args)
+    var result = app2.parse_arguments(args)
     assert_equal(result.subcommand, "")
     assert_equal(result.positionals[0], "hello")
     print("  ✓ test_allow_positional_with_subcommands_opt_in")
@@ -1183,7 +1183,7 @@ fn test_alias_dispatch_basic() raises:
     app.add_subcommand(clone^)
 
     var args: List[String] = ["app", "cl", "https://example.com/repo.git"]
-    var result = app.parse_args(args)
+    var result = app.parse_arguments(args)
     assert_equal(result.subcommand, "clone")
     var sub_result = result.get_subcommand_result()
     assert_equal(sub_result.positionals[0], "https://example.com/repo.git")
@@ -1200,7 +1200,7 @@ fn test_alias_stores_canonical_name() raises:
 
     # Use second alias.
     var args: List[String] = ["app", "cm"]
-    var result = app.parse_args(args)
+    var result = app.parse_arguments(args)
     assert_equal(result.subcommand, "commit")
     print("  ✓ test_alias_stores_canonical_name")
 
@@ -1218,7 +1218,7 @@ fn test_alias_dispatch_with_child_flags() raises:
     app.add_subcommand(commit^)
 
     var args: List[String] = ["app", "ci", "-m", "fix bug", "--amend"]
-    var result = app.parse_args(args)
+    var result = app.parse_arguments(args)
     assert_equal(result.subcommand, "commit")
     var sub = result.get_subcommand_result()
     assert_equal(sub.get_string("message"), "fix bug")
@@ -1236,7 +1236,7 @@ fn test_alias_primary_name_still_works() raises:
     app.add_subcommand(clone^)
 
     var args: List[String] = ["app", "clone"]
-    var result = app.parse_args(args)
+    var result = app.parse_arguments(args)
     assert_equal(result.subcommand, "clone")
     print("  ✓ test_alias_primary_name_still_works")
 
@@ -1287,21 +1287,21 @@ fn test_alias_multiple_subcommands() raises:
 
     # Dispatch via clone alias.
     var args1: List[String] = ["app", "cl"]
-    var r1 = app.parse_args(args1)
+    var r1 = app.parse_arguments(args1)
     assert_equal(r1.subcommand, "clone")
 
     # Dispatch via commit alias.
     var args2: List[String] = ["app", "ci"]
-    var r2 = app.parse_args(args2)
+    var r2 = app.parse_arguments(args2)
     assert_equal(r2.subcommand, "commit")
 
     # Primary names still work.
     var args3: List[String] = ["app", "clone"]
-    var r3 = app.parse_args(args3)
+    var r3 = app.parse_arguments(args3)
     assert_equal(r3.subcommand, "clone")
 
     var args4: List[String] = ["app", "commit"]
-    var r4 = app.parse_args(args4)
+    var r4 = app.parse_arguments(args4)
     assert_equal(r4.subcommand, "commit")
     print("  ✓ test_alias_multiple_subcommands")
 

--- a/tests/test_subcommands.mojo
+++ b/tests/test_subcommands.mojo
@@ -1156,7 +1156,7 @@ fn test_non_positional_args_unaffected_by_guard() raises:
 fn test_command_aliases_empty_by_default() raises:
     """Tests that a fresh Command has no aliases registered."""
     var sub = Command("clone", "Clone a repo")
-    assert_equal(len(sub._aliases), 0)
+    assert_equal(len(sub._command_aliases), 0)
     print("  ✓ test_command_aliases_empty_by_default")
 
 
@@ -1165,9 +1165,9 @@ fn test_command_aliases_builder() raises:
     var sub = Command("clone", "Clone a repo")
     var names: List[String] = ["cl", "cln"]
     sub.command_aliases(names^)
-    assert_equal(len(sub._aliases), 2)
-    assert_equal(sub._aliases[0], "cl")
-    assert_equal(sub._aliases[1], "cln")
+    assert_equal(len(sub._command_aliases), 2)
+    assert_equal(sub._command_aliases[0], "cl")
+    assert_equal(sub._command_aliases[1], "cln")
     print("  ✓ test_command_aliases_builder")
 
 
@@ -1267,8 +1267,8 @@ fn test_alias_copy_init() raises:
     var aliases: List[String] = ["cl"]
     sub.command_aliases(aliases^)
     var sub2 = sub.copy()
-    assert_equal(len(sub2._aliases), 1)
-    assert_equal(sub2._aliases[0], "cl")
+    assert_equal(len(sub2._command_aliases), 1)
+    assert_equal(sub2._command_aliases[0], "cl")
     print("  ✓ test_alias_copy_init")
 
 

--- a/tests/test_typo_suggestions.mojo
+++ b/tests/test_typo_suggestions.mojo
@@ -23,7 +23,7 @@ fn test_typo_long_option_suggests() raises:
     var args2: List[String] = ["test", "--vrebose"]
     var caught = False
     try:
-        _ = command.parse_args(args2)
+        _ = command.parse_arguments(args2)
     except e:
         caught = True
         var msg = String(e)
@@ -49,7 +49,7 @@ fn test_typo_long_option_no_suggestion() raises:
     var args: List[String] = ["test", "--zzzzzzz"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)
@@ -71,7 +71,7 @@ fn test_typo_long_option_single_char_diff() raises:
     var args: List[String] = ["test", "--outptu", "file.txt"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)
@@ -101,7 +101,7 @@ fn test_typo_subcommand_suggests() raises:
     var args: List[String] = ["app", "serach"]
     var caught = False
     try:
-        _ = root.parse_args(args)
+        _ = root.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)
@@ -127,7 +127,7 @@ fn test_typo_subcommand_no_suggestion() raises:
     var args: List[String] = ["app", "xxxxxxx"]
     var caught = False
     try:
-        _ = root.parse_args(args)
+        _ = root.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)
@@ -156,7 +156,7 @@ fn test_typo_alias_suggests() raises:
     var args: List[String] = ["test", "--colro"]
     var caught = False
     try:
-        _ = command.parse_args(args)
+        _ = command.parse_arguments(args)
     except e:
         caught = True
         var msg = String(e)

--- a/tests/test_typo_suggestions.mojo
+++ b/tests/test_typo_suggestions.mojo
@@ -168,5 +168,33 @@ fn test_typo_alias_suggests() raises:
     print("  ✓ test_typo_alias_suggests")
 
 
+fn test_typo_subcommand_alias_suggests() raises:
+    """Tests that a typo near a subcommand alias triggers a suggestion."""
+    var root = Command("app", "Test app")
+    var clone = Command("clone", "Clone a repo")
+    var aliases: List[String] = ["cl"]
+    clone.command_aliases(aliases^)
+    root.add_subcommand(clone^)
+
+    # "clon" is close to both "clone" and "cl"
+    var args: List[String] = ["app", "clon"]
+    var caught = False
+    try:
+        _ = root.parse_arguments(args)
+    except e:
+        caught = True
+        var msg = String(e)
+        assert_true(
+            "Did you mean" in msg,
+            msg="Error should suggest a correction for 'clon'",
+        )
+        assert_true(
+            "clone" in msg,
+            msg="Error should suggest 'clone' for 'clon'",
+        )
+    assert_true(caught, msg="Should have raised error for 'clon'")
+    print("  ✓ test_typo_subcommand_alias_suggests")
+
+
 fn main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
This PR implements command aliases for the ArgMojo CLI argument parsing library. It also renames several API methods for consistency (`parse_args()` → `parse_arguments()`, `help_on_no_args()` → `help_on_no_arguments()`, `.nargs()` → `.number_of_values()`, `nargs_count` field → `num_values`).