### PR TITLE
[core] Add range clamping + conduct ceiling and clamping at validation phase + warning message

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 A command-line argument parser library for [Mojo](https://www.modular.com/mojo), inspired by Python's `argparse`, Rust's `clap`, Go's `cobra`, and other popular libraries.
 
+<!-- 
 > **A**rguments **R**esolved and **G**rouped into **M**eaningful **O**ptions and **J**oined **O**bjects
+ -->
 
 [![Version](https://img.shields.io/github/v/tag/forfudan/argmojo?label=version&color=blue)](https://github.com/forfudan/argmojo/releases)
 [![Mojo](https://img.shields.io/badge/mojo-0.26.1-orange)](https://docs.modular.com/mojo/manual/)

--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -26,66 +26,66 @@ This section summarises the key design patterns and features from well-known arg
 
 These features appear across multiple libraries and depend only on string operations and basic data structures.
 
-| Feature                            | argparse | Click | cobra | clap | Other                  | Planned phase |
-| ---------------------------------- | -------- | ----- | ----- | ---- | ---------------------- | ------------- |
-| Long/short options with values     | ✓        | ✓     | ✓     | ✓    |                        | **Done**      |
-| Positional arguments               | ✓        | ✓     | ✓     | ✓    |                        | **Done**      |
-| Boolean flags                      | ✓        | ✓     | ✓     | ✓    |                        | **Done**      |
-| Default values                     | ✓        | ✓     | ✓     | ✓    |                        | **Done**      |
-| Required argument validation       | ✓        | ✓     | ✓     | ✓    |                        | **Done**      |
-| `--` stop marker                   | ✓        | ✓     | ✓     | ✓    |                        | **Done**      |
-| Auto `--help` / `-h` / `-?`        | ✓        | ✓     | ✓     | ✓    |                        | **Done**      |
-| Auto `--version` / `-V`            | ✓        | ✓     | ✓     | ✓    |                        | **Done**      |
-| Short flag merging (`-abc`)        | ✓        | —     | ✓     | ✓    |                        | **Done**      |
-| Metavar (display name for value)   | ✓        | —     | —     | ✓    |                        | **Done**      |
-| Positional arg count validation    | —        | —     | ✓     | ✓    |                        | **Done**      |
-| Choices / enum validation          | ✓        | ✓     | —     | ✓    |                        | **Done**      |
-| Mutually exclusive flags           | ✓        | —     | ✓     | ✓    |                        | **Done**      |
-| Flags required together            | —        | —     | ✓     | —    |                        | **Done**      |
-| `--no-X` negation flags            | ✓ (3.9)  | —     | —     | ✓    |                        | **Done**      |
-| Long option prefix matching        | ✓        | —     | —     | —    |                        | **Done**      |
-| Append / collect action            | ✓        | ✓     | ✓     | ✓    |                        | **Done**      |
-| One-required group                 | —        | —     | ✓     | ✓    |                        | **Done**      |
-| Value delimiter (`--tag a,b,c`)    | —        | —     | ✓     | ✓    |                        | **Done**      |
-| Colored help (customisable)        | —        | ✓     | —     | ✓    | pixi                   | **Done**      |
-| Colored warning and error messages | -        | ✓     | -     | ✓    |                        | **Done**      |
-| nargs (multi-value per option)     | ✓        | ✓     | —     | ✓    |                        | **Done**      |
-| Conditional requirement            | —        | —     | ✓     | ✓    |                        | **Done**      |
-| Numeric range validation           | —        | —     | —     | —    |                        | **Done**      |
-| Key-value map (`-Dkey=val`)        | —        | —     | —     | —    | Java `-D`, Docker `-e` | **Done**      |
-| Aliases for long names             | —        | —     | ✓     | ✓    |                        | **Done**      |
-| Deprecated arguments               | ✓ (3.13) | —     | ✓     | —    |                        | **Done**      |
-| Negative number passthrough        | ✓        | —     | —     | ✓    | Essential for `decimo` | **Done**      |
-| Subcommands                        | ✓        | ✓     | ✓     | ✓    |                        | **Done**      |
-| Auto-added `help` subcommand       | —        | —     | ✓     | ✓    | git, cargo, kubectl    | **Done**      |
-| Persistent (global) flags          | —        | —     | ✓     | ✓    | git `--no-pager` etc.  | **Done**      |
-| Suggest on typo (Levenshtein)      | ✓ (3.14) | —     | ✓     | ✓    |                        | **Done**      |
-| Subcommand aliases                 | —        | —     | ✓     | ✓    | cobra, clap            | **Done**      |
-| Count with ceiling                 | -        | —     | —     | -    |                        | **Done**      |
-| Cap and floor (clamp) for ranges   | -        | —     | —     | —    |                        | Phase 5       |
-| Hidden subcommands                 | —        | —     | ✓     | ✓    |                        | Phase 5       |
-| `NO_COLOR` env variable            | —        | —     | —     | —    | I need it personally   | Phase 5       |
-| Response file (`@args.txt`)        | ✓        | —     | —     | —    | javac, MSBuild         | Phase 5       |
-| Argument parents (shared args)     | ✓        | —     | —     | —    |                        | Phase 5       |
-| Interactive prompting              | —        | ✓     | —     | —    |                        | Phase 5       |
-| Password / masked input            | —        | ✓     | —     | —    |                        | Phase 5       |
-| Confirmation (`--yes` / `-y`)      | —        | ✓     | —     | —    |                        | Phase 5       |
-| Pre/Post run hooks                 | —        | —     | ✓     | —    |                        | Phase 5       |
-| REMAINDER nargs                    | ✓        | —     | —     | —    |                        | Phase 5       |
-| Partial parsing (known args)       | ✓        | —     | —     | ✓    |                        | Phase 5       |
-| Require equals syntax              | —        | —     | —     | ✓    |                        | Phase 5       |
-| Default-if-present (const)         | ✓        | —     | —     | ✓    |                        | Phase 5       |
-| Mutual implication (`implies`)     | —        | —     | —     | —    | ArgMojo unique feature | Phase 5       |
-| Stdin value (`-` convention)       | —        | —     | ✓     | —    | Unix convention        | Phase 5       |
-| Shell completion script generation | —        | ✓     | ✓     | ✓    | bash / zsh / fish      | Phase 5       |
-| CJK-aware help formatting          | —        | —     | —     | —    | I need it personally   | Phase 6       |
-| CJK full-to-half-width correction  | —        | —     | —     | —    | I need it personally   | Phase 6       |
-| CJK punctuation detection          | —        | —     | —     | —    | I need it personally   | Phase 6       |
-| Typed retrieval (`get_int()` etc.) | ✓        | ✓     | ✓     | ✓    |                        | **Done**      |
-| `Parseable` trait for type params  | —        | —     | —     | ✓    |                        | Phase 7       |
-| Derive / struct-based schema       | —        | —     | —     | ✓    | Requires Mojo macros   | Phase unknown |
-| Enum → type mapping (real enums)   | —        | —     | —     | ✓    | Requires reflection    | Phase unknown |
-| Subcommand variant dispatch        | —        | —     | —     | ✓    | Requires sum types     | Phase unknown |
+| Feature                            | argparse | Click | cobra | clap | Other                        | Planned phase |
+| ---------------------------------- | -------- | ----- | ----- | ---- | ---------------------------- | ------------- |
+| Long/short options with values     | ✓        | ✓     | ✓     | ✓    |                              | **Done**      |
+| Positional arguments               | ✓        | ✓     | ✓     | ✓    |                              | **Done**      |
+| Boolean flags                      | ✓        | ✓     | ✓     | ✓    |                              | **Done**      |
+| Default values                     | ✓        | ✓     | ✓     | ✓    |                              | **Done**      |
+| Required argument validation       | ✓        | ✓     | ✓     | ✓    |                              | **Done**      |
+| `--` stop marker                   | ✓        | ✓     | ✓     | ✓    |                              | **Done**      |
+| Auto `--help` / `-h` / `-?`        | ✓        | ✓     | ✓     | ✓    |                              | **Done**      |
+| Auto `--version` / `-V`            | ✓        | ✓     | ✓     | ✓    |                              | **Done**      |
+| Short flag merging (`-abc`)        | ✓        | —     | ✓     | ✓    |                              | **Done**      |
+| Metavar (display name for value)   | ✓        | —     | —     | ✓    |                              | **Done**      |
+| Positional arg count validation    | —        | —     | ✓     | ✓    |                              | **Done**      |
+| Choices / enum validation          | ✓        | ✓     | —     | ✓    |                              | **Done**      |
+| Mutually exclusive flags           | ✓        | —     | ✓     | ✓    |                              | **Done**      |
+| Flags required together            | —        | —     | ✓     | —    |                              | **Done**      |
+| `--no-X` negation flags            | ✓ (3.9)  | —     | —     | ✓    |                              | **Done**      |
+| Long option prefix matching        | ✓        | —     | —     | —    |                              | **Done**      |
+| Append / collect action            | ✓        | ✓     | ✓     | ✓    |                              | **Done**      |
+| One-required group                 | —        | —     | ✓     | ✓    |                              | **Done**      |
+| Value delimiter (`--tag a,b,c`)    | —        | —     | ✓     | ✓    |                              | **Done**      |
+| Colored help (customisable)        | —        | ✓     | —     | ✓    | pixi                         | **Done**      |
+| Colored warning and error messages | -        | ✓     | -     | ✓    |                              | **Done**      |
+| nargs (multi-value per option)     | ✓        | ✓     | —     | ✓    |                              | **Done**      |
+| Conditional requirement            | —        | —     | ✓     | ✓    |                              | **Done**      |
+| Numeric range validation           | —        | —     | —     | —    |                              | **Done**      |
+| Key-value map (`-Dkey=val`)        | —        | —     | —     | —    | Java `-D`, Docker `-e`       | **Done**      |
+| Aliases for long names             | —        | —     | ✓     | ✓    |                              | **Done**      |
+| Deprecated arguments               | ✓ (3.13) | —     | ✓     | —    |                              | **Done**      |
+| Negative number passthrough        | ✓        | —     | —     | ✓    | Essential for `decimo`       | **Done**      |
+| Subcommands                        | ✓        | ✓     | ✓     | ✓    |                              | **Done**      |
+| Auto-added `help` subcommand       | —        | —     | ✓     | ✓    | git, cargo, kubectl          | **Done**      |
+| Persistent (global) flags          | —        | —     | ✓     | ✓    | git `--no-pager` etc.        | **Done**      |
+| Suggest on typo (Levenshtein)      | ✓ (3.14) | —     | ✓     | ✓    |                              | **Done**      |
+| Subcommand aliases                 | —        | —     | ✓     | ✓    | cobra, clap                  | **Done**      |
+| Count with ceiling                 | -        | —     | —     | -    |                              | **Done**      |
+| Cap and floor (clamp) for ranges   | -        | ✓     | —     | —    | Click `IntRange(clamp=True)` | **Done**      |
+| Hidden subcommands                 | —        | —     | ✓     | ✓    |                              | Phase 5       |
+| `NO_COLOR` env variable            | —        | —     | —     | —    | I need it personally         | Phase 5       |
+| Response file (`@args.txt`)        | ✓        | —     | —     | —    | javac, MSBuild               | Phase 5       |
+| Argument parents (shared args)     | ✓        | —     | —     | —    |                              | Phase 5       |
+| Interactive prompting              | —        | ✓     | —     | —    |                              | Phase 5       |
+| Password / masked input            | —        | ✓     | —     | —    |                              | Phase 5       |
+| Confirmation (`--yes` / `-y`)      | —        | ✓     | —     | —    |                              | Phase 5       |
+| Pre/Post run hooks                 | —        | —     | ✓     | —    |                              | Phase 5       |
+| REMAINDER nargs                    | ✓        | —     | —     | —    |                              | Phase 5       |
+| Partial parsing (known args)       | ✓        | —     | —     | ✓    |                              | Phase 5       |
+| Require equals syntax              | —        | —     | —     | ✓    |                              | Phase 5       |
+| Default-if-present (const)         | ✓        | —     | —     | ✓    |                              | Phase 5       |
+| Mutual implication (`implies`)     | —        | —     | —     | —    | ArgMojo unique feature       | Phase 5       |
+| Stdin value (`-` convention)       | —        | —     | ✓     | —    | Unix convention              | Phase 5       |
+| Shell completion script generation | —        | ✓     | ✓     | ✓    | bash / zsh / fish            | Phase 5       |
+| CJK-aware help formatting          | —        | —     | —     | —    | I need it personally         | Phase 6       |
+| CJK full-to-half-width correction  | —        | —     | —     | —    | I need it personally         | Phase 6       |
+| CJK punctuation detection          | —        | —     | —     | —    | I need it personally         | Phase 6       |
+| Typed retrieval (`get_int()` etc.) | ✓        | ✓     | ✓     | ✓    |                              | **Done**      |
+| `Parseable` trait for type params  | —        | —     | —     | ✓    |                              | Phase 7       |
+| Derive / struct-based schema       | —        | —     | —     | ✓    | Requires Mojo macros         | Phase unknown |
+| Enum → type mapping (real enums)   | —        | —     | —     | ✓    | Requires reflection          | Phase unknown |
+| Subcommand variant dispatch        | —        | —     | —     | ✓    | Requires sum types           | Phase unknown |
 
 ### 2.3 Features Excluded (Infeasible or Inappropriate)
 
@@ -200,6 +200,7 @@ examples/
 | Negative number passthrough (`-9`, `-3.14`, `-1.5e10` as positionals)                              | ✓      | ✓     |
 | Subcommand data model (`add_subcommand()`, dispatch, `help` sub)                                   | ✓      | ✓     |
 | Colored warning and error messages (`_warn()`, `_error()`, all errors printed in colour to stderr) | ✓      | ✓     |
+| Range clamping (`.range(1, 100).clamp()` → adjust + warn instead of error)                         | ✓      | ✓     |
 
 ### 4.3 API Design (Current)
 
@@ -372,7 +373,7 @@ The practical view — both dimensions checked together at parse time:
 - [x] **Aliases** for long names — `.aliases(["color"])` for `--colour` / `--color`
 - [x] **Deprecated arguments** — `.deprecated("Use --format instead")` prints warning to stderr (argparse 3.13)
 
-### Phase 4: Subcommands (for v0.2 or v0.3 depending on complexity)
+### Phase 4: Subcommands (for v0.2)
 
 Subcommands (`app <subcommand> [args]`) are the first feature that turns ArgMojo from a single-parser into a parser tree. The core insight is that **a subcommand is just another `Command` instance** — it already has `parse_arguments()`, `_generate_help()`, and all validation logic. No new parser, tokenizer, or separate module files are needed.
 
@@ -498,7 +499,7 @@ if result.subcommand == "search":
 - [x] Update user manual with subcommand usage patterns
 - [x] Document persistent flag behavior and conflict rules
 
-### Phase 5: Polish (nice-to-have features, may not be implemented soon)
+### Phase 5: Polish (nice-to-have features, most of which will be in v0.3, some may be deferred to v0.4+)
 
 #### Pre-requisite refactor
 
@@ -521,7 +522,8 @@ Before adding Phase 5 features, further decompose `parse_arguments()` for readab
 #### Features
 
 - [x] **Typo suggestions** — "Unknown option '--vrb', did you mean '--verbose'?" (Levenshtein distance; cobra, argparse 3.14)
-- [x] **Flag counter with ceiling** — `.count().max(3)` caps `-vvvvv` at 3 (no major library has this)
+- [x] **Flag counter with ceiling** — `.count().max(3)` caps `-vvvvv` at 3 with a warning (no major library has this)
+- [x] **Range clamping** — `.range(min, max).clamp()` adjusts out-of-range values to the nearest boundary with a warning instead of erroring (Click has `IntRange(clamp=True)`)
 - [x] **Colored error output** — ANSI styled error messages (help output already colored)
 - [x] **Shell completion script generation** — `generate_completion("bash"|"zsh"|"fish")` returns a complete completion script; static approach (no runtime hook), covers options/flags/choices/subcommands (clap `generate`, cobra `completion`, click `shell_complete`)
 - [ ] **Argument groups in help** — group related options under headings (argparse add_argument_group)
@@ -553,7 +555,7 @@ These will **NOT** be implemented in this phase, but will be considered in futur
 - Environment variable fallback
 - Template-based help formatting
 
-### Phase 6: CJK Features
+### Phase 6: CJK Features (hopefully for v0.4 because I need it personally)
 
 ArgMojo's differentiating features — no other CLI library addresses CJK-specific pain points.
 
@@ -646,6 +648,7 @@ These features represent the "next generation" of CLI parser design, inspired by
 | Enum validation              | `.choices(["debug", "release"])`                                                                                                               | String-level enum; help shows `{debug,release}` |
 | Required / optional          | `.required()` / `.default("...")`                                                                                                              | Parse-time enforcement with coloured errors     |
 | Flag counter (not just bool) | `.count()` + `get_count()`                                                                                                                     | `-vvv → 3`; `.count().max(N)` caps at ceiling   |
+| Range clamping               | `.range(min, max).clamp()`                                                                                                                     | Adjusts out-of-range values with a warning      |
 | Subcommand dispatch          | `result.subcommand == "search"` + `get_subcommand_result()`                                                                                    | Same pattern as Go cobra                        |
 
 ## 6. Parsing Algorithm
@@ -686,7 +689,9 @@ Input: ["demo", "yuhao", "./src", "--ling", "-i", "--max-depth", "3"]
     ├─ Mutually exclusive groups
     ├─ Required-together groups
     ├─ One-required groups
-    └─ Conditional requirements
+    ├─ Conditional requirements
+    ├─ Count ceilings (clamp + warn)
+    └─ Numeric range constraints (error or clamp + warn)
 6. Return ParseResult
 ```
 

--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -61,6 +61,8 @@ These features appear across multiple libraries and depend only on string operat
 | Persistent (global) flags          | —        | —     | ✓     | ✓    | git `--no-pager` etc.  | **Done**      |
 | Suggest on typo (Levenshtein)      | ✓ (3.14) | —     | ✓     | ✓    |                        | **Done**      |
 | Subcommand aliases                 | —        | —     | ✓     | ✓    | cobra, clap            | **Done**      |
+| Count with ceiling                 | -        | —     | —     | -    |                        | **Done**      |
+| Cap and floor (clamp) for ranges   | -        | —     | —     | —    |                        | Phase 5       |
 | Hidden subcommands                 | —        | —     | ✓     | ✓    |                        | Phase 5       |
 | `NO_COLOR` env variable            | —        | —     | —     | —    | I need it personally   | Phase 5       |
 | Response file (`@args.txt`)        | ✓        | —     | —     | —    | javac, MSBuild         | Phase 5       |
@@ -179,7 +181,7 @@ examples/
 | Choices validation (`.choices()`)                                                                  | ✓      | ✓     |
 | Metavar (`.metavar("FILE")`)                                                                       | ✓      | ✓     |
 | Hidden arguments (`.hidden()`)                                                                     | ✓      | ✓     |
-| Count action (`-vvv` → 3)                                                                          | ✓      | ✓     |
+| Count action (`-vvv` → 3) with ceiling (`.max(N)`)                                                 | ✓      | ✓     |
 | Positional arg count validation                                                                    | ✓      | ✓     |
 | Clean exit for `--help` / `--version`                                                              | ✓      | —     |
 | Mutually exclusive groups                                                                          | ✓      | ✓     |
@@ -519,7 +521,7 @@ Before adding Phase 5 features, further decompose `parse_arguments()` for readab
 #### Features
 
 - [x] **Typo suggestions** — "Unknown option '--vrb', did you mean '--verbose'?" (Levenshtein distance; cobra, argparse 3.14)
-- [ ] **Flag counter with ceiling** — `.count().max(3)` caps `-vvvvv` at 3 (no major library has this)
+- [x] **Flag counter with ceiling** — `.count().max(3)` caps `-vvvvv` at 3 (no major library has this)
 - [x] **Colored error output** — ANSI styled error messages (help output already colored)
 - [x] **Shell completion script generation** — `generate_completion("bash"|"zsh"|"fish")` returns a complete completion script; static approach (no runtime hook), covers options/flags/choices/subcommands (clap `generate`, cobra `completion`, click `shell_complete`)
 - [ ] **Argument groups in help** — group related options under headings (argparse add_argument_group)
@@ -643,7 +645,7 @@ These features represent the "next generation" of CLI parser design, inspired by
 | Typed retrieval              | `get_flag()->Bool`, `get_int()->Int`, `get_string()->String`, `get_count()->Int`, `get_list()->List[String]`, `get_map()->Dict[String,String]` | Already typed at retrieval                      |
 | Enum validation              | `.choices(["debug", "release"])`                                                                                                               | String-level enum; help shows `{debug,release}` |
 | Required / optional          | `.required()` / `.default("...")`                                                                                                              | Parse-time enforcement with coloured errors     |
-| Flag counter (not just bool) | `.count()` + `get_count()`                                                                                                                     | `-vvv → 3`; `.count().max(N)` planned           |
+| Flag counter (not just bool) | `.count()` + `get_count()`                                                                                                                     | `-vvv → 3`; `.count().max(N)` caps at ceiling   |
 | Subcommand dispatch          | `result.subcommand == "search"` + `get_subcommand_result()`                                                                                    | Same pattern as Go cobra                        |
 
 ## 6. Parsing Algorithm

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,7 @@
 # ArgMojo changelog
 
+This document tracks all notable changes to ArgMojo, including new features, API changes, bug fixes, and documentation updates.
+
 ## 20260228 (v0.2.0)
 
 ArgMojo v0.2.0 is a major release that transforms the library from a single-command parser into a full **subcommand-capable CLI framework**. It introduces hierarchical subcommands with automatic dispatch, persistent (global) flags with bidirectional sync, negative number passthrough, colored error messages, custom tips, and significant help/UX improvements. The public API is also refined: `Arg` → `Argument`, `Result` → `ParseResult` (old names kept as aliases). Two complete example CLIs (`mgrep` and `mgit`) replace the previous demo.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,10 @@
 
 This document tracks all notable changes to ArgMojo, including new features, API changes, bug fixes, and documentation updates.
 
+<!-->
+Do not add unreleased changes here. This file will be edited just before each release to reflect the final changelog for that version.
+<-->
+
 ## 20260228 (v0.2.0)
 
 ArgMojo v0.2.0 is a major release that transforms the library from a single-command parser into a full **subcommand-capable CLI framework**. It introduces hierarchical subcommands with automatic dispatch, persistent (global) flags with bidirectional sync, negative number passthrough, colored error messages, custom tips, and significant help/UX improvements. The public API is also refined: `Arg` → `Argument`, `Result` → `ParseResult` (old names kept as aliases). Two complete example CLIs (`mgrep` and `mgit`) replace the previous demo.

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -35,6 +35,7 @@ from argmojo import Argument, Command
   - [Choices Validation](#choices-validation)
   - [Positional Argument Count Validation](#positional-argument-count-validation)
   - [Numeric Range Validation](#numeric-range-validation)
+  - [Range Clamping (`.clamp()`)](#range-clamping-clamp)
 - [Group Constraints](#group-constraints)
   - [Mutually Exclusive Groups](#mutually-exclusive-groups)
   - [One-Required Groups](#one-required-groups)
@@ -379,7 +380,7 @@ Merged short flags work seamlessly: `-vvv` is three occurrences of `-v`.
 
 ### Count Ceiling (`.max()`)
 
-You can cap a count flag at a maximum value with `.max(n)`. Any occurrences beyond the ceiling are silently ignored — the count never exceeds the specified maximum.
+You can cap a count flag at a maximum value with `.max(n)`. Any occurrences beyond the ceiling are clamped to the maximum and a warning is printed to stderr informing the user of the adjustment.
 
 ```mojo
 command.add_argument(
@@ -390,12 +391,18 @@ command.add_argument(
 
 ```bash
 myapp -vvv           # verbose = 3
-myapp -vvvvv         # verbose = 3  (capped at ceiling)
-myapp -vvvvvvvvvv    # verbose = 3  (still capped)
+myapp -vvvvv         # verbose = 3  (capped, warning printed)
+myapp -vvvvvvvvvv    # verbose = 3  (capped, warning printed)
 myapp -vv            # verbose = 2  (below ceiling, not affected)
 ```
 
-This is useful when verbosity levels above a certain threshold have no additional effect, or to prevent accidental over-counting. From users perspective, they may encounter less error messages compared to use an option with a range validation (e.g., `.range(0, 3)`) which would reject `-vvvv` with an error instead of silently capping it.
+The warning looks like:
+
+```bash
+Warning: '--verbose' count 5 exceeds maximum 3, capped to 3
+```
+
+This is useful when verbosity levels above a certain threshold have no additional effect, or to prevent accidental over-counting. From users' perspective, they get a clear warning rather than a hard error, which is friendlier than using the count option without a ceiling and silently ignoring extra occurrences.
 
 ### Negatable Flags
 
@@ -959,6 +966,57 @@ command.add_argument(
 ```bash
 myapp --port 50 --port 101
 # Error: Value 101 for '--port' is out of range [1, 100]
+```
+
+### Range Clamping (`.clamp()`)
+
+By default, an out-of-range value causes a hard error. If you prefer a gentler approach, chain `.clamp()` after `.range()` to **adjust** the value to the nearest boundary and print a warning instead of failing.
+
+```mojo
+command.add_argument(
+    Argument("level", help="Compression level (0–9)")
+        .long("level")
+        .range(0, 9)
+        .clamp()
+)
+```
+
+```bash
+myapp --level 5      # OK — level = 5
+myapp --level 20     # Warning, level = 9  (clamped to max)
+myapp --level -3     # Warning, level = 0  (clamped to min)
+```
+
+The warning looks like:
+
+```bash
+Warning: '--level' value 20 is out of range [0, 9], clamped to 9
+```
+
+---
+
+**With append mode** — each collected value is clamped individually:
+
+```mojo
+command.add_argument(
+    Argument("port", help="Ports").long("port").append().range(1, 100).clamp()
+)
+```
+
+```bash
+myapp --port 50 --port 200 --port 0
+# Warning: '--port' value 200 is out of range [1, 100], clamped to 100
+# Warning: '--port' value 0 is out of range [1, 100], clamped to 1
+# Result: ports = [50, 100, 1]
+```
+
+---
+
+**Without `.clamp()`** — the existing behaviour is unchanged; an out-of-range value raises an error:
+
+```bash
+myapp --port 200
+# Error: Value 200 for '--port' is out of range [1, 100]
 ```
 
 ## Group Constraints

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -24,6 +24,7 @@ from argmojo import Argument, Command
   - [Attached Short Values](#attached-short-values)
 - [Flag Variants](#flag-variants)
   - [Count Flags](#count-flags)
+  - [Count Ceiling (`.max()`)](#count-ceiling-max)
   - [Negatable Flags](#negatable-flags)
 - [Collecting Multiple Values](#collecting-multiple-values)
   - [Append / Collect Action](#append--collect-action)
@@ -44,6 +45,7 @@ from argmojo import Argument, Command
   - [Parsing Subcommand Results](#parsing-subcommand-results)
   - [Persistent (Global) Flags](#persistent-global-flags)
   - [The help Subcommand](#the-help-subcommand)
+  - [Subcommand Aliases](#subcommand-aliases)
   - [Unknown Subcommand Error](#unknown-subcommand-error)
   - [Mixing Positional Args with Subcommands](#mixing-positional-args-with-subcommands)
 - [Help \& Display](#help--display)
@@ -374,6 +376,26 @@ if level >= 2:
 Count flags are a special kind of boolean flag — calling `.count()` automatically sets `.flag()` as well, so they don't expect a value.
 
 Merged short flags work seamlessly: `-vvv` is three occurrences of `-v`.
+
+### Count Ceiling (`.max()`)
+
+You can cap a count flag at a maximum value with `.max(n)`. Any occurrences beyond the ceiling are silently ignored — the count never exceeds the specified maximum.
+
+```mojo
+command.add_argument(
+    Argument("verbose", help="Increase verbosity (capped at 3)")
+    .long("verbose").short("v").count().max(3)
+)
+```
+
+```bash
+myapp -vvv           # verbose = 3
+myapp -vvvvv         # verbose = 3  (capped at ceiling)
+myapp -vvvvvvvvvv    # verbose = 3  (still capped)
+myapp -vv            # verbose = 2  (below ceiling, not affected)
+```
+
+This is useful when verbosity levels above a certain threshold have no additional effect, or to prevent accidental over-counting. From users perspective, they may encounter less error messages compared to use an option with a range validation (e.g., `.range(0, 3)`) which would reject `-vvvv` with an error instead of silently capping it.
 
 ### Negatable Flags
 

--- a/src/argmojo/argument.mojo
+++ b/src/argmojo/argument.mojo
@@ -34,6 +34,9 @@ struct Argument(Copyable, Movable, Stringable, Writable):
     # Count flag  (-vvv → 3)  →  result.get_count("verbose")
     _ = Argument("verbose", help="...").long("verbose").short("v").count()
 
+    # Count flag with ceiling  (-vvvvv capped at 3)
+    _ = Argument("verbose", help="...").long("verbose").short("v").count().max(3)
+
     # Negatable flag  (--color / --no-color)  →  result.get_flag("color")
     _ = Argument("color", help="...").long("color").flag().negatable()
 
@@ -110,6 +113,10 @@ struct Argument(Copyable, Movable, Stringable, Writable):
     """Alternative long names that resolve to this argument."""
     var deprecated_msg: String
     """If non-empty, this argument is deprecated; the string is the warning message."""
+    var count_max: Int
+    """Maximum count value (ceiling) for counter flags. 0 means no limit."""
+    var has_count_max: Bool
+    """Whether a count ceiling has been set via ``.max()``."""
     var is_persistent: Bool
     """If True, this argument is automatically inherited by every subcommand.
     Persistent flags/options are injected into child command parsers at
@@ -150,6 +157,8 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         self.is_map = False
         self.alias_names = List[String]()
         self.deprecated_msg = ""
+        self.count_max = 0
+        self.has_count_max = False
         self.is_persistent = False
 
     fn __copyinit__(out self, copy: Self):
@@ -185,6 +194,8 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         for i in range(len(copy.alias_names)):
             self.alias_names.append(copy.alias_names[i])
         self.deprecated_msg = copy.deprecated_msg
+        self.count_max = copy.count_max
+        self.has_count_max = copy.has_count_max
         self.is_persistent = copy.is_persistent
 
     fn __moveinit__(out self, deinit move: Self):
@@ -216,6 +227,8 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         self.is_map = move.is_map
         self.alias_names = move.alias_names^
         self.deprecated_msg = move.deprecated_msg^
+        self.count_max = move.count_max
+        self.has_count_max = move.has_count_max
         self.is_persistent = move.is_persistent
 
     # ===------------------------------------------------------------------=== #
@@ -348,11 +361,32 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         Each occurrence increments a counter. For example, ``-vvv`` sets
         the count to 3. Use ``get_count()`` on ParseResult to retrieve.
 
+        Chain with ``.max(n)`` to cap the counter at a ceiling value.
+
         Returns:
             Self marked as a counter.
         """
         self.is_count = True
         self.is_flag = True
+        return self^
+
+    fn max(var self, ceiling: Int) -> Self:
+        """Sets a ceiling for a counter flag.
+
+        When a counter flag has a ceiling, the count is capped at the
+        given value regardless of how many times the flag appears.
+        For example, ``.count().max(3)`` caps ``-vvvvv`` at 3.
+
+        Must be used after ``.count()``.
+
+        Args:
+            ceiling: The maximum count value (must be ≥ 1).
+
+        Returns:
+            Self with the count ceiling set.
+        """
+        self.count_max = ceiling
+        self.has_count_max = True
         return self^
 
     fn negatable(var self) -> Self:

--- a/src/argmojo/argument.mojo
+++ b/src/argmojo/argument.mojo
@@ -52,6 +52,9 @@ struct Argument(Copyable, Movable, Stringable, Writable):
     # Numeric range validation  →  result.get_int("port")
     _ = Argument("port", help="...").long("port").range(1, 65535)
 
+    # Numeric range with clamping  (--level 200 → 100 with warning)
+    _ = Argument("level", help="...").long("level").range(0, 100).clamp()
+
     # Key-value map  (--def k=v --def k2=v2)  →  result.get_map("def")
     _ = Argument("def", help="...").long("define").short("D").map_option()
 
@@ -107,6 +110,8 @@ struct Argument(Copyable, Movable, Stringable, Writable):
     """Maximum allowed value (inclusive) for numeric range validation."""
     var has_range: Bool
     """Whether numeric range validation is active."""
+    var is_clamp: Bool
+    """If True, out-of-range values are clamped (adjusted with warning) instead of rejected."""
     var is_map: Bool
     """If True, each value is parsed as key=value and stored in a Dict."""
     var alias_names: List[String]
@@ -154,6 +159,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         self.range_min = 0
         self.range_max = 0
         self.has_range = False
+        self.is_clamp = False
         self.is_map = False
         self.alias_names = List[String]()
         self.deprecated_msg = ""
@@ -189,6 +195,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         self.range_min = copy.range_min
         self.range_max = copy.range_max
         self.has_range = copy.has_range
+        self.is_clamp = copy.is_clamp
         self.is_map = copy.is_map
         self.alias_names = List[String]()
         for i in range(len(copy.alias_names)):
@@ -224,6 +231,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         self.range_min = move.range_min
         self.range_max = move.range_max
         self.has_range = move.has_range
+        self.is_clamp = move.is_clamp
         self.is_map = move.is_map
         self.alias_names = move.alias_names^
         self.deprecated_msg = move.deprecated_msg^
@@ -464,6 +472,10 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         ``[min_val, max_val]`` (inclusive).  Validation occurs
         after parsing, during the validation phase.
 
+        By default, out-of-range values cause an error.  Chain with
+        ``.clamp()`` to silently adjust the value (with a warning)
+        instead of erroring.
+
         Args:
             min_val: Minimum allowed value (inclusive).
             max_val: Maximum allowed value (inclusive).
@@ -474,6 +486,25 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         self.range_min = min_val
         self.range_max = max_val
         self.has_range = True
+        return self^
+
+    fn clamp(var self) -> Self:
+        """Enables clamping for numeric range validation.
+
+        When clamping is enabled (used after ``.range(min, max)``),
+        out-of-range values are adjusted to the nearest boundary
+        instead of causing an error.  A warning is printed to stderr
+        to inform the user of the adjustment.
+
+        For example, ``.range(1, 100).clamp()`` causes ``--level 200``
+        to be silently adjusted to 100 with a warning.
+
+        Must be used after ``.range()``.
+
+        Returns:
+            Self with clamping enabled.
+        """
+        self.is_clamp = True
         return self^
 
     fn map_option(var self) -> Self:

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -1128,16 +1128,13 @@ struct Command(Copyable, Movable, Stringable, Writable):
         if is_negation:
             result.flags[matched.name] = False
         elif matched.is_count and not has_eq:
-            # Count flag: increment counter (with optional ceiling).
+            # Count flag: increment counter.
             var cur: Int = 0
             try:
                 cur = result.counts[matched.name]
             except:
                 pass
-            var new_val = cur + 1
-            if matched.has_count_max and new_val > matched.count_max:
-                new_val = matched.count_max
-            result.counts[matched.name] = new_val
+            result.counts[matched.name] = cur + 1
         elif matched.is_flag and not has_eq:
             result.flags[matched.name] = True
         elif matched.num_values > 0:
@@ -1211,10 +1208,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 cur = result.counts[matched.name]
             except:
                 pass
-            var new_val = cur + 1
-            if matched.has_count_max and new_val > matched.count_max:
-                new_val = matched.count_max
-            result.counts[matched.name] = new_val
+            result.counts[matched.name] = cur + 1
         elif matched.is_flag:
             result.flags[matched.name] = True
         elif matched.num_values > 0:
@@ -1296,10 +1290,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                         cur = result.counts[m.name]
                     except:
                         pass
-                    var new_val = cur + 1
-                    if m.has_count_max and new_val > m.count_max:
-                        new_val = m.count_max
-                    result.counts[m.name] = new_val
+                    result.counts[m.name] = cur + 1
                     j += 1
                 elif m.is_flag:
                     result.flags[m.name] = True
@@ -1542,7 +1533,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 else:
                     result.values[a.name] = a.default_value
 
-    fn _validate(self, result: ParseResult) raises:
+    fn _validate(self, mut result: ParseResult) raises:
         """Runs all post-parse validation checks on the result.
 
         Checks (in order):
@@ -1552,10 +1543,11 @@ struct Command(Copyable, Movable, Stringable, Writable):
         4. Required-together groups are all-or-nothing.
         5. One-required groups have at least one member set.
         6. Conditional requirements are satisfied.
-        7. Numeric range constraints are met.
+        7. Count ceilings are enforced (clamp + warn).
+        8. Numeric range constraints are met (error or clamp + warn).
 
         Args:
-            result: The parse result to validate.
+            result: The parse result to validate (may be mutated by clamping).
 
         Raises:
             Error if any validation check fails.
@@ -1656,10 +1648,34 @@ struct Command(Copyable, Movable, Stringable, Writable):
                     + " is provided"
                 )
 
+        # Validate count ceilings — clamp and warn.
+        for j in range(len(self.args)):
+            var a = self.args[j].copy()
+            if a.is_count and a.has_count_max:
+                var cur: Int
+                try:
+                    cur = result.counts[a.name]
+                except:
+                    continue
+                if cur > a.count_max:
+                    self._warn(
+                        self._display_name(a.name)
+                        + " count "
+                        + String(cur)
+                        + " exceeds maximum "
+                        + String(a.count_max)
+                        + ", capped to "
+                        + String(a.count_max)
+                    )
+                    result.counts[a.name] = a.count_max
+
         # Validate numeric range constraints.
         for j in range(len(self.args)):
             var a = self.args[j].copy()
             if a.has_range and result.has(a.name):
+                var display = String("'") + a.name + "'"
+                if a.long_name:
+                    display = "'--" + a.long_name + "'"
                 # Get the raw string value(s) for this argument.
                 if a.is_append:
                     var lst = result.get_list(a.name)
@@ -1678,20 +1694,36 @@ struct Command(Copyable, Movable, Stringable, Writable):
                                 + "'"
                             )
                         if v < a.range_min or v > a.range_max:
-                            var display = String("'") + a.name + "'"
-                            if a.long_name:
-                                display = "'--" + a.long_name + "'"
-                            self._error(
-                                "Value "
-                                + String(v)
-                                + " for "
-                                + display
-                                + " is out of range ["
-                                + String(a.range_min)
-                                + ", "
-                                + String(a.range_max)
-                                + "]"
-                            )
+                            if a.is_clamp:
+                                var clamped = v
+                                if v < a.range_min:
+                                    clamped = a.range_min
+                                elif v > a.range_max:
+                                    clamped = a.range_max
+                                self._warn(
+                                    display
+                                    + " value "
+                                    + String(v)
+                                    + " is out of range ["
+                                    + String(a.range_min)
+                                    + ", "
+                                    + String(a.range_max)
+                                    + "], clamped to "
+                                    + String(clamped)
+                                )
+                                result.lists[a.name][k] = String(clamped)
+                            else:
+                                self._error(
+                                    "Value "
+                                    + String(v)
+                                    + " for "
+                                    + display
+                                    + " is out of range ["
+                                    + String(a.range_min)
+                                    + ", "
+                                    + String(a.range_max)
+                                    + "]"
+                                )
                 else:
                     var raw: String
                     try:
@@ -1712,20 +1744,36 @@ struct Command(Copyable, Movable, Stringable, Writable):
                             + "'"
                         )
                     if v < a.range_min or v > a.range_max:
-                        var display = String("'") + a.name + "'"
-                        if a.long_name:
-                            display = "'--" + a.long_name + "'"
-                        self._error(
-                            "Value "
-                            + String(v)
-                            + " for "
-                            + display
-                            + " is out of range ["
-                            + String(a.range_min)
-                            + ", "
-                            + String(a.range_max)
-                            + "]"
-                        )
+                        if a.is_clamp:
+                            var clamped = v
+                            if v < a.range_min:
+                                clamped = a.range_min
+                            elif v > a.range_max:
+                                clamped = a.range_max
+                            self._warn(
+                                display
+                                + " value "
+                                + String(v)
+                                + " is out of range ["
+                                + String(a.range_min)
+                                + ", "
+                                + String(a.range_max)
+                                + "], clamped to "
+                                + String(clamped)
+                            )
+                            result.values[a.name] = String(clamped)
+                        else:
+                            self._error(
+                                "Value "
+                                + String(v)
+                                + " for "
+                                + display
+                                + " is out of range ["
+                                + String(a.range_min)
+                                + ", "
+                                + String(a.range_max)
+                                + "]"
+                            )
 
     # ===------------------------------------------------------------------=== #
     # Argument lookup helpers

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -1128,13 +1128,16 @@ struct Command(Copyable, Movable, Stringable, Writable):
         if is_negation:
             result.flags[matched.name] = False
         elif matched.is_count and not has_eq:
-            # Count flag: increment counter.
+            # Count flag: increment counter (with optional ceiling).
             var cur: Int = 0
             try:
                 cur = result.counts[matched.name]
             except:
                 pass
-            result.counts[matched.name] = cur + 1
+            var new_val = cur + 1
+            if matched.has_count_max and new_val > matched.count_max:
+                new_val = matched.count_max
+            result.counts[matched.name] = new_val
         elif matched.is_flag and not has_eq:
             result.flags[matched.name] = True
         elif matched.num_values > 0:
@@ -1208,7 +1211,10 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 cur = result.counts[matched.name]
             except:
                 pass
-            result.counts[matched.name] = cur + 1
+            var new_val = cur + 1
+            if matched.has_count_max and new_val > matched.count_max:
+                new_val = matched.count_max
+            result.counts[matched.name] = new_val
         elif matched.is_flag:
             result.flags[matched.name] = True
         elif matched.num_values > 0:
@@ -1290,7 +1296,10 @@ struct Command(Copyable, Movable, Stringable, Writable):
                         cur = result.counts[m.name]
                     except:
                         pass
-                    result.counts[m.name] = cur + 1
+                    var new_val = cur + 1
+                    if m.has_count_max and new_val > m.count_max:
+                        new_val = m.count_max
+                    result.counts[m.name] = new_val
                     j += 1
                 elif m.is_flag:
                     result.flags[m.name] = True

--- a/tests/test_extras.mojo
+++ b/tests/test_extras.mojo
@@ -137,6 +137,147 @@ fn test_range_with_short_option() raises:
     print("  ✓ test_range_with_short_option")
 
 
+# ── Range clamping (.clamp()) ────────────────────────────────────────────────
+
+
+fn test_clamp_above_max() raises:
+    """Tests that .clamp() adjusts a value above max to max."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("level", help="Level").long("level").range(1, 100).clamp()
+    )
+
+    var args: List[String] = ["test", "--level", "200"]
+    var result = command.parse_arguments(args)
+    assert_equal(
+        result.get_int("level"),
+        100,
+        msg="200 should be clamped to 100",
+    )
+    print("  ✓ test_clamp_above_max")
+
+
+fn test_clamp_below_min() raises:
+    """Tests that .clamp() adjusts a value below min to min."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("level", help="Level").long("level").range(1, 100).clamp()
+    )
+
+    var args: List[String] = ["test", "--level", "-5"]
+    var result = command.parse_arguments(args)
+    assert_equal(
+        result.get_int("level"),
+        1,
+        msg="-5 should be clamped to 1",
+    )
+    print("  ✓ test_clamp_below_min")
+
+
+fn test_clamp_within_range_no_change() raises:
+    """Tests that .clamp() does not affect a value within range."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("level", help="Level").long("level").range(1, 100).clamp()
+    )
+
+    var args: List[String] = ["test", "--level", "50"]
+    var result = command.parse_arguments(args)
+    assert_equal(
+        result.get_int("level"),
+        50,
+        msg="50 should remain 50",
+    )
+    print("  ✓ test_clamp_within_range_no_change")
+
+
+fn test_clamp_at_boundary() raises:
+    """Tests that .clamp() does not trigger at exact boundaries."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("port", help="Port").long("port").range(1, 65535).clamp()
+    )
+
+    var args1: List[String] = ["test", "--port", "1"]
+    var result1 = command.parse_arguments(args1)
+    assert_equal(result1.get_int("port"), 1, msg="1 at min boundary is fine")
+
+    var args2: List[String] = ["test", "--port", "65535"]
+    var result2 = command.parse_arguments(args2)
+    assert_equal(
+        result2.get_int("port"), 65535, msg="65535 at max boundary is fine"
+    )
+    print("  ✓ test_clamp_at_boundary")
+
+
+fn test_clamp_with_short_option() raises:
+    """Tests that .clamp() works with short option syntax."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("level", help="Level")
+        .long("level")
+        .short("l")
+        .range(0, 10)
+        .clamp()
+    )
+
+    var args: List[String] = ["test", "-l", "99"]
+    var result = command.parse_arguments(args)
+    assert_equal(
+        result.get_int("level"),
+        10,
+        msg="99 with range [0,10] should clamp to 10",
+    )
+    print("  ✓ test_clamp_with_short_option")
+
+
+fn test_clamp_with_append() raises:
+    """Tests that .clamp() adjusts individual values in append mode."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("port", help="Ports")
+        .long("port")
+        .append()
+        .range(1, 100)
+        .clamp()
+    )
+
+    var args: List[String] = [
+        "test",
+        "--port",
+        "50",
+        "--port",
+        "200",
+        "--port",
+        "0",
+    ]
+    var result = command.parse_arguments(args)
+    var lst = result.get_list("port")
+    assert_equal(lst[0], "50", msg="50 should remain 50")
+    assert_equal(lst[1], "100", msg="200 should clamp to 100")
+    assert_equal(lst[2], "1", msg="0 should clamp to 1")
+    print("  ✓ test_clamp_with_append")
+
+
+fn test_range_without_clamp_still_errors() raises:
+    """Tests that .range() without .clamp() still raises errors."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("port", help="Port").long("port").range(1, 65535)
+    )
+
+    var args: List[String] = ["test", "--port", "99999"]
+    var caught = False
+    try:
+        _ = command.parse_arguments(args)
+    except e:
+        caught = True
+        var msg = String(e)
+        assert_true("out of range" in msg, msg="should error on out of range")
+    assert_true(caught, msg="Should have raised for out-of-range without clamp")
+    print("  ✓ test_range_without_clamp_still_errors")
+
+
 # ── Key-value map option ─────────────────────────────────────────────────────
 
 

--- a/tests/test_parse.mojo
+++ b/tests/test_parse.mojo
@@ -426,6 +426,182 @@ fn test_count_default_zero() raises:
     print("  ✓ test_count_default_zero")
 
 
+# ── Count ceiling (.max()) ───────────────────────────────────────────────────────
+
+
+fn test_count_max_caps_merged_short() raises:
+    """Tests that .count().max(3) caps -vvvvv at 3."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("verbose", help="Verbosity level")
+        .long("verbose")
+        .short("v")
+        .count()
+        .max(3)
+    )
+
+    var args: List[String] = ["test", "-vvvvv"]
+    var result = command.parse_arguments(args)
+    assert_equal(
+        result.get_count("verbose"),
+        3,
+        msg="-vvvvv with max(3) should cap at 3",
+    )
+    print("  ✓ test_count_max_caps_merged_short")
+
+
+fn test_count_max_caps_repeated_long() raises:
+    """Tests that .max(2) caps repeated --verbose at 2."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("verbose", help="Verbosity level")
+        .long("verbose")
+        .short("v")
+        .count()
+        .max(2)
+    )
+
+    var args: List[String] = [
+        "test",
+        "--verbose",
+        "--verbose",
+        "--verbose",
+        "--verbose",
+    ]
+    var result = command.parse_arguments(args)
+    assert_equal(
+        result.get_count("verbose"),
+        2,
+        msg="4x --verbose with max(2) should cap at 2",
+    )
+    print("  ✓ test_count_max_caps_repeated_long")
+
+
+fn test_count_max_caps_mixed() raises:
+    """Tests that .max(3) caps mixed -vv --verbose --verbose at 3."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("verbose", help="Verbosity level")
+        .long("verbose")
+        .short("v")
+        .count()
+        .max(3)
+    )
+
+    var args: List[String] = ["test", "-vv", "--verbose", "--verbose"]
+    var result = command.parse_arguments(args)
+    assert_equal(
+        result.get_count("verbose"),
+        3,
+        msg="Mixed 4 occurrences with max(3) should cap at 3",
+    )
+    print("  ✓ test_count_max_caps_mixed")
+
+
+fn test_count_max_below_ceiling() raises:
+    """Tests that .max(5) does not affect -vv (below ceiling)."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("verbose", help="Verbosity level")
+        .long("verbose")
+        .short("v")
+        .count()
+        .max(5)
+    )
+
+    var args: List[String] = ["test", "-vv"]
+    var result = command.parse_arguments(args)
+    assert_equal(
+        result.get_count("verbose"),
+        2,
+        msg="-vv with max(5) should remain 2",
+    )
+    print("  ✓ test_count_max_below_ceiling")
+
+
+fn test_count_max_exact_ceiling() raises:
+    """Tests that -vvv with .max(3) returns exactly 3."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("verbose", help="Verbosity level")
+        .long("verbose")
+        .short("v")
+        .count()
+        .max(3)
+    )
+
+    var args: List[String] = ["test", "-vvv"]
+    var result = command.parse_arguments(args)
+    assert_equal(
+        result.get_count("verbose"),
+        3,
+        msg="-vvv with max(3) should be exactly 3",
+    )
+    print("  ✓ test_count_max_exact_ceiling")
+
+
+fn test_count_max_single_short() raises:
+    """Tests that .max(2) caps -v -v -v via separate short flags at 2."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("verbose", help="Verbosity level")
+        .long("verbose")
+        .short("v")
+        .count()
+        .max(2)
+    )
+
+    var args: List[String] = ["test", "-v", "-v", "-v"]
+    var result = command.parse_arguments(args)
+    assert_equal(
+        result.get_count("verbose"),
+        2,
+        msg="3x -v with max(2) should cap at 2",
+    )
+    print("  ✓ test_count_max_single_short")
+
+
+fn test_count_without_max_no_ceiling() raises:
+    """Tests that .count() without .max() has no ceiling."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("verbose", help="Verbosity level")
+        .long("verbose")
+        .short("v")
+        .count()
+    )
+
+    var args: List[String] = ["test", "-vvvvvvvvvv"]
+    var result = command.parse_arguments(args)
+    assert_equal(
+        result.get_count("verbose"),
+        10,
+        msg="-vvvvvvvvvv without max should be 10",
+    )
+    print("  ✓ test_count_without_max_no_ceiling")
+
+
+fn test_count_max_one() raises:
+    """Tests that .max(1) caps any number of flags at 1 (boolean-like)."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("verbose", help="Verbosity level")
+        .long("verbose")
+        .short("v")
+        .count()
+        .max(1)
+    )
+
+    var args: List[String] = ["test", "-vvv"]
+    var result = command.parse_arguments(args)
+    assert_equal(
+        result.get_count("verbose"),
+        1,
+        msg="-vvv with max(1) should cap at 1",
+    )
+    print("  ✓ test_count_max_one")
+
+
 # ── Positional arg count validation ──────────────────────────────────────────────
 
 


### PR DESCRIPTION
This PR extends ArgMojo’s validation phase to support (1) count-flag ceilings via `.count().max(n)` and (2) numeric range clamping via `.range(min,max).clamp()`, emitting warnings when values are capped/clamped.

**Changes:**
- Add `Argument.max()` (count ceiling) and `Argument.clamp()` (range clamping) plus the associated `Argument` state.
- Enforce count ceilings and range clamping during `Command._validate()` (with warnings).
- Add test coverage and user-facing documentation for the new behaviors.