### PR TITLE
[core][demo] Provide a new demo + make some attributes private + rename some attributes and methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ logs/
 # Built example binaries
 /mgrep
 /mgit
+/demo
 
 # Local notes (not tracked)
 local/

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,9 +2,9 @@
 
 This document tracks all notable changes to ArgMojo, including new features, API changes, bug fixes, and documentation updates.
 
-<!-->
+<!--
 Do not add unreleased changes here. This file will be edited just before each release to reflect the final changelog for that version.
-<-->
+-->
 
 ## 20260228 (v0.2.0)
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -696,7 +696,7 @@ command.add_argument(Argument("rgb", help="RGB colour").long("rgb").short("c").n
 ```
 
 `.number_of_values(N)` automatically implies `.append()` — values are stored in
-`ParseResult.lists` and retrieved with `get_list()`.
+`ParseResult._lists` and retrieved with `get_list()`.
 
 ---
 
@@ -1643,7 +1643,7 @@ app.add_argument(Argument("fallback", help="Fallback").positional())
 # "foo" doesn't match any subcommand → treated as positional
 var args: List[String] = ["app", "foo"]
 var result = app.parse_arguments(args)
-print(result.positionals[0])  # "foo"
+print(result.get_string("fallback"))  # "foo"
 ```
 
 Please seriously **think twice** before doing this — it's usually better to design your CLI with a clear separation between subcommands and positionals. Allowing both on the same command can lead to confusing user experiences and error messages.

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -399,7 +399,7 @@ myapp -vv            # verbose = 2  (below ceiling, not affected)
 The warning looks like:
 
 ```bash
-Warning: '--verbose' count 5 exceeds maximum 3, capped to 3
+warning: '--verbose' count 5 exceeds maximum 3, capped to 3
 ```
 
 This is useful when verbosity levels above a certain threshold have no additional effect, or to prevent accidental over-counting. From users' perspective, they get a clear warning rather than a hard error, which is friendlier than using the count option without a ceiling and silently ignoring extra occurrences.
@@ -990,7 +990,7 @@ myapp --level -3     # Warning, level = 0  (clamped to min)
 The warning looks like:
 
 ```bash
-Warning: '--level' value 20 is out of range [0, 9], clamped to 9
+warning: '--level' value 20 is out of range [0, 9], clamped to 9
 ```
 
 ---
@@ -1005,8 +1005,8 @@ command.add_argument(
 
 ```bash
 myapp --port 50 --port 200 --port 0
-# Warning: '--port' value 200 is out of range [1, 100], clamped to 100
-# Warning: '--port' value 0 is out of range [1, 100], clamped to 1
+# warning: '--port' value 200 is out of range [1, 100], clamped to 100
+# warning: '--port' value 0 is out of range [1, 100], clamped to 1
 # Result: ports = [50, 100, 1]
 ```
 

--- a/examples/demo.mojo
+++ b/examples/demo.mojo
@@ -1,0 +1,287 @@
+"""Example: a feature showcase to demonstrate argmojo capabilities.
+
+This demo is designed to cover features NOT shown in mgrep.mojo (single-
+command) or mgit.mojo (subcommand-based), and to make it easy to try
+them interactively from the command line.
+
+Showcases: count ceiling (.count().max(N)), range clamping (.range().clamp()),
+one-required groups, mutually exclusive groups, required-together groups,
+conditional requirements, negatable flags, color customisation
+(header_color, arg_color), numeric range validation, append with range
+clamping, value delimiter, nargs, key-value map, aliases, deprecated args,
+negative number passthrough, allow_positional_with_subcommands, custom tips,
+and help_on_no_arguments.
+
+Note: This demo looks very strange, but useful :D
+
+Try these (build first with: pixi run package && mojo build -I src -o demo examples/demo.mojo):
+
+  # ── Root command ─────────────────────────────────────────────────────
+  ./demo --help
+  ./demo --version
+
+  # count ceiling: -vvvvv caps at 3
+  ./demo input.txt -vvvvv
+  ./demo input.txt -vv
+
+  # range clamping: --level 20 clamps to 9; --level -5 clamps to 0
+  ./demo input.txt --level 20
+  ./demo input.txt --level -5
+  ./demo input.txt --level 5
+
+  # negatable flag: --color / --no-color
+  ./demo input.txt --color
+  ./demo input.txt --no-color
+
+  # required-together: --host and --port must appear together
+  ./demo input.txt --host localhost --port 8080
+  ./demo input.txt --host localhost           # error: --port required
+
+  # conditional requirement: --output required when --save is set
+  ./demo input.txt --save --output results.json
+  ./demo input.txt --save                     # error: --output required
+
+  # append with range clamping: each --port value clamped to [1, 65535]
+  ./demo input.txt --host localhost --port 80 --port 99999
+
+  # nargs: --point takes exactly 3 values (x y z)
+  ./demo input.txt --point 1.0 2.5 3.7
+
+  # value delimiter: --tags a,b,c splits by comma
+  ./demo input.txt --tags feat,fix,docs
+
+  # key-value map: -D key=value (repeatable)
+  ./demo input.txt -D env=prod -D region=us-east
+
+  # aliases: --colour is an alias for --color-theme
+  ./demo input.txt --colour monokai
+  ./demo input.txt --color-theme dracula
+
+  # deprecated argument: --legacy prints a warning
+  ./demo input.txt --legacy
+
+  # negative number passthrough
+  ./demo -- -42
+
+  # kitchen sink
+  ./demo input.txt -vvvvv --level 20 --color --host 127.0.0.1 --port 80 --port 443 --point 1 2 3 --tags a,b,c -D x=1 -D y=2
+
+  # ── Subcommand: export (one-required + mutually exclusive) ───────────
+  ./demo export --help
+  ./demo export data.csv --json               # ok
+  ./demo export data.csv --json --yaml        # error: mutually exclusive
+  ./demo export data.csv                      # error: one of --json/--yaml/--toml required
+
+  # ── Subcommand: analyze (range clamping on subcommand) ───────────────
+  ./demo analyze --help
+  ./demo analyze data.csv --workers 4 --threshold 95
+  ./demo analyze data.csv --workers 999       # clamped to 32
+"""
+
+from argmojo import Argument, Command
+
+
+fn main() raises:
+    var app = Command(
+        "demo",
+        (
+            "ArgMojo feature showcase — demonstrates capabilities not covered"
+            " by mgrep or mgit."
+        ),
+        version="0.3.0",
+    )
+
+    # ── Color customisation ──────────────────────────────────────────────
+    app.header_color("CYAN")
+    app.arg_color("GREEN")
+
+    # ── Positional arguments ─────────────────────────────────────────────
+    app.add_argument(
+        Argument("input", help="Input file to process")
+        .positional()
+        .default("stdin")
+    )
+
+    # ── Count flag with ceiling ──────────────────────────────────────────
+    # -vvvvv caps at 3; emits a warning when exceeded.
+    app.add_argument(
+        Argument("verbose", help="Increase verbosity (capped at 3)")
+        .long("verbose")
+        .short("v")
+        .count()
+        .max(3)
+    )
+
+    # ── Numeric range with clamping ──────────────────────────────────────
+    # --level 20 → clamped to 9 with a warning; --level -5 → clamped to 0.
+    app.add_argument(
+        Argument("level", help="Processing level [0–9]")
+        .long("level")
+        .short("l")
+        .range(0, 9)
+        .clamp()
+    )
+
+    # ── Negatable flag ───────────────────────────────────────────────────
+    app.add_argument(
+        Argument("color", help="Enable colored output")
+        .long("color")
+        .flag()
+        .negatable()
+    )
+
+    # ── Required-together group ──────────────────────────────────────────
+    # --host and --port must both appear or both be absent.
+    app.add_argument(
+        Argument("host", help="Server hostname")
+        .long("host")
+        .short("H")
+        .metavar("ADDR")
+    )
+    app.add_argument(
+        Argument(
+            "port", help="Server port(s), repeatable, clamped to [1, 65535]"
+        )
+        .long("port")
+        .short("P")
+        .append()
+        .range(1, 65535)
+        .clamp()
+    )
+    var net_group: List[String] = ["host", "port"]
+    app.required_together(net_group^)
+
+    # ── Conditional requirement ──────────────────────────────────────────
+    # --output is required when --save is present.
+    app.add_argument(
+        Argument("save", help="Save results to a file")
+        .long("save")
+        .short("S")
+        .flag()
+    )
+    app.add_argument(
+        Argument("output", help="Output file path (required with --save)")
+        .long("output")
+        .short("o")
+        .metavar("FILE")
+    )
+    app.required_if("output", "save")
+
+    # ── Nargs: consumes exactly 3 values ─────────────────────────────────
+    app.add_argument(
+        Argument("point", help="A 3D point (X Y Z)")
+        .long("point")
+        .number_of_values(3)
+        .metavar("COORD")
+    )
+
+    # ── Value delimiter ──────────────────────────────────────────────────
+    app.add_argument(
+        Argument("tags", help="Comma-separated tags")
+        .long("tags")
+        .short("t")
+        .delimiter(",")
+    )
+
+    # ── Key-value map ────────────────────────────────────────────────────
+    app.add_argument(
+        Argument("define", help="Define a variable (key=value, repeatable)")
+        .long("define")
+        .short("D")
+        .map_option()
+    )
+
+    # ── Aliases ──────────────────────────────────────────────────────────
+    var theme_aliases: List[String] = ["colour"]
+    app.add_argument(
+        Argument("color-theme", help="Color theme name")
+        .long("color-theme")
+        .aliases(theme_aliases^)
+        .default("auto")
+    )
+
+    # ── Deprecated argument ──────────────────────────────────────────────
+    app.add_argument(
+        Argument("legacy", help="Enable legacy mode (deprecated)")
+        .long("legacy")
+        .flag()
+        .deprecated(
+            "Legacy mode will be removed in v1.0; use --level 0 instead"
+        )
+    )
+
+    # ── Hidden argument ──────────────────────────────────────────────────
+    app.add_argument(
+        Argument("debug-internals", help="Dump internal state (debug)")
+        .long("debug-internals")
+        .flag()
+        .hidden()
+    )
+
+    # ── Negative number passthrough ──────────────────────────────────────
+    app.allow_negative_numbers()
+
+    # ── Allow positional args alongside subcommands ──────────────────────
+    app.allow_positional_with_subcommands()
+
+    # ── Custom tips ──────────────────────────────────────────────────────
+    app.add_tip("Count ceiling: try -vvvvv and observe the warning.")
+    app.add_tip("Range clamping: try --level 20 or --level -5.")
+    app.add_tip("Negatable: --color enables, --no-color disables.")
+    app.add_tip("Delimiter: --tags a,b,c splits into [a, b, c].")
+
+    # ── Subcommand: export ───────────────────────────────────────────────
+    # Demonstrates one-required + mutually exclusive on a subcommand.
+    var export = Command("export", "Export data in a chosen format")
+    export.add_argument(
+        Argument("file", help="File to export").positional().required()
+    )
+    export.add_argument(
+        Argument("json", help="Export as JSON").long("json").flag()
+    )
+    export.add_argument(
+        Argument("yaml", help="Export as YAML").long("yaml").flag()
+    )
+    export.add_argument(
+        Argument("toml", help="Export as TOML").long("toml").flag()
+    )
+    var format_group: List[String] = ["json", "yaml", "toml"]
+    export.one_required(format_group.copy())
+    export.mutually_exclusive(format_group^)
+    export.help_on_no_arguments()
+    var export_aliases: List[String] = ["ex"]
+    export.command_aliases(export_aliases^)
+    app.add_subcommand(export^)
+
+    # ── Subcommand: analyze ──────────────────────────────────────────────
+    # Demonstrates range clamping on a subcommand.
+    var analyze = Command("analyze", "Run analysis on input data")
+    analyze.add_argument(
+        Argument("data", help="Data file to analyze").positional().required()
+    )
+    analyze.add_argument(
+        Argument("workers", help="Number of parallel workers [1-32]")
+        .long("workers")
+        .short("w")
+        .range(1, 32)
+        .clamp()
+        .default("4")
+    )
+    analyze.add_argument(
+        Argument("threshold", help="Confidence threshold [0-100]")
+        .long("threshold")
+        .metavar("PCT")
+        .range(0, 100)
+        .clamp()
+    )
+    analyze.help_on_no_arguments()
+    var analyze_aliases: List[String] = ["an"]
+    analyze.command_aliases(analyze_aliases^)
+    app.add_subcommand(analyze^)
+
+    # ── Show help when invoked with no arguments ─────────────────────────
+    app.help_on_no_arguments()
+
+    # ── Parse & display ──────────────────────────────────────────────────
+    var result = app.parse()
+    app.print_summary(result)

--- a/pixi.toml
+++ b/pixi.toml
@@ -41,7 +41,8 @@ test = """\
 # build example binaries
 build = """pixi run package \
 && mojo build -I src examples/mgrep.mojo -o mgrep \
-&& mojo build -I src examples/mgit.mojo -o mgit"""
+&& mojo build -I src examples/mgit.mojo -o mgit \
+&& mojo build -I src examples/demo.mojo -o demo"""
 
 # clean build artifacts
-clean = "rm -f argmojo.mojopkg mgrep mgit"
+clean = "rm -f argmojo.mojopkg mgrep mgit demo"

--- a/src/argmojo/argument.mojo
+++ b/src/argmojo/argument.mojo
@@ -16,115 +16,101 @@ struct Argument(Copyable, Movable, Stringable, Writable):
 
     ```mojo
     from argmojo import Command, Argument
-
     # Boolean flag  →  result.get_flag("verbose")
     _ = Argument("verbose", help="...").long("verbose").short("v").flag()
-
     # Key-value option  →  result.get_string("output")
     _ = Argument("output", help="...").long("output").short("o")
-
     # Key-value with default  →  result.get_string("format")
     _ = Argument("format", help="...").long("format").default("json")
-
     # Restrict to a set of values
     _ = Argument("level", help="...").long("level").choices(["debug","info","warn"])
-
     # Positional (matched by order)  →  result.get_string("path")
     _ = Argument("path", help="...").positional().required()
     _ = Argument("dest", help="...").positional().default(".")
-
     # Count flag  (-vvv → 3)  →  result.get_count("verbose")
     _ = Argument("verbose", help="...").long("verbose").short("v").count()
-
     # Count flag with ceiling  (-vvvvv capped at 3)
     _ = Argument("verbose", help="...").long("verbose").short("v").count().max(3)
-
     # Negatable flag  (--color / --no-color)  →  result.get_flag("color")
     _ = Argument("color", help="...").long("color").flag().negatable()
-
     # Append / collect  (--tag x --tag y → ["x","y"])  →  result.get_list("tag")
     _ = Argument("tag", help="...").long("tag").short("t").append()
-
     # Value delimiter  (--env a,b,c → ["a","b","c"])  →  result.get_list("env")
     _ = Argument("env", help="...").long("env").delimiter(",")
-
     # Multi-value  (--point 1 2 → ["1","2"])  →  result.get_list("point")
     _ = Argument("point", help="...").long("point").number_of_values(2)
-
     # Numeric range validation  →  result.get_int("port")
     _ = Argument("port", help="...").long("port").range(1, 65535)
-
     # Numeric range with clamping  (--level 200 → 100 with warning)
     _ = Argument("level", help="...").long("level").range(0, 100).clamp()
-
     # Key-value map  (--def k=v --def k2=v2)  →  result.get_map("def")
     _ = Argument("def", help="...").long("define").short("D").map_option()
-
     # Aliases  (--colour and --color both work)
     _ = Argument("colour", help="...").long("colour").aliases(["color"])
-
     # Deprecated argument  (still works but prints a warning to stderr)
     _ = Argument("old", help="...").long("old-flag").deprecated("Use --new-flag instead")
-
     # Display helpers
     _ = Argument("file", help="...").long("file").metavar("PATH")  # help: --file PATH
     _ = Argument("internal", help="...").long("internal").hidden()  # hidden from help
     ```
     """
 
+    # === Public fields ===
     var name: String
     """Internal name used to retrieve this argument's value from ParseResult."""
     var help_text: String
     """Help text displayed in usage information."""
-    var long_name: String
+
+    # === Private fields ===
+    var _long_name: String
     """Long option name (e.g., 'output' for --output). Empty if not set."""
-    var short_name: String
+    var _short_name: String
     """Short option name (e.g., 'o' for -o). Empty if not set."""
-    var is_flag: Bool
+    var _is_flag: Bool
     """If True, this argument is a boolean flag that takes no value."""
-    var is_required: Bool
+    var _is_required: Bool
     """If True, parsing fails when this argument is not provided."""
-    var is_positional: Bool
+    var _is_positional: Bool
     """If True, this argument is matched by position rather than by name."""
-    var default_value: String
+    var _default_value: String
     """Default value used when the argument is not provided."""
-    var has_default: Bool
+    var _has_default: Bool
     """Whether a default value has been set."""
-    var choice_values: List[String]
+    var _choice_values: List[String]
     """Allowed values for this argument. Empty means any value is accepted."""
-    var metavar_name: String
+    var _metavar_name: String
     """Display name for the value in help text (e.g., 'FILE' for --output FILE)."""
-    var is_hidden: Bool
+    var _is_hidden: Bool
     """If True, this argument is not shown in help output."""
-    var is_count: Bool
+    var _is_count: Bool
     """If True, each occurrence increments a counter (e.g., -vvv → 3)."""
-    var is_negatable: Bool
+    var _is_negatable: Bool
     """If True, this flag also accepts --no-X to set it to False."""
-    var is_append: Bool
+    var _is_append: Bool
     """If True, repeated uses collect values into a list (e.g., --tag x --tag y)."""
-    var delimiter_char: String
+    var _delimiter_char: String
     """If non-empty, each value is split by this delimiter into multiple list entries."""
-    var num_values: Int
+    var _number_of_values: Int
     """Number of values to consume per occurrence (0 means single-value mode)."""
-    var range_min: Int
+    var _range_min: Int
     """Minimum allowed value (inclusive) for numeric range validation."""
-    var range_max: Int
+    var _range_max: Int
     """Maximum allowed value (inclusive) for numeric range validation."""
-    var has_range: Bool
+    var _has_range: Bool
     """Whether numeric range validation is active."""
-    var is_clamp: Bool
+    var _is_clamp: Bool
     """If True, out-of-range values are clamped (adjusted with warning) instead of rejected."""
-    var is_map: Bool
+    var _is_map: Bool
     """If True, each value is parsed as key=value and stored in a Dict."""
-    var alias_names: List[String]
+    var _alias_names: List[String]
     """Alternative long names that resolve to this argument."""
-    var deprecated_msg: String
+    var _deprecated_msg: String
     """If non-empty, this argument is deprecated; the string is the warning message."""
-    var count_max: Int
+    var _count_max: Int
     """Maximum count value (ceiling) for counter flags. 0 means no limit."""
-    var has_count_max: Bool
+    var _has_count_max: Bool
     """Whether a count ceiling has been set via ``.max()``."""
-    var is_persistent: Bool
+    var _is_persistent: Bool
     """If True, this argument is automatically inherited by every subcommand.
     Persistent flags/options are injected into child command parsers at
     dispatch time so the user may place them either before or after the
@@ -143,31 +129,31 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         """
         self.name = name
         self.help_text = help
-        self.long_name = ""
-        self.short_name = ""
-        self.is_flag = False
-        self.is_required = False
-        self.is_positional = False
-        self.default_value = ""
-        self.has_default = False
-        self.choice_values = List[String]()
-        self.metavar_name = ""
-        self.is_hidden = False
-        self.is_count = False
-        self.is_negatable = False
-        self.is_append = False
-        self.delimiter_char = ""
-        self.num_values = 0
-        self.range_min = 0
-        self.range_max = 0
-        self.has_range = False
-        self.is_clamp = False
-        self.is_map = False
-        self.alias_names = List[String]()
-        self.deprecated_msg = ""
-        self.count_max = 0
-        self.has_count_max = False
-        self.is_persistent = False
+        self._long_name = ""
+        self._short_name = ""
+        self._is_flag = False
+        self._is_required = False
+        self._is_positional = False
+        self._default_value = ""
+        self._has_default = False
+        self._choice_values = List[String]()
+        self._metavar_name = ""
+        self._is_hidden = False
+        self._is_count = False
+        self._is_negatable = False
+        self._is_append = False
+        self._delimiter_char = ""
+        self._number_of_values = 0
+        self._range_min = 0
+        self._range_max = 0
+        self._has_range = False
+        self._is_clamp = False
+        self._is_map = False
+        self._alias_names = List[String]()
+        self._deprecated_msg = ""
+        self._count_max = 0
+        self._has_count_max = False
+        self._is_persistent = False
 
     fn __copyinit__(out self, copy: Self):
         """Creates a copy of this argument.
@@ -177,35 +163,35 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         """
         self.name = copy.name
         self.help_text = copy.help_text
-        self.long_name = copy.long_name
-        self.short_name = copy.short_name
-        self.is_flag = copy.is_flag
-        self.is_required = copy.is_required
-        self.is_positional = copy.is_positional
-        self.default_value = copy.default_value
-        self.has_default = copy.has_default
-        self.choice_values = List[String]()
-        for i in range(len(copy.choice_values)):
-            self.choice_values.append(copy.choice_values[i])
-        self.metavar_name = copy.metavar_name
-        self.is_hidden = copy.is_hidden
-        self.is_count = copy.is_count
-        self.is_negatable = copy.is_negatable
-        self.is_append = copy.is_append
-        self.delimiter_char = copy.delimiter_char
-        self.num_values = copy.num_values
-        self.range_min = copy.range_min
-        self.range_max = copy.range_max
-        self.has_range = copy.has_range
-        self.is_clamp = copy.is_clamp
-        self.is_map = copy.is_map
-        self.alias_names = List[String]()
-        for i in range(len(copy.alias_names)):
-            self.alias_names.append(copy.alias_names[i])
-        self.deprecated_msg = copy.deprecated_msg
-        self.count_max = copy.count_max
-        self.has_count_max = copy.has_count_max
-        self.is_persistent = copy.is_persistent
+        self._long_name = copy._long_name
+        self._short_name = copy._short_name
+        self._is_flag = copy._is_flag
+        self._is_required = copy._is_required
+        self._is_positional = copy._is_positional
+        self._default_value = copy._default_value
+        self._has_default = copy._has_default
+        self._choice_values = List[String]()
+        for i in range(len(copy._choice_values)):
+            self._choice_values.append(copy._choice_values[i])
+        self._metavar_name = copy._metavar_name
+        self._is_hidden = copy._is_hidden
+        self._is_count = copy._is_count
+        self._is_negatable = copy._is_negatable
+        self._is_append = copy._is_append
+        self._delimiter_char = copy._delimiter_char
+        self._number_of_values = copy._number_of_values
+        self._range_min = copy._range_min
+        self._range_max = copy._range_max
+        self._has_range = copy._has_range
+        self._is_clamp = copy._is_clamp
+        self._is_map = copy._is_map
+        self._alias_names = List[String]()
+        for i in range(len(copy._alias_names)):
+            self._alias_names.append(copy._alias_names[i])
+        self._deprecated_msg = copy._deprecated_msg
+        self._count_max = copy._count_max
+        self._has_count_max = copy._has_count_max
+        self._is_persistent = copy._is_persistent
 
     fn __moveinit__(out self, deinit move: Self):
         """Moves the value from another Argument.
@@ -215,31 +201,31 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         """
         self.name = move.name^
         self.help_text = move.help_text^
-        self.long_name = move.long_name^
-        self.short_name = move.short_name^
-        self.is_flag = move.is_flag
-        self.is_required = move.is_required
-        self.is_positional = move.is_positional
-        self.default_value = move.default_value^
-        self.has_default = move.has_default
-        self.choice_values = move.choice_values^
-        self.metavar_name = move.metavar_name^
-        self.is_hidden = move.is_hidden
-        self.is_count = move.is_count
-        self.is_negatable = move.is_negatable
-        self.is_append = move.is_append
-        self.delimiter_char = move.delimiter_char^
-        self.num_values = move.num_values
-        self.range_min = move.range_min
-        self.range_max = move.range_max
-        self.has_range = move.has_range
-        self.is_clamp = move.is_clamp
-        self.is_map = move.is_map
-        self.alias_names = move.alias_names^
-        self.deprecated_msg = move.deprecated_msg^
-        self.count_max = move.count_max
-        self.has_count_max = move.has_count_max
-        self.is_persistent = move.is_persistent
+        self._long_name = move._long_name^
+        self._short_name = move._short_name^
+        self._is_flag = move._is_flag
+        self._is_required = move._is_required
+        self._is_positional = move._is_positional
+        self._default_value = move._default_value^
+        self._has_default = move._has_default
+        self._choice_values = move._choice_values^
+        self._metavar_name = move._metavar_name^
+        self._is_hidden = move._is_hidden
+        self._is_count = move._is_count
+        self._is_negatable = move._is_negatable
+        self._is_append = move._is_append
+        self._delimiter_char = move._delimiter_char^
+        self._number_of_values = move._number_of_values
+        self._range_min = move._range_min
+        self._range_max = move._range_max
+        self._has_range = move._has_range
+        self._is_clamp = move._is_clamp
+        self._is_map = move._is_map
+        self._alias_names = move._alias_names^
+        self._deprecated_msg = move._deprecated_msg^
+        self._count_max = move._count_max
+        self._has_count_max = move._has_count_max
+        self._is_persistent = move._is_persistent
 
     # ===------------------------------------------------------------------=== #
     # Builder methods for configuring the argument
@@ -254,7 +240,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         Returns:
             Self with the long name set.
         """
-        self.long_name = name
+        self._long_name = name
         return self^
 
     fn short(var self, name: String) -> Self:
@@ -266,7 +252,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         Returns:
             Self with the short name set.
         """
-        self.short_name = name
+        self._short_name = name
         return self^
 
     fn flag(var self) -> Self:
@@ -280,7 +266,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
             For example --verbose would set a 'verbose' flag to True, while its
             absence leaves it False.
         """
-        self.is_flag = True
+        self._is_flag = True
         return self^
 
     fn required(var self) -> Self:
@@ -293,7 +279,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
             Required arguments must be provided in the input; otherwise, parsing
             will fail.
         """
-        self.is_required = True
+        self._is_required = True
         return self^
 
     fn positional(var self) -> Self:
@@ -302,7 +288,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         Returns:
             Self marked as positional.
         """
-        self.is_positional = True
+        self._is_positional = True
         return self^
 
     fn takes_value(var self) -> Self:
@@ -311,9 +297,9 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         This is the default behavior; use this for clarity when needed.
 
         Returns:
-            Self with is_flag set to False.
+            Self with _is_flag set to False.
         """
-        self.is_flag = False
+        self._is_flag = False
         return self^
 
     fn default(var self, value: String) -> Self:
@@ -325,8 +311,8 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         Returns:
             Self with the default value set.
         """
-        self.default_value = value
-        self.has_default = True
+        self._default_value = value
+        self._has_default = True
         return self^
 
     fn choices(var self, var values: List[String]) -> Self:
@@ -338,7 +324,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         Returns:
             Self with the choices set.
         """
-        self.choice_values = values^
+        self._choice_values = values^
         return self^
 
     fn metavar(var self, name: String) -> Self:
@@ -353,7 +339,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         Returns:
             Self with the metavar set.
         """
-        self.metavar_name = name
+        self._metavar_name = name
         return self^
 
     fn hidden(var self) -> Self:
@@ -362,7 +348,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         Returns:
             Self marked as hidden.
         """
-        self.is_hidden = True
+        self._is_hidden = True
         return self^
 
     fn count(var self) -> Self:
@@ -376,8 +362,8 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         Returns:
             Self marked as a counter.
         """
-        self.is_count = True
-        self.is_flag = True
+        self._is_count = True
+        self._is_flag = True
         return self^
 
     fn max(var self, ceiling: Int) -> Self:
@@ -404,7 +390,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
                 file=stderr,
             )
             exit(1)
-        if not self.is_count:
+        if not self._is_count:
             print(
                 (
                     "Argument.max(): can only be used after .count(); call"
@@ -413,8 +399,8 @@ struct Argument(Copyable, Movable, Stringable, Writable):
                 file=stderr,
             )
             exit(1)
-        self.count_max = ceiling
-        self.has_count_max = True
+        self._count_max = ceiling
+        self._has_count_max = True
         return self^
 
     fn negatable(var self) -> Self:
@@ -427,7 +413,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         Returns:
             Self marked as negatable.
         """
-        self.is_negatable = True
+        self._is_negatable = True
         return self^
 
     fn append(var self) -> Self:
@@ -440,7 +426,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         Returns:
             Self marked as append.
         """
-        self.is_append = True
+        self._is_append = True
         return self^
 
     # TODO: Allow auto-translating full-width punctuation to ASCII for delimiter.
@@ -462,8 +448,8 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         Returns:
             Self with the delimiter and append mode set.
         """
-        self.delimiter_char = sep
-        self.is_append = True
+        self._delimiter_char = sep
+        self._is_append = True
         return self^
 
     fn number_of_values(var self, n: Int) -> Self:
@@ -479,10 +465,10 @@ struct Argument(Copyable, Movable, Stringable, Writable):
             n: Number of values to consume (must be ≥ 2).
 
         Returns:
-            Self with num_values and append mode set.
+            Self with _number_of_values and append mode set.
         """
-        self.num_values = n
-        self.is_append = True
+        self._number_of_values = n
+        self._is_append = True
         return self^
 
     fn range(var self, min_val: Int, max_val: Int) -> Self:
@@ -503,9 +489,9 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         Returns:
             Self with range validation enabled.
         """
-        self.range_min = min_val
-        self.range_max = max_val
-        self.has_range = True
+        self._range_min = min_val
+        self._range_max = max_val
+        self._has_range = True
         return self^
 
     fn clamp(var self) -> Self:
@@ -524,7 +510,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         Returns:
             Self with clamping enabled.
         """
-        self.is_clamp = True
+        self._is_clamp = True
         return self^
 
     fn map_option(var self) -> Self:
@@ -540,8 +526,8 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         Returns:
             Self marked as a map option.
         """
-        self.is_map = True
-        self.is_append = True
+        self._is_map = True
+        self._is_append = True
         return self^
 
     fn aliases(var self, var names: List[String]) -> Self:
@@ -557,7 +543,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         Returns:
             Self with aliases registered.
         """
-        self.alias_names = names^
+        self._alias_names = names^
         return self^
 
     fn deprecated(var self, message: String) -> Self:
@@ -572,7 +558,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         Returns:
             Self marked as deprecated.
         """
-        self.deprecated_msg = message
+        self._deprecated_msg = message
         return self^
 
     fn persistent(var self) -> Self:
@@ -591,14 +577,14 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         The child result also carries the value when the flag appears
         after the subcommand token.
 
-        Persistent arguments may not share a ``long_name`` or ``short_name``
+        Persistent arguments may not share a ``_long_name`` or ``_short_name``
         with any local argument of a registered subcommand — ArgMojo raises
         an error at ``add_subcommand()`` time if a conflict is detected.
 
         Returns:
             Self marked as persistent.
         """
-        self.is_persistent = True
+        self._is_persistent = True
         return self^
 
     # ===------------------------------------------------------------------=== #
@@ -608,15 +594,15 @@ struct Argument(Copyable, Movable, Stringable, Writable):
     fn __str__(self) -> String:
         """Returns a string representation of this argument definition."""
         var s = String("Argument(name='") + self.name + "'"
-        if self.long_name:
-            s += ", long='--" + self.long_name + "'"
-        if self.short_name:
-            s += ", short='-" + self.short_name + "'"
-        if self.is_flag:
+        if self._long_name:
+            s += ", long='--" + self._long_name + "'"
+        if self._short_name:
+            s += ", short='-" + self._short_name + "'"
+        if self._is_flag:
             s += ", flag"
-        if self.is_positional:
+        if self._is_positional:
             s += ", positional"
-        if self.is_required:
+        if self._is_required:
             s += ", required"
         s += ")"
         return s
@@ -633,18 +619,18 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         writer.write("Argument(name='")
         writer.write(self.name)
         writer.write("'")
-        if self.long_name:
+        if self._long_name:
             writer.write(", long='--")
-            writer.write(self.long_name)
+            writer.write(self._long_name)
             writer.write("'")
-        if self.short_name:
+        if self._short_name:
             writer.write(", short='-")
-            writer.write(self.short_name)
+            writer.write(self._short_name)
             writer.write("'")
-        if self.is_flag:
+        if self._is_flag:
             writer.write(", flag")
-        if self.is_positional:
+        if self._is_positional:
             writer.write(", positional")
-        if self.is_required:
+        if self._is_required:
             writer.write(", required")
         writer.write(")")

--- a/src/argmojo/argument.mojo
+++ b/src/argmojo/argument.mojo
@@ -1,5 +1,7 @@
 """Defines a single command-line argument."""
 
+from sys import exit, stderr
+
 
 comptime Arg = Argument
 """Shorthand alias for ``Argument``."""
@@ -393,6 +395,24 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         Returns:
             Self with the count ceiling set.
         """
+        if ceiling < 1:
+            print(
+                (
+                    "Argument.max(): ceiling must be >= 1; call .max() with"
+                    " a value of at least 1."
+                ),
+                file=stderr,
+            )
+            exit(1)
+        if not self.is_count:
+            print(
+                (
+                    "Argument.max(): can only be used after .count(); call"
+                    " .count() before .max()."
+                ),
+                file=stderr,
+            )
+            exit(1)
         self.count_max = ceiling
         self.has_count_max = True
         return self^

--- a/src/argmojo/argument.mojo
+++ b/src/argmojo/argument.mojo
@@ -473,7 +473,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         consecutive arguments.  For example, ``.number_of_values(2)`` on
         ``--point`` causes ``--point 1 2`` to collect ``["1", "2"]``.
         Implies ``.append()`` so values are stored in
-        ``ParseResult.lists``.
+        ``ParseResult._lists``.
 
         Args:
             n: Number of values to consume (must be ≥ 2).
@@ -531,7 +531,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         """Marks this argument as a key-value map option.
 
         Each value must be in ``key=value`` format.  Values are
-        stored in ``ParseResult.maps`` and retrieved with
+        stored in ``ParseResult._maps`` and retrieved with
         ``get_map()``.  Implies ``.append()`` for repeated uses.
 
         For example, ``--define DEBUG=1 --define VERSION=2`` produces

--- a/src/argmojo/argument.mojo
+++ b/src/argmojo/argument.mojo
@@ -78,7 +78,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
     """Whether a default value has been set."""
     var _choice_values: List[String]
     """Allowed values for this argument. Empty means any value is accepted."""
-    var _metavar_name: String
+    var _metavar: String
     """Display name for the value in help text (e.g., 'FILE' for --output FILE)."""
     var _is_hidden: Bool
     """If True, this argument is not shown in help output."""
@@ -137,7 +137,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         self._default_value = ""
         self._has_default = False
         self._choice_values = List[String]()
-        self._metavar_name = ""
+        self._metavar = ""
         self._is_hidden = False
         self._is_count = False
         self._is_negatable = False
@@ -173,7 +173,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         self._choice_values = List[String]()
         for i in range(len(copy._choice_values)):
             self._choice_values.append(copy._choice_values[i])
-        self._metavar_name = copy._metavar_name
+        self._metavar = copy._metavar
         self._is_hidden = copy._is_hidden
         self._is_count = copy._is_count
         self._is_negatable = copy._is_negatable
@@ -209,7 +209,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         self._default_value = move._default_value^
         self._has_default = move._has_default
         self._choice_values = move._choice_values^
-        self._metavar_name = move._metavar_name^
+        self._metavar = move._metavar^
         self._is_hidden = move._is_hidden
         self._is_count = move._is_count
         self._is_negatable = move._is_negatable
@@ -339,7 +339,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         Returns:
             Self with the metavar set.
         """
-        self._metavar_name = name
+        self._metavar = name
         return self^
 
     fn hidden(var self) -> Self:

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -2271,8 +2271,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
                     var ncount = self.args[i]._number_of_values
                     var repeat = ncount if ncount > 0 else 1
                     var append_dots = self.args[i]._is_append and ncount == 0
-                    if self.args[i]._metavar_name:
-                        var mv = self.args[i]._metavar_name
+                    if self.args[i]._metavar:
+                        var mv = self.args[i]._metavar
                         var mv_plain = String("")
                         var mv_colored = String("")
                         for _r in range(repeat - 1):
@@ -3088,9 +3088,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                         choices += arg._choice_values[k]
                     spec += ":value:(" + choices + ")"
                 else:
-                    var mv = (
-                        arg._metavar_name if arg._metavar_name else arg.name
-                    )
+                    var mv = arg._metavar if arg._metavar else arg.name
                     spec += ":" + mv + ":"
             spec += "'"
         else:
@@ -3103,9 +3101,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                         choices += arg._choice_values[k]
                     spec += "[" + desc + "]:value:(" + choices + ")'"
                 else:
-                    var mv = (
-                        arg._metavar_name if arg._metavar_name else arg.name
-                    )
+                    var mv = arg._metavar if arg._metavar else arg.name
                     spec += "[" + desc + "]:" + mv + ":'"
             else:
                 spec += "[" + desc + "]'"

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -30,6 +30,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
     ```
     """
 
+    # === Public fields ===
     var name: String
     """The command name (typically the program name)."""
     var description: String
@@ -40,6 +41,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
     """Registered argument definitions."""
     var subcommands: List[Command]
     """Registered subcommand definitions. Each is a full Command instance."""
+
+    # === Private fields ===
     var _exclusive_groups: List[List[String]]
     """Groups of mutually exclusive argument names."""
     var _required_groups: List[List[String]]
@@ -937,7 +940,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 continue
 
             if stop_parsing_options:
-                result.positionals.append(arg)
+                result._positionals.append(arg)
                 i += 1
                 continue
 
@@ -994,7 +997,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                             has_digit_short = True
                             break
                     if self._allow_negative_numbers or not has_digit_short:
-                        result.positionals.append(arg)
+                        result._positionals.append(arg)
                         i += 1
                         continue
                 # ────────────────────────────────────────────────────────────
@@ -1033,7 +1036,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                     i = new_i
                     continue
 
-            result.positionals.append(arg)
+            result._positionals.append(arg)
             i += 1
 
         # Apply defaults and validate constraints.
@@ -1126,17 +1129,17 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 "'--" + key + "' is deprecated: " + matched.deprecated_msg
             )
         if is_negation:
-            result.flags[matched.name] = False
+            result._flags[matched.name] = False
         elif matched.is_count and not has_eq:
             # Count flag: increment counter.
             var cur: Int = 0
             try:
-                cur = result.counts[matched.name]
+                cur = result._counts[matched.name]
             except:
                 pass
-            result.counts[matched.name] = cur + 1
+            result._counts[matched.name] = cur + 1
         elif matched.is_flag and not has_eq:
-            result.flags[matched.name] = True
+            result._flags[matched.name] = True
         elif matched.num_values > 0:
             # nargs: consume exactly N values.
             if has_eq:
@@ -1147,8 +1150,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
                     + String(matched.num_values)
                     + " values; '=' syntax is not supported"
                 )
-            if matched.name not in result.lists:
-                result.lists[matched.name] = List[String]()
+            if matched.name not in result._lists:
+                result._lists[matched.name] = List[String]()
             for _n in range(matched.num_values):
                 i += 1
                 if i >= len(raw_args):
@@ -1160,7 +1163,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                         + " values"
                     )
                 self._validate_choices(matched, raw_args[i])
-                result.lists[matched.name].append(raw_args[i])
+                result._lists[matched.name].append(raw_args[i])
         else:
             if not has_eq:
                 i += 1
@@ -1173,7 +1176,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 self._store_append_value(matched, value, result)
             else:
                 self._validate_choices(matched, value)
-                result.values[matched.name] = value
+                result._values[matched.name] = value
         i += 1
         return i
 
@@ -1205,16 +1208,16 @@ struct Command(Copyable, Movable, Stringable, Writable):
         if matched.is_count:
             var cur: Int = 0
             try:
-                cur = result.counts[matched.name]
+                cur = result._counts[matched.name]
             except:
                 pass
-            result.counts[matched.name] = cur + 1
+            result._counts[matched.name] = cur + 1
         elif matched.is_flag:
-            result.flags[matched.name] = True
+            result._flags[matched.name] = True
         elif matched.num_values > 0:
             # nargs: consume exactly N values.
-            if matched.name not in result.lists:
-                result.lists[matched.name] = List[String]()
+            if matched.name not in result._lists:
+                result._lists[matched.name] = List[String]()
             for _n in range(matched.num_values):
                 i += 1
                 if i >= len(raw_args):
@@ -1226,7 +1229,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                         + " values"
                     )
                 self._validate_choices(matched, raw_args[i])
-                result.lists[matched.name].append(raw_args[i])
+                result._lists[matched.name].append(raw_args[i])
         else:
             i += 1
             if i >= len(raw_args):
@@ -1238,7 +1241,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 self._store_append_value(matched, val, result)
             else:
                 self._validate_choices(matched, val)
-                result.values[matched.name] = val
+                result._values[matched.name] = val
         i += 1
         return i
 
@@ -1287,19 +1290,19 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 if m.is_count:
                     var cur: Int = 0
                     try:
-                        cur = result.counts[m.name]
+                        cur = result._counts[m.name]
                     except:
                         pass
-                    result.counts[m.name] = cur + 1
+                    result._counts[m.name] = cur + 1
                     j += 1
                 elif m.is_flag:
-                    result.flags[m.name] = True
+                    result._flags[m.name] = True
                     j += 1
                 elif m.num_values > 0:
                     # nargs in merged flags: rest of string is
                     # ignored; consume N values from argv.
-                    if m.name not in result.lists:
-                        result.lists[m.name] = List[String]()
+                    if m.name not in result._lists:
+                        result._lists[m.name] = List[String]()
                     for _n in range(m.num_values):
                         i += 1
                         if i >= len(raw_args):
@@ -1311,7 +1314,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                                 + " values"
                             )
                         self._validate_choices(m, raw_args[i])
-                        result.lists[m.name].append(raw_args[i])
+                        result._lists[m.name].append(raw_args[i])
                     j = len(key)  # break
                 else:
                     # This char takes a value — rest of string is
@@ -1328,7 +1331,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                         self._store_append_value(m, val, result)
                     else:
                         self._validate_choices(m, val)
-                        result.values[m.name] = val
+                        result._values[m.name] = val
                     j = len(key)  # break
         else:
             # First char takes a value — rest of string is the
@@ -1343,8 +1346,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 )
             if first_match.num_values > 0:
                 # nargs: consume N values from argv (ignore attached).
-                if first_match.name not in result.lists:
-                    result.lists[first_match.name] = List[String]()
+                if first_match.name not in result._lists:
+                    result._lists[first_match.name] = List[String]()
                 for _n in range(first_match.num_values):
                     i += 1
                     if i >= len(raw_args):
@@ -1356,7 +1359,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                             + " values"
                         )
                     self._validate_choices(first_match, raw_args[i])
-                    result.lists[first_match.name].append(raw_args[i])
+                    result._lists[first_match.name].append(raw_args[i])
             elif first_match.is_map:
                 var val = String(key[1:])
                 self._store_map_value(first_match, val, result)
@@ -1366,7 +1369,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
             else:
                 var val = String(key[1:])
                 self._validate_choices(first_match, val)
-                result.values[first_match.name] = val
+                result._values[first_match.name] = val
         i += 1
         return i
 
@@ -1439,19 +1442,19 @@ struct Command(Copyable, Movable, Stringable, Writable):
                     continue
                 var _pn = self.args[_pi].name
                 # Bubble up: child parsed flag after subcommand token.
-                if _pn in child_result.flags and _pn not in result.flags:
-                    result.flags[_pn] = child_result.flags[_pn]
-                if _pn in child_result.values and _pn not in result.values:
-                    result.values[_pn] = child_result.values[_pn]
-                if _pn in child_result.counts and _pn not in result.counts:
-                    result.counts[_pn] = child_result.counts[_pn]
+                if _pn in child_result._flags and _pn not in result._flags:
+                    result._flags[_pn] = child_result._flags[_pn]
+                if _pn in child_result._values and _pn not in result._values:
+                    result._values[_pn] = child_result._values[_pn]
+                if _pn in child_result._counts and _pn not in result._counts:
+                    result._counts[_pn] = child_result._counts[_pn]
                 # Push down: root parsed flag before subcommand token.
-                if _pn in result.flags and _pn not in child_result.flags:
-                    child_result.flags[_pn] = result.flags[_pn]
-                if _pn in result.values and _pn not in child_result.values:
-                    child_result.values[_pn] = result.values[_pn]
-                if _pn in result.counts and _pn not in child_result.counts:
-                    child_result.counts[_pn] = result.counts[_pn]
+                if _pn in result._flags and _pn not in child_result._flags:
+                    child_result._flags[_pn] = result._flags[_pn]
+                if _pn in result._values and _pn not in child_result._values:
+                    child_result._values[_pn] = result._values[_pn]
+                if _pn in result._counts and _pn not in child_result._counts:
+                    child_result._counts[_pn] = result._counts[_pn]
             result.subcommand = canon
             result._subcommand_results.append(child_result^)
             # All remaining tokens were consumed by the child.
@@ -1510,7 +1513,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         """Fills in default values for arguments not provided by the user.
 
         For positional arguments, defaults are placed into the correct slot.
-        For named arguments, the default is stored in ``result.values``.
+        For named arguments, the default is stored in ``result._values``.
 
         Args:
             result: The parse result to mutate in-place.
@@ -1526,12 +1529,12 @@ struct Command(Copyable, Movable, Stringable, Writable):
                     # Fill positional to the right slot.
                     for k in range(len(result._positional_names)):
                         if result._positional_names[k] == a.name:
-                            while len(result.positionals) <= k:
-                                result.positionals.append("")
-                            if not result.positionals[k]:
-                                result.positionals[k] = a.default_value
+                            while len(result._positionals) <= k:
+                                result._positionals.append("")
+                            if not result._positionals[k]:
+                                result._positionals[k] = a.default_value
                 else:
-                    result.values[a.name] = a.default_value
+                    result._values[a.name] = a.default_value
 
     fn _validate(self, mut result: ParseResult) raises:
         """Runs all post-parse validation checks on the result.
@@ -1562,12 +1565,12 @@ struct Command(Copyable, Movable, Stringable, Writable):
 
         # Validate positional argument count — too many args is an error.
         var expected_count: Int = len(result._positional_names)
-        if expected_count > 0 and len(result.positionals) > expected_count:
+        if expected_count > 0 and len(result._positionals) > expected_count:
             self._error_with_usage(
                 "Too many positional arguments: expected "
                 + String(expected_count)
                 + ", got "
-                + String(len(result.positionals))
+                + String(len(result._positionals))
             )
 
         # Validate mutually exclusive groups.
@@ -1654,7 +1657,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
             if a.is_count and a.has_count_max:
                 var cur: Int
                 try:
-                    cur = result.counts[a.name]
+                    cur = result._counts[a.name]
                 except:
                     continue
                 if cur > a.count_max:
@@ -1667,7 +1670,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                         + ", capped to "
                         + String(a.count_max)
                     )
-                    result.counts[a.name] = a.count_max
+                    result._counts[a.name] = a.count_max
 
         # Validate numeric range constraints.
         for j in range(len(self.args)):
@@ -1709,7 +1712,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                                     + "], clamped to "
                                     + String(clamped)
                                 )
-                                result.lists[a.name][k] = String(clamped)
+                                result._lists[a.name][k] = String(clamped)
                             else:
                                 self._error(
                                     "Value "
@@ -1759,11 +1762,13 @@ struct Command(Copyable, Movable, Stringable, Writable):
                                 + "], clamped to "
                                 + String(clamped)
                             )
-                            result.values[a.name] = String(clamped)
+                            result._values[a.name] = String(clamped)
                             if a.is_positional:
                                 for pi in range(len(result._positional_names)):
                                     if result._positional_names[pi] == a.name:
-                                        result.positionals[pi] = String(clamped)
+                                        result._positionals[pi] = String(
+                                            clamped
+                                        )
                                         break
                         else:
                             self._error(
@@ -1980,18 +1985,18 @@ struct Command(Copyable, Movable, Stringable, Writable):
             value: The raw value string.
             result: The ParseResult to store into.
         """
-        if arg.name not in result.lists:
-            result.lists[arg.name] = List[String]()
+        if arg.name not in result._lists:
+            result._lists[arg.name] = List[String]()
         if arg.delimiter_char:
             var parts = value.split(arg.delimiter_char)
             for p in range(len(parts)):
                 var piece = String(parts[p])
                 if piece:  # skip empty pieces from e.g. trailing comma
                     self._validate_choices(arg, piece)
-                    result.lists[arg.name].append(piece)
+                    result._lists[arg.name].append(piece)
         else:
             self._validate_choices(arg, value)
-            result.lists[arg.name].append(value)
+            result._lists[arg.name].append(value)
 
     fn _store_map_value(
         self, arg: Argument, value: String, mut result: ParseResult
@@ -2007,11 +2012,11 @@ struct Command(Copyable, Movable, Stringable, Writable):
             value: The raw value string (e.g., "key=value").
             result: The ParseResult to store into.
         """
-        if arg.name not in result.maps:
-            result.maps[arg.name] = Dict[String, String]()
+        if arg.name not in result._maps:
+            result._maps[arg.name] = Dict[String, String]()
         # Also store in lists for has() detection.
-        if arg.name not in result.lists:
-            result.lists[arg.name] = List[String]()
+        if arg.name not in result._lists:
+            result._lists[arg.name] = List[String]()
 
         if arg.delimiter_char:
             var parts = value.split(arg.delimiter_char)
@@ -2029,8 +2034,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
                         )
                     var k = String(piece[:eq])
                     var v = String(piece[eq + 1 :])
-                    result.maps[arg.name][k] = v
-                    result.lists[arg.name].append(piece)
+                    result._maps[arg.name][k] = v
+                    result._lists[arg.name].append(piece)
         else:
             var eq = value.find("=")
             if eq < 0:
@@ -2043,8 +2048,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 )
             var k = String(value[:eq])
             var v = String(value[eq + 1 :])
-            result.maps[arg.name][k] = v
-            result.lists[arg.name].append(value)
+            result._maps[arg.name][k] = v
+            result._lists[arg.name].append(value)
 
     fn _generate_help(self, color: Bool = True) -> String:
         """Generates a help message from registered arguments.
@@ -2604,7 +2609,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
             elif self.args[i].is_flag:
                 val_str = String(result.get_flag(self.args[i].name))
             elif self.args[i].is_map:
-                if self.args[i].name in result.maps:
+                if self.args[i].name in result._maps:
                     var m = result.get_map(self.args[i].name)
                     var s = String("{")
                     var first = True

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -248,7 +248,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         """
         # Guard: positional args + subcommands require explicit opt-in.
         if (
-            argument.is_positional
+            argument._is_positional
             and len(self.subcommands) > 0
             and not self._allow_positional_with_subcommands
         ):
@@ -297,7 +297,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         # Guard: subcommands + positional args require explicit opt-in.
         if not self._allow_positional_with_subcommands:
             for _pi in range(len(self.args)):
-                if self.args[_pi].is_positional:
+                if self.args[_pi]._is_positional:
                     self._error(
                         "Cannot add subcommand '"
                         + sub.name
@@ -312,39 +312,39 @@ struct Command(Copyable, Movable, Stringable, Writable):
         # any local arg in the child — that would make the option ambiguous
         # after injection.
         for pi in range(len(self.args)):
-            if not self.args[pi].is_persistent:
+            if not self.args[pi]._is_persistent:
                 continue
             var pa = self.args[pi].copy()
             for ci in range(len(sub.args)):
                 var ca = sub.args[ci].copy()
                 if (
-                    pa.long_name
-                    and ca.long_name
-                    and pa.long_name == ca.long_name
+                    pa._long_name
+                    and ca._long_name
+                    and pa._long_name == ca._long_name
                 ):
                     self._error(
                         "Persistent flag '--"
-                        + pa.long_name
+                        + pa._long_name
                         + "' on '"
                         + self.name
                         + "' conflicts with '--"
-                        + ca.long_name
+                        + ca._long_name
                         + "' on subcommand '"
                         + sub.name
                         + "'"
                     )
                 if (
-                    pa.short_name
-                    and ca.short_name
-                    and pa.short_name == ca.short_name
+                    pa._short_name
+                    and ca._short_name
+                    and pa._short_name == ca._short_name
                 ):
                     self._error(
                         "Persistent flag '-"
-                        + pa.short_name
+                        + pa._short_name
                         + "' on '"
                         + self.name
                         + "' conflicts with '-"
-                        + ca.short_name
+                        + ca._short_name
                         + "' on subcommand '"
                         + sub.name
                         + "'"
@@ -810,8 +810,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
         """
         var s = String("Usage: ") + self.name
         for i in range(len(self.args)):
-            if self.args[i].is_positional and not self.args[i].is_hidden:
-                if self.args[i].is_required:
+            if self.args[i]._is_positional and not self.args[i]._is_hidden:
+                if self.args[i]._is_required:
                     s += " <" + self.args[i].name + ">"
                 else:
                     s += " [" + self.args[i].name + "]"
@@ -916,7 +916,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
 
         # Register positional argument names in order.
         for i in range(len(self.args)):
-            if self.args[i].is_positional:
+            if self.args[i]._is_positional:
                 result._positional_names.append(self.args[i].name)
 
         # Skip argv[0] and start from argv[1].
@@ -992,7 +992,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 if _looks_like_number(arg):
                     var has_digit_short = False
                     for _ni in range(len(self.args)):
-                        var sn = self.args[_ni].short_name
+                        var sn = self.args[_ni]._short_name
                         if sn >= "0" and sn <= "9":
                             has_digit_short = True
                             break
@@ -1088,8 +1088,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
             # Exact match first.
             for idx in range(len(self.args)):
                 if (
-                    self.args[idx].long_name == base_key
-                    and self.args[idx].is_negatable
+                    self.args[idx]._long_name == base_key
+                    and self.args[idx]._is_negatable
                 ):
                     is_negation = True
                     key = base_key
@@ -1100,15 +1100,15 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 var neg_idx: Int = -1
                 for idx in range(len(self.args)):
                     if (
-                        self.args[idx].long_name
-                        and self.args[idx].long_name.startswith(base_key)
-                        and self.args[idx].is_negatable
+                        self.args[idx]._long_name
+                        and self.args[idx]._long_name.startswith(base_key)
+                        and self.args[idx]._is_negatable
                     ):
-                        neg_candidates.append(self.args[idx].long_name)
+                        neg_candidates.append(self.args[idx]._long_name)
                         neg_idx = idx
                 if len(neg_candidates) == 1:
                     is_negation = True
-                    key = self.args[neg_idx].long_name
+                    key = self.args[neg_idx]._long_name
                 elif len(neg_candidates) > 1:
                     var opts = String("")
                     for j in range(len(neg_candidates)):
@@ -1124,13 +1124,13 @@ struct Command(Copyable, Movable, Stringable, Writable):
 
         var matched: Argument = self._find_by_long(key)
         # Emit deprecation warning if applicable.
-        if matched.deprecated_msg:
+        if matched._deprecated_msg:
             self._warn(
-                "'--" + key + "' is deprecated: " + matched.deprecated_msg
+                "'--" + key + "' is deprecated: " + matched._deprecated_msg
             )
         if is_negation:
             result._flags[matched.name] = False
-        elif matched.is_count and not has_eq:
+        elif matched._is_count and not has_eq:
             # Count flag: increment counter.
             var cur: Int = 0
             try:
@@ -1138,28 +1138,28 @@ struct Command(Copyable, Movable, Stringable, Writable):
             except:
                 pass
             result._counts[matched.name] = cur + 1
-        elif matched.is_flag and not has_eq:
+        elif matched._is_flag and not has_eq:
             result._flags[matched.name] = True
-        elif matched.num_values > 0:
+        elif matched._number_of_values > 0:
             # nargs: consume exactly N values.
             if has_eq:
                 self._error(
                     "Option '--"
                     + key
                     + "' takes "
-                    + String(matched.num_values)
+                    + String(matched._number_of_values)
                     + " values; '=' syntax is not supported"
                 )
             if matched.name not in result._lists:
                 result._lists[matched.name] = List[String]()
-            for _n in range(matched.num_values):
+            for _n in range(matched._number_of_values):
                 i += 1
                 if i >= len(raw_args):
                     self._error(
                         "Option '--"
                         + key
                         + "' requires "
-                        + String(matched.num_values)
+                        + String(matched._number_of_values)
                         + " values"
                     )
                 self._validate_choices(matched, raw_args[i])
@@ -1170,9 +1170,9 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 if i >= len(raw_args):
                     self._error("Option '--" + key + "' requires a value")
                 value = raw_args[i]
-            if matched.is_map:
+            if matched._is_map:
                 self._store_map_value(matched, value, result)
-            elif matched.is_append:
+            elif matched._is_append:
                 self._store_append_value(matched, value, result)
             else:
                 self._validate_choices(matched, value)
@@ -1201,31 +1201,31 @@ struct Command(Copyable, Movable, Stringable, Writable):
         var i = start
         var matched = self._find_by_short(key)
         # Emit deprecation warning if applicable.
-        if matched.deprecated_msg:
+        if matched._deprecated_msg:
             self._warn(
-                "'-" + key + "' is deprecated: " + matched.deprecated_msg
+                "'-" + key + "' is deprecated: " + matched._deprecated_msg
             )
-        if matched.is_count:
+        if matched._is_count:
             var cur: Int = 0
             try:
                 cur = result._counts[matched.name]
             except:
                 pass
             result._counts[matched.name] = cur + 1
-        elif matched.is_flag:
+        elif matched._is_flag:
             result._flags[matched.name] = True
-        elif matched.num_values > 0:
+        elif matched._number_of_values > 0:
             # nargs: consume exactly N values.
             if matched.name not in result._lists:
                 result._lists[matched.name] = List[String]()
-            for _n in range(matched.num_values):
+            for _n in range(matched._number_of_values):
                 i += 1
                 if i >= len(raw_args):
                     self._error(
                         "Option '-"
                         + key
                         + "' requires "
-                        + String(matched.num_values)
+                        + String(matched._number_of_values)
                         + " values"
                     )
                 self._validate_choices(matched, raw_args[i])
@@ -1235,9 +1235,9 @@ struct Command(Copyable, Movable, Stringable, Writable):
             if i >= len(raw_args):
                 self._error("Option '-" + key + "' requires a value")
             var val = raw_args[i]
-            if matched.is_map:
+            if matched._is_map:
                 self._store_map_value(matched, val, result)
-            elif matched.is_append:
+            elif matched._is_append:
                 self._store_append_value(matched, val, result)
             else:
                 self._validate_choices(matched, val)
@@ -1275,7 +1275,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         var first_char = String(key[0:1])
         var first_match = self._find_by_short(first_char)
 
-        if first_match.is_flag:
+        if first_match._is_flag:
             # First char is a flag — treat entire string as merged
             # flags, except the last char which may take a value.
             var j: Int = 0
@@ -1283,11 +1283,11 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 var ch = String(key[j : j + 1])
                 var m = self._find_by_short(ch)
                 # Emit deprecation warning if applicable.
-                if m.deprecated_msg:
+                if m._deprecated_msg:
                     self._warn(
-                        "'-" + ch + "' is deprecated: " + m.deprecated_msg
+                        "'-" + ch + "' is deprecated: " + m._deprecated_msg
                     )
-                if m.is_count:
+                if m._is_count:
                     var cur: Int = 0
                     try:
                         cur = result._counts[m.name]
@@ -1295,22 +1295,22 @@ struct Command(Copyable, Movable, Stringable, Writable):
                         pass
                     result._counts[m.name] = cur + 1
                     j += 1
-                elif m.is_flag:
+                elif m._is_flag:
                     result._flags[m.name] = True
                     j += 1
-                elif m.num_values > 0:
+                elif m._number_of_values > 0:
                     # nargs in merged flags: rest of string is
                     # ignored; consume N values from argv.
                     if m.name not in result._lists:
                         result._lists[m.name] = List[String]()
-                    for _n in range(m.num_values):
+                    for _n in range(m._number_of_values):
                         i += 1
                         if i >= len(raw_args):
                             self._error(
                                 "Option '-"
                                 + ch
                                 + "' requires "
-                                + String(m.num_values)
+                                + String(m._number_of_values)
                                 + " values"
                             )
                         self._validate_choices(m, raw_args[i])
@@ -1325,9 +1325,9 @@ struct Command(Copyable, Movable, Stringable, Writable):
                         if i >= len(raw_args):
                             self._error("Option '-" + ch + "' requires a value")
                         val = raw_args[i]
-                    if m.is_map:
+                    if m._is_map:
                         self._store_map_value(m, val, result)
-                    elif m.is_append:
+                    elif m._is_append:
                         self._store_append_value(m, val, result)
                     else:
                         self._validate_choices(m, val)
@@ -1337,33 +1337,33 @@ struct Command(Copyable, Movable, Stringable, Writable):
             # First char takes a value — rest of string is the
             # attached value (e.g., -ofile.txt).
             # Emit deprecation warning if applicable.
-            if first_match.deprecated_msg:
+            if first_match._deprecated_msg:
                 self._warn(
                     "'-"
                     + first_char
                     + "' is deprecated: "
-                    + first_match.deprecated_msg
+                    + first_match._deprecated_msg
                 )
-            if first_match.num_values > 0:
+            if first_match._number_of_values > 0:
                 # nargs: consume N values from argv (ignore attached).
                 if first_match.name not in result._lists:
                     result._lists[first_match.name] = List[String]()
-                for _n in range(first_match.num_values):
+                for _n in range(first_match._number_of_values):
                     i += 1
                     if i >= len(raw_args):
                         self._error(
                             "Option '-"
                             + first_char
                             + "' requires "
-                            + String(first_match.num_values)
+                            + String(first_match._number_of_values)
                             + " values"
                         )
                     self._validate_choices(first_match, raw_args[i])
                     result._lists[first_match.name].append(raw_args[i])
-            elif first_match.is_map:
+            elif first_match._is_map:
                 var val = String(key[1:])
                 self._store_map_value(first_match, val, result)
-            elif first_match.is_append:
+            elif first_match._is_append:
                 var val = String(key[1:])
                 self._store_append_value(first_match, val, result)
             else:
@@ -1427,7 +1427,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
             # Set full command path so child help/errors show "app sub".
             child_copy.name = self.name + " " + canon
             for _pi in range(len(self.args)):
-                if self.args[_pi].is_persistent:
+                if self.args[_pi]._is_persistent:
                     child_copy.args.append(self.args[_pi].copy())
             var child_result = child_copy.parse_arguments(child_argv)
             # Bubble up persistent values from child to root result so
@@ -1438,7 +1438,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
             # Also push down root-parsed persistent values to child
             # result so that sub_result.get_flag("x") always works too.
             for _pi in range(len(self.args)):
-                if not self.args[_pi].is_persistent:
+                if not self.args[_pi]._is_persistent:
                     continue
                 var _pn = self.args[_pi].name
                 # Bubble up: child parsed flag after subcommand token.
@@ -1524,17 +1524,17 @@ struct Command(Copyable, Movable, Stringable, Writable):
         """
         for j in range(len(self.args)):
             var a = self.args[j].copy()
-            if a.has_default and not result.has(a.name):
-                if a.is_positional:
+            if a._has_default and not result.has(a.name):
+                if a._is_positional:
                     # Fill positional to the right slot.
                     for k in range(len(result._positional_names)):
                         if result._positional_names[k] == a.name:
                             while len(result._positionals) <= k:
                                 result._positionals.append("")
                             if not result._positionals[k]:
-                                result._positionals[k] = a.default_value
+                                result._positionals[k] = a._default_value
                 else:
-                    result._values[a.name] = a.default_value
+                    result._values[a.name] = a._default_value
 
     fn _validate(self, mut result: ParseResult) raises:
         """Runs all post-parse validation checks on the result.
@@ -1558,7 +1558,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         # Validate required arguments.
         for j in range(len(self.args)):
             var a = self.args[j].copy()
-            if a.is_required and not result.has(a.name):
+            if a._is_required and not result.has(a.name):
                 self._error_with_usage(
                     "Required argument '" + a.name + "' was not provided"
                 )
@@ -1654,31 +1654,31 @@ struct Command(Copyable, Movable, Stringable, Writable):
         # Validate count ceilings — clamp and warn.
         for j in range(len(self.args)):
             var a = self.args[j].copy()
-            if a.is_count and a.has_count_max:
+            if a._is_count and a._has_count_max:
                 var cur: Int
                 try:
                     cur = result._counts[a.name]
                 except:
                     continue
-                if cur > a.count_max:
+                if cur > a._count_max:
                     self._warn(
                         self._display_name(a.name)
                         + " count "
                         + String(cur)
                         + " exceeds maximum "
-                        + String(a.count_max)
+                        + String(a._count_max)
                         + ", capped to "
-                        + String(a.count_max)
+                        + String(a._count_max)
                     )
-                    result._counts[a.name] = a.count_max
+                    result._counts[a.name] = a._count_max
 
         # Validate numeric range constraints.
         for j in range(len(self.args)):
             var a = self.args[j].copy()
-            if a.has_range and result.has(a.name):
+            if a._has_range and result.has(a.name):
                 var display = self._display_name(a.name)
                 # Get the raw string value(s) for this argument.
-                if a.is_append:
+                if a._is_append:
                     var lst = result.get_list(a.name)
                     for k in range(len(lst)):
                         var v: Int = (
@@ -1694,21 +1694,21 @@ struct Command(Copyable, Movable, Stringable, Writable):
                                 + lst[k]
                                 + "'"
                             )
-                        if v < a.range_min or v > a.range_max:
-                            if a.is_clamp:
+                        if v < a._range_min or v > a._range_max:
+                            if a._is_clamp:
                                 var clamped = v
-                                if v < a.range_min:
-                                    clamped = a.range_min
-                                elif v > a.range_max:
-                                    clamped = a.range_max
+                                if v < a._range_min:
+                                    clamped = a._range_min
+                                elif v > a._range_max:
+                                    clamped = a._range_max
                                 self._warn(
                                     display
                                     + " value "
                                     + String(v)
                                     + " is out of range ["
-                                    + String(a.range_min)
+                                    + String(a._range_min)
                                     + ", "
-                                    + String(a.range_max)
+                                    + String(a._range_max)
                                     + "], clamped to "
                                     + String(clamped)
                                 )
@@ -1720,9 +1720,9 @@ struct Command(Copyable, Movable, Stringable, Writable):
                                     + " for "
                                     + display
                                     + " is out of range ["
-                                    + String(a.range_min)
+                                    + String(a._range_min)
                                     + ", "
-                                    + String(a.range_max)
+                                    + String(a._range_max)
                                     + "]"
                                 )
                 else:
@@ -1744,26 +1744,26 @@ struct Command(Copyable, Movable, Stringable, Writable):
                             + raw
                             + "'"
                         )
-                    if v < a.range_min or v > a.range_max:
-                        if a.is_clamp:
+                    if v < a._range_min or v > a._range_max:
+                        if a._is_clamp:
                             var clamped = v
-                            if v < a.range_min:
-                                clamped = a.range_min
-                            elif v > a.range_max:
-                                clamped = a.range_max
+                            if v < a._range_min:
+                                clamped = a._range_min
+                            elif v > a._range_max:
+                                clamped = a._range_max
                             self._warn(
                                 display
                                 + " value "
                                 + String(v)
                                 + " is out of range ["
-                                + String(a.range_min)
+                                + String(a._range_min)
                                 + ", "
-                                + String(a.range_max)
+                                + String(a._range_max)
                                 + "], clamped to "
                                 + String(clamped)
                             )
                             result._values[a.name] = String(clamped)
-                            if a.is_positional:
+                            if a._is_positional:
                                 for pi in range(len(result._positional_names)):
                                     if result._positional_names[pi] == a.name:
                                         result._positionals[pi] = String(
@@ -1777,9 +1777,9 @@ struct Command(Copyable, Movable, Stringable, Writable):
                                 + " for "
                                 + display
                                 + " is out of range ["
-                                + String(a.range_min)
+                                + String(a._range_min)
                                 + ", "
-                                + String(a.range_max)
+                                + String(a._range_max)
                                 + "]"
                             )
 
@@ -1807,37 +1807,37 @@ struct Command(Copyable, Movable, Stringable, Writable):
         """
         # 1. Exact match on long_name.
         for i in range(len(self.args)):
-            if self.args[i].long_name == name:
+            if self.args[i]._long_name == name:
                 return self.args[i].copy()
 
         # 2. Exact match on aliases.
         for i in range(len(self.args)):
-            for j in range(len(self.args[i].alias_names)):
-                if self.args[i].alias_names[j] == name:
+            for j in range(len(self.args[i]._alias_names)):
+                if self.args[i]._alias_names[j] == name:
                     return self.args[i].copy()
 
         # 3. Prefix match on long_name.
         var candidates = List[String]()
         var candidate_idx: Int = -1
         for i in range(len(self.args)):
-            if self.args[i].long_name and self.args[i].long_name.startswith(
+            if self.args[i]._long_name and self.args[i]._long_name.startswith(
                 name
             ):
-                candidates.append(self.args[i].long_name)
+                candidates.append(self.args[i]._long_name)
                 candidate_idx = i
 
         # 4. Prefix match on aliases.
         for i in range(len(self.args)):
-            for j in range(len(self.args[i].alias_names)):
-                if self.args[i].alias_names[j].startswith(name):
+            for j in range(len(self.args[i]._alias_names)):
+                if self.args[i]._alias_names[j].startswith(name):
                     # Avoid duplicate if the same arg already matched via long_name.
                     var already = False
                     for k in range(len(candidates)):
-                        if candidates[k] == self.args[i].long_name:
+                        if candidates[k] == self.args[i]._long_name:
                             already = True
                             break
                     if not already:
-                        candidates.append(self.args[i].long_name)
+                        candidates.append(self.args[i]._long_name)
                         candidate_idx = i
 
         if len(candidates) == 1:
@@ -1856,10 +1856,10 @@ struct Command(Copyable, Movable, Stringable, Writable):
         # Collect all known long names + aliases for typo suggestion.
         var all_longs = List[String]()
         for i in range(len(self.args)):
-            if self.args[i].long_name != "":
-                all_longs.append(self.args[i].long_name)
-            for j in range(len(self.args[i].alias_names)):
-                all_longs.append(self.args[i].alias_names[j])
+            if self.args[i]._long_name != "":
+                all_longs.append(self.args[i]._long_name)
+            for j in range(len(self.args[i]._alias_names)):
+                all_longs.append(self.args[i]._alias_names[j])
         var suggestion = _suggest_similar(name, all_longs)
         if suggestion != "":
             self._error(
@@ -1887,7 +1887,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
             Error if no argument matches.
         """
         for i in range(len(self.args)):
-            if self.args[i].short_name == name:
+            if self.args[i]._short_name == name:
                 return self.args[i].copy()
         # Short options are always a single character; any two single-character
         # inputs have Levenshtein distance ≤ 1, so the threshold would always
@@ -1934,10 +1934,10 @@ struct Command(Copyable, Movable, Stringable, Writable):
         """
         for i in range(len(self.args)):
             if self.args[i].name == name:
-                if self.args[i].long_name:
-                    return "'--" + self.args[i].long_name + "'"
-                elif self.args[i].short_name:
-                    return "'-" + self.args[i].short_name + "'"
+                if self.args[i]._long_name:
+                    return "'--" + self.args[i]._long_name + "'"
+                elif self.args[i]._short_name:
+                    return "'-" + self.args[i]._short_name + "'"
                 break
         return "'" + name + "'"
 
@@ -1951,16 +1951,16 @@ struct Command(Copyable, Movable, Stringable, Writable):
         Raises:
             Error if the value is not in the allowed choices.
         """
-        if len(arg.choice_values) == 0:
+        if len(arg._choice_values) == 0:
             return
-        for i in range(len(arg.choice_values)):
-            if arg.choice_values[i] == value:
+        for i in range(len(arg._choice_values)):
+            if arg._choice_values[i] == value:
                 return
         var allowed = String("")
-        for i in range(len(arg.choice_values)):
+        for i in range(len(arg._choice_values)):
             if i > 0:
                 allowed += ", "
-            allowed += "'" + arg.choice_values[i] + "'"
+            allowed += "'" + arg._choice_values[i] + "'"
         self._error(
             "Invalid value '"
             + value
@@ -1987,8 +1987,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
         """
         if arg.name not in result._lists:
             result._lists[arg.name] = List[String]()
-        if arg.delimiter_char:
-            var parts = value.split(arg.delimiter_char)
+        if arg._delimiter_char:
+            var parts = value.split(arg._delimiter_char)
             for p in range(len(parts)):
                 var piece = String(parts[p])
                 if piece:  # skip empty pieces from e.g. trailing comma
@@ -2018,8 +2018,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
         if arg.name not in result._lists:
             result._lists[arg.name] = List[String]()
 
-        if arg.delimiter_char:
-            var parts = value.split(arg.delimiter_char)
+        if arg._delimiter_char:
+            var parts = value.split(arg._delimiter_char)
             for p in range(len(parts)):
                 var piece = String(parts[p])
                 if piece:
@@ -2103,8 +2103,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
 
         # Show positional args in usage line.
         for i in range(len(self.args)):
-            if self.args[i].is_positional and not self.args[i].is_hidden:
-                if self.args[i].is_required:
+            if self.args[i]._is_positional and not self.args[i]._is_hidden:
+                if self.args[i]._is_required:
                     s += (
                         " "
                         + arg_color
@@ -2156,7 +2156,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         """
         var has_positional = False
         for i in range(len(self.args)):
-            if self.args[i].is_positional and not self.args[i].is_hidden:
+            if self.args[i]._is_positional and not self.args[i]._is_hidden:
                 has_positional = True
                 break
 
@@ -2168,7 +2168,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         var pos_colors = List[String]()  # coloured text for display
         var pos_helps = List[String]()
         for i in range(len(self.args)):
-            if self.args[i].is_positional and not self.args[i].is_hidden:
+            if self.args[i]._is_positional and not self.args[i]._is_hidden:
                 var plain = String("  ") + self.args[i].name
                 var colored = (
                     String("  ") + arg_color + self.args[i].name + reset_code
@@ -2222,57 +2222,57 @@ struct Command(Copyable, Movable, Stringable, Writable):
         var opt_persistent = List[Bool]()
 
         for i in range(len(self.args)):
-            if not self.args[i].is_positional and not self.args[i].is_hidden:
+            if not self.args[i]._is_positional and not self.args[i]._is_hidden:
                 var plain = String("  ")
                 var colored = String("  ")
-                if self.args[i].short_name:
-                    plain += "-" + self.args[i].short_name
+                if self.args[i]._short_name:
+                    plain += "-" + self.args[i]._short_name
                     colored += (
-                        arg_color + "-" + self.args[i].short_name + reset_code
+                        arg_color + "-" + self.args[i]._short_name + reset_code
                     )
-                    if self.args[i].long_name:
+                    if self.args[i]._long_name:
                         plain += ", "
                         colored += ", "
                 else:
                     plain += "    "
                     colored += "    "
-                if self.args[i].long_name:
-                    var long_part = String("--") + self.args[i].long_name
+                if self.args[i]._long_name:
+                    var long_part = String("--") + self.args[i]._long_name
                     plain += long_part
                     colored += arg_color + long_part + reset_code
-                    if self.args[i].is_negatable:
+                    if self.args[i]._is_negatable:
                         var neg_part = (
-                            String(" / --no-") + self.args[i].long_name
+                            String(" / --no-") + self.args[i]._long_name
                         )
                         plain += neg_part
                         colored += (
                             " / "
                             + arg_color
                             + "--no-"
-                            + self.args[i].long_name
+                            + self.args[i]._long_name
                             + reset_code
                         )
                     # Show aliases.
-                    for j in range(len(self.args[i].alias_names)):
+                    for j in range(len(self.args[i]._alias_names)):
                         var alias_part = (
-                            String(", --") + self.args[i].alias_names[j]
+                            String(", --") + self.args[i]._alias_names[j]
                         )
                         plain += alias_part
                         colored += (
                             ", "
                             + arg_color
                             + "--"
-                            + self.args[i].alias_names[j]
+                            + self.args[i]._alias_names[j]
                             + reset_code
                         )
 
                 # Show metavar or choices for value-taking options.
-                if not self.args[i].is_flag:
-                    var ncount = self.args[i].num_values
+                if not self.args[i]._is_flag:
+                    var ncount = self.args[i]._number_of_values
                     var repeat = ncount if ncount > 0 else 1
-                    var append_dots = self.args[i].is_append and ncount == 0
-                    if self.args[i].metavar_name:
-                        var mv = self.args[i].metavar_name
+                    var append_dots = self.args[i]._is_append and ncount == 0
+                    if self.args[i]._metavar_name:
+                        var mv = self.args[i]._metavar_name
                         var mv_plain = String("")
                         var mv_colored = String("")
                         for _r in range(repeat - 1):
@@ -2284,12 +2284,12 @@ struct Command(Copyable, Movable, Stringable, Writable):
                         mv_colored += " " + arg_color + last + reset_code
                         plain += mv_plain
                         colored += mv_colored
-                    elif len(self.args[i].choice_values) > 0:
+                    elif len(self.args[i]._choice_values) > 0:
                         var choices_str = String("{")
-                        for j in range(len(self.args[i].choice_values)):
+                        for j in range(len(self.args[i]._choice_values)):
                             if j > 0:
                                 choices_str += ","
-                            choices_str += self.args[i].choice_values[j]
+                            choices_str += self.args[i]._choice_values[j]
                         choices_str += "}"
                         var suffix = choices_str
                         if append_dots:
@@ -2299,7 +2299,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                     else:
                         # Default placeholder: <key=value> for map, <name> otherwise.
                         var tag: String
-                        if self.args[i].is_map:
+                        if self.args[i]._is_map:
                             tag = "<key=value>"
                         else:
                             tag = "<" + self.args[i].name + ">"
@@ -2317,13 +2317,13 @@ struct Command(Copyable, Movable, Stringable, Writable):
 
                 opt_plains.append(plain)
                 opt_colors.append(colored)
-                opt_persistent.append(self.args[i].is_persistent)
+                opt_persistent.append(self.args[i]._is_persistent)
                 # Append deprecation notice to help text if applicable.
                 var help = self.args[i].help_text
-                if self.args[i].deprecated_msg:
+                if self.args[i]._deprecated_msg:
                     if help:
                         help += " "
-                    help += "[deprecated: " + self.args[i].deprecated_msg + "]"
+                    help += "[deprecated: " + self.args[i]._deprecated_msg + "]"
                 opt_helps.append(help)
 
         # Built-in options (always shown under local "Options:" section).
@@ -2513,7 +2513,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         """
         var has_positional = False
         for i in range(len(self.args)):
-            if self.args[i].is_positional and not self.args[i].is_hidden:
+            if self.args[i]._is_positional and not self.args[i]._is_hidden:
                 has_positional = True
                 break
 
@@ -2528,7 +2528,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
             if not neg_auto:
                 var has_digit_short = False
                 for _ti in range(len(self.args)):
-                    var sc = self.args[_ti].short_name
+                    var sc = self.args[_ti]._short_name
                     if len(sc) == 1 and sc[0:1] >= "0" and sc[0:1] <= "9":
                         has_digit_short = True
                         break
@@ -2575,7 +2575,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
 
         # Positional arguments.
         for i in range(len(self.args)):
-            if self.args[i].is_positional:
+            if self.args[i]._is_positional:
                 var val = String("(not set)")
                 try:
                     val = result.get_string(self.args[i].name)
@@ -2588,27 +2588,27 @@ struct Command(Copyable, Movable, Stringable, Writable):
         var displays = List[String]()
         var value_strs = List[String]()
         for i in range(len(self.args)):
-            if self.args[i].is_positional:
+            if self.args[i]._is_positional:
                 continue
             # Skip hidden args that weren't provided.
-            if self.args[i].is_hidden and not result.has(self.args[i].name):
+            if self.args[i]._is_hidden and not result.has(self.args[i].name):
                 continue
 
             var display = String("")
-            if self.args[i].short_name:
-                display += "-" + self.args[i].short_name
-            if self.args[i].long_name:
+            if self.args[i]._short_name:
+                display += "-" + self.args[i]._short_name
+            if self.args[i]._long_name:
                 if display:
                     display += ", "
-                display += "--" + self.args[i].long_name
+                display += "--" + self.args[i]._long_name
             displays.append(display)
 
             var val_str: String
-            if self.args[i].is_count:
+            if self.args[i]._is_count:
                 val_str = String(result.get_count(self.args[i].name))
-            elif self.args[i].is_flag:
+            elif self.args[i]._is_flag:
                 val_str = String(result.get_flag(self.args[i].name))
-            elif self.args[i].is_map:
+            elif self.args[i]._is_map:
                 if self.args[i].name in result._maps:
                     var m = result.get_map(self.args[i].name)
                     var s = String("{")
@@ -2622,7 +2622,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                     val_str = s
                 else:
                     val_str = "{}"
-            elif self.args[i].is_append:
+            elif self.args[i]._is_append:
                 var lst = result.get_list(self.args[i].name)
                 if len(lst) > 0:
                     var s = String("[")
@@ -2796,22 +2796,22 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 # Iterate sub.args for subcommand's own arguments.
                 for j in range(len(sub.args)):
                     var arg = sub.args[j].copy()
-                    if arg.is_hidden or arg.is_positional:
+                    if arg._is_hidden or arg._is_positional:
                         continue
                     var line = "complete -c " + self.name
                     line += " -n '" + sub_cond + "'"
-                    if arg.short_name:
-                        line += " -s " + arg.short_name
-                    if arg.long_name:
-                        line += " -l " + arg.long_name
-                    if not arg.is_flag and not arg.is_count:
+                    if arg._short_name:
+                        line += " -s " + arg._short_name
+                    if arg._long_name:
+                        line += " -l " + arg._long_name
+                    if not arg._is_flag and not arg._is_count:
                         line += " -r"
-                    if len(arg.choice_values) > 0:
+                    if len(arg._choice_values) > 0:
                         var choices = String("")
-                        for k in range(len(arg.choice_values)):
+                        for k in range(len(arg._choice_values)):
                             if choices:
                                 choices += " "
-                            choices += arg.choice_values[k]
+                            choices += arg._choice_values[k]
                         line += " -a '" + choices + "'"
                     if arg.help_text:
                         line += " -d '" + self._fish_escape(arg.help_text) + "'"
@@ -2857,25 +2857,25 @@ struct Command(Copyable, Movable, Stringable, Writable):
         var s = String("")
         for i in range(len(self.args)):
             var arg = self.args[i].copy()
-            if arg.is_hidden or arg.is_positional:
+            if arg._is_hidden or arg._is_positional:
                 continue
-            if persistent_only and not arg.is_persistent:
+            if persistent_only and not arg._is_persistent:
                 continue
             var line = "complete -c " + cmd_name
             if condition:
                 line += " -n '" + condition + "'"
-            if arg.short_name:
-                line += " -s " + arg.short_name
-            if arg.long_name:
-                line += " -l " + arg.long_name
-            if not arg.is_flag and not arg.is_count:
+            if arg._short_name:
+                line += " -s " + arg._short_name
+            if arg._long_name:
+                line += " -l " + arg._long_name
+            if not arg._is_flag and not arg._is_count:
                 line += " -r"
-            if len(arg.choice_values) > 0:
+            if len(arg._choice_values) > 0:
                 var choices = String("")
-                for k in range(len(arg.choice_values)):
+                for k in range(len(arg._choice_values)):
                     if choices:
                         choices += " "
-                    choices += arg.choice_values[k]
+                    choices += arg._choice_values[k]
                 line += " -a '" + choices + "'"
             if arg.help_text:
                 line += " -d '" + self._fish_escape(arg.help_text) + "'"
@@ -2938,9 +2938,9 @@ struct Command(Copyable, Movable, Stringable, Writable):
         # User-defined arguments.
         for i in range(len(self.args)):
             var arg = self.args[i].copy()
-            if arg.is_hidden:
+            if arg._is_hidden:
                 continue
-            if arg.is_positional:
+            if arg._is_positional:
                 continue
             s += "    " + self._zsh_arg_spec(arg) + " \\\n"
         # Built-in options.
@@ -2989,7 +2989,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         # Root-level options.
         for i in range(len(self.args)):
             var arg = self.args[i].copy()
-            if arg.is_hidden or arg.is_positional:
+            if arg._is_hidden or arg._is_positional:
                 continue
             s += "    " + self._zsh_arg_spec(arg) + " \\\n"
         s += "    '(- *)'{-h,--help}'[Show this help message]' \\\n"
@@ -3022,9 +3022,9 @@ struct Command(Copyable, Movable, Stringable, Writable):
             s += "          _arguments \\\n"
             for j in range(len(sub.args)):
                 var arg = sub.args[j].copy()
-                if arg.is_hidden:
+                if arg._is_hidden:
                     continue
-                if arg.is_positional:
+                if arg._is_positional:
                     continue
                 s += "            " + self._zsh_arg_spec(arg) + " \\\n"
             s += "            '(- *)'{-h,--help}'[Show this help message]'\n"
@@ -3057,51 +3057,55 @@ struct Command(Copyable, Movable, Stringable, Writable):
         var spec = String("")
         var desc = self._zsh_escape(arg.help_text) if arg.help_text else ""
 
-        if arg.short_name and arg.long_name:
+        if arg._short_name and arg._long_name:
             # Grouped short+long form.
             spec += (
                 "'(-"
-                + arg.short_name
+                + arg._short_name
                 + " --"
-                + arg.long_name
+                + arg._long_name
                 + ")'"
                 + "{-"
-                + arg.short_name
+                + arg._short_name
                 + ",--"
-                + arg.long_name
+                + arg._long_name
                 + "}"
             )
-        elif arg.long_name:
-            spec += "'--" + arg.long_name
-        elif arg.short_name:
-            spec += "'-" + arg.short_name
+        elif arg._long_name:
+            spec += "'--" + arg._long_name
+        elif arg._short_name:
+            spec += "'-" + arg._short_name
 
-        if arg.short_name and arg.long_name:
+        if arg._short_name and arg._long_name:
             # Description + value spec.
             spec += "'[" + desc + "]"
-            if not arg.is_flag and not arg.is_count:
-                if len(arg.choice_values) > 0:
+            if not arg._is_flag and not arg._is_count:
+                if len(arg._choice_values) > 0:
                     var choices = String("")
-                    for k in range(len(arg.choice_values)):
+                    for k in range(len(arg._choice_values)):
                         if choices:
                             choices += " "
-                        choices += arg.choice_values[k]
+                        choices += arg._choice_values[k]
                     spec += ":value:(" + choices + ")"
                 else:
-                    var mv = arg.metavar_name if arg.metavar_name else arg.name
+                    var mv = (
+                        arg._metavar_name if arg._metavar_name else arg.name
+                    )
                     spec += ":" + mv + ":"
             spec += "'"
         else:
-            if not arg.is_flag and not arg.is_count:
-                if len(arg.choice_values) > 0:
+            if not arg._is_flag and not arg._is_count:
+                if len(arg._choice_values) > 0:
                     var choices = String("")
-                    for k in range(len(arg.choice_values)):
+                    for k in range(len(arg._choice_values)):
                         if choices:
                             choices += " "
-                        choices += arg.choice_values[k]
+                        choices += arg._choice_values[k]
                     spec += "[" + desc + "]:value:(" + choices + ")'"
                 else:
-                    var mv = arg.metavar_name if arg.metavar_name else arg.name
+                    var mv = (
+                        arg._metavar_name if arg._metavar_name else arg.name
+                    )
                     spec += "[" + desc + "]:" + mv + ":'"
             else:
                 spec += "[" + desc + "]'"
@@ -3176,12 +3180,12 @@ struct Command(Copyable, Movable, Stringable, Writable):
             words += " --" + self._completions_name
         for i in range(len(self.args)):
             var arg = self.args[i].copy()
-            if arg.is_hidden or arg.is_positional:
+            if arg._is_hidden or arg._is_positional:
                 continue
-            if arg.long_name:
-                words += " --" + arg.long_name
-            if arg.short_name:
-                words += " -" + arg.short_name
+            if arg._long_name:
+                words += " --" + arg._long_name
+            if arg._short_name:
+                words += " -" + arg._short_name
 
         # Handle value completion for prev.
         var s = self._bash_prev_cases()
@@ -3219,12 +3223,12 @@ struct Command(Copyable, Movable, Stringable, Writable):
             root_words += " --" + self._completions_name
         for i in range(len(self.args)):
             var arg = self.args[i].copy()
-            if arg.is_hidden or arg.is_positional:
+            if arg._is_hidden or arg._is_positional:
                 continue
-            if arg.long_name:
-                root_words += " --" + arg.long_name
-            if arg.short_name:
-                root_words += " -" + arg.short_name
+            if arg._long_name:
+                root_words += " --" + arg._long_name
+            if arg._short_name:
+                root_words += " -" + arg._short_name
 
         # Detect subcommand in COMP_WORDS.
         s += "  local subcmd=''\n"
@@ -3258,12 +3262,12 @@ struct Command(Copyable, Movable, Stringable, Writable):
             var sub_words = String("--help")
             for j in range(len(sub.args)):
                 var arg = sub.args[j].copy()
-                if arg.is_hidden or arg.is_positional:
+                if arg._is_hidden or arg._is_positional:
                     continue
-                if arg.long_name:
-                    sub_words += " --" + arg.long_name
-                if arg.short_name:
-                    sub_words += " -" + arg.short_name
+                if arg._long_name:
+                    sub_words += " --" + arg._long_name
+                if arg._short_name:
+                    sub_words += " -" + arg._short_name
             # Build pattern: name|alias1|alias2
             var bash_pat = sub.name
             for _ai in range(len(sub._command_aliases)):
@@ -3299,9 +3303,9 @@ struct Command(Copyable, Movable, Stringable, Writable):
         if not has_choices:
             for i in range(len(self.args)):
                 if (
-                    not self.args[i].is_hidden
-                    and not self.args[i].is_positional
-                    and len(self.args[i].choice_values) > 0
+                    not self.args[i]._is_hidden
+                    and not self.args[i]._is_positional
+                    and len(self.args[i]._choice_values) > 0
                 ):
                     has_choices = True
                     break
@@ -3318,23 +3322,23 @@ struct Command(Copyable, Movable, Stringable, Writable):
         for i in range(len(self.args)):
             var arg = self.args[i].copy()
             if (
-                arg.is_hidden
-                or arg.is_positional
-                or len(arg.choice_values) == 0
+                arg._is_hidden
+                or arg._is_positional
+                or len(arg._choice_values) == 0
             ):
                 continue
             var pattern = String("")
-            if arg.long_name:
-                pattern += "--" + arg.long_name
-            if arg.short_name:
+            if arg._long_name:
+                pattern += "--" + arg._long_name
+            if arg._short_name:
                 if pattern:
                     pattern += "|"
-                pattern += "-" + arg.short_name
+                pattern += "-" + arg._short_name
             var choices = String("")
-            for k in range(len(arg.choice_values)):
+            for k in range(len(arg._choice_values)):
                 if choices:
                     choices += " "
-                choices += arg.choice_values[k]
+                choices += arg._choice_values[k]
             s += "    " + pattern + ")\n"
             s += '      COMPREPLY=($(compgen -W "' + choices + '" -- "$cur"))\n'
             s += "      return\n"
@@ -3360,9 +3364,9 @@ struct Command(Copyable, Movable, Stringable, Writable):
         var has_choices = False
         for i in range(len(args)):
             if (
-                not args[i].is_hidden
-                and not args[i].is_positional
-                and len(args[i].choice_values) > 0
+                not args[i]._is_hidden
+                and not args[i]._is_positional
+                and len(args[i]._choice_values) > 0
             ):
                 has_choices = True
                 break
@@ -3373,23 +3377,23 @@ struct Command(Copyable, Movable, Stringable, Writable):
         for i in range(len(args)):
             var arg = args[i].copy()
             if (
-                arg.is_hidden
-                or arg.is_positional
-                or len(arg.choice_values) == 0
+                arg._is_hidden
+                or arg._is_positional
+                or len(arg._choice_values) == 0
             ):
                 continue
             var pattern = String("")
-            if arg.long_name:
-                pattern += "--" + arg.long_name
-            if arg.short_name:
+            if arg._long_name:
+                pattern += "--" + arg._long_name
+            if arg._short_name:
                 if pattern:
                     pattern += "|"
-                pattern += "-" + arg.short_name
+                pattern += "-" + arg._short_name
             var choices = String("")
-            for k in range(len(arg.choice_values)):
+            for k in range(len(arg._choice_values)):
                 if choices:
                     choices += " "
-                choices += arg.choice_values[k]
+                choices += arg._choice_values[k]
             s += indent + "  " + pattern + ")\n"
             s += (
                 indent

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -1673,9 +1673,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         for j in range(len(self.args)):
             var a = self.args[j].copy()
             if a.has_range and result.has(a.name):
-                var display = String("'") + a.name + "'"
-                if a.long_name:
-                    display = "'--" + a.long_name + "'"
+                var display = self._display_name(a.name)
                 # Get the raw string value(s) for this argument.
                 if a.is_append:
                     var lst = result.get_list(a.name)
@@ -1762,6 +1760,11 @@ struct Command(Copyable, Movable, Stringable, Writable):
                                 + String(clamped)
                             )
                             result.values[a.name] = String(clamped)
+                            if a.is_positional:
+                                for pi in range(len(result._positional_names)):
+                                    if result._positional_names[pi] == a.name:
+                                        result.positionals[pi] = String(clamped)
+                                        break
                         else:
                             self._error(
                                 "Value "

--- a/src/argmojo/parse_result.mojo
+++ b/src/argmojo/parse_result.mojo
@@ -7,37 +7,39 @@ struct ParseResult(Copyable, Movable, Stringable, Writable):
     Provides typed accessors to retrieve argument values by name.
     """
 
-    var flags: Dict[String, Bool]
+    # === Public fields ===
+    var subcommand: String
+    """Name of the selected subcommand. Empty string if no subcommand was given."""
+
+    # === Private fields ===
+    var _flags: Dict[String, Bool]
     """Boolean flag values, keyed by argument name."""
-    var values: Dict[String, String]
+    var _values: Dict[String, String]
     """String argument values, keyed by argument name."""
-    var positionals: List[String]
+    var _positionals: List[String]
     """Positional argument values, in order."""
-    var counts: Dict[String, Int]
+    var _counts: Dict[String, Int]
     """Counter values for count-type arguments (e.g., -vvv → 3)."""
-    var lists: Dict[String, List[String]]
+    var _lists: Dict[String, List[String]]
     """Collected list values for append-type arguments (e.g., --tag x --tag y)."""
-    var maps: Dict[String, Dict[String, String]]
+    var _maps: Dict[String, Dict[String, String]]
     """Key-value map values for map-type arguments (e.g., --define key=val)."""
     var _positional_names: List[String]
     """Names of positional arguments, in declaration order."""
-    var subcommand: String
-    """Name of the selected subcommand. Empty string if no subcommand was given."""
     var _subcommand_results: List[ParseResult]
     """Child ParseResult from subcommand parsing. Contains 0 or 1 elements.
-
     Use ``has_subcommand_result()`` to check presence and
     ``get_subcommand_result()`` to retrieve the value.
     """
 
     fn __init__(out self):
         """Creates an empty ParseResult."""
-        self.flags = Dict[String, Bool]()
-        self.values = Dict[String, String]()
-        self.positionals = List[String]()
-        self.counts = Dict[String, Int]()
-        self.lists = Dict[String, List[String]]()
-        self.maps = Dict[String, Dict[String, String]]()
+        self._flags = Dict[String, Bool]()
+        self._values = Dict[String, String]()
+        self._positionals = List[String]()
+        self._counts = Dict[String, Int]()
+        self._lists = Dict[String, List[String]]()
+        self._maps = Dict[String, Dict[String, String]]()
         self._positional_names = List[String]()
         self.subcommand = ""
         self._subcommand_results = List[ParseResult]()
@@ -48,16 +50,16 @@ struct ParseResult(Copyable, Movable, Stringable, Writable):
         Args:
             copy: The ParseResult to copy from.
         """
-        self.flags = copy.flags.copy()
-        self.values = copy.values.copy()
-        self.positionals = copy.positionals.copy()
-        self.counts = copy.counts.copy()
-        self.lists = Dict[String, List[String]]()
-        for entry in copy.lists.items():
-            self.lists[entry.key] = entry.value.copy()
-        self.maps = Dict[String, Dict[String, String]]()
-        for entry in copy.maps.items():
-            self.maps[entry.key] = entry.value.copy()
+        self._flags = copy._flags.copy()
+        self._values = copy._values.copy()
+        self._positionals = copy._positionals.copy()
+        self._counts = copy._counts.copy()
+        self._lists = Dict[String, List[String]]()
+        for entry in copy._lists.items():
+            self._lists[entry.key] = entry.value.copy()
+        self._maps = Dict[String, Dict[String, String]]()
+        for entry in copy._maps.items():
+            self._maps[entry.key] = entry.value.copy()
         self._positional_names = copy._positional_names.copy()
         self.subcommand = copy.subcommand
         self._subcommand_results = copy._subcommand_results.copy()
@@ -68,12 +70,12 @@ struct ParseResult(Copyable, Movable, Stringable, Writable):
         Args:
             move: The ParseResult to move from.
         """
-        self.flags = move.flags^
-        self.values = move.values^
-        self.positionals = move.positionals^
-        self.counts = move.counts^
-        self.lists = move.lists^
-        self.maps = move.maps^
+        self._flags = move._flags^
+        self._values = move._values^
+        self._positionals = move._positionals^
+        self._counts = move._counts^
+        self._lists = move._lists^
+        self._maps = move._maps^
         self._positional_names = move._positional_names^
         self.subcommand = move.subcommand^
         self._subcommand_results = move._subcommand_results^
@@ -88,7 +90,7 @@ struct ParseResult(Copyable, Movable, Stringable, Writable):
             True if the flag was set, False otherwise.
         """
         try:
-            return self.flags[name]
+            return self._flags[name]
         except:
             return False
 
@@ -106,15 +108,15 @@ struct ParseResult(Copyable, Movable, Stringable, Writable):
         """
         # Check named values first.
         try:
-            return self.values[name]
+            return self._values[name]
         except:
             pass
 
         # Check positional arguments by name.
         for i in range(len(self._positional_names)):
             if self._positional_names[i] == name:
-                if i < len(self.positionals):
-                    return self.positionals[i]
+                if i < len(self._positionals):
+                    return self._positionals[i]
 
         raise Error("Argument '" + name + "' not found")
 
@@ -143,7 +145,7 @@ struct ParseResult(Copyable, Movable, Stringable, Writable):
             The number of times the flag was provided.
         """
         try:
-            return self.counts[name]
+            return self._counts[name]
         except:
             return 0
 
@@ -165,7 +167,7 @@ struct ParseResult(Copyable, Movable, Stringable, Writable):
         """
         try:
             var result = List[String]()
-            var lst = self.lists[name].copy()
+            var lst = self._lists[name].copy()
             for i in range(len(lst)):
                 result.append(String(lst[i]))
             return result^
@@ -186,7 +188,7 @@ struct ParseResult(Copyable, Movable, Stringable, Writable):
         try:
             # Return a copy of the stored map.
             var result = Dict[String, String]()
-            var m = self.maps[name].copy()
+            var m = self._maps[name].copy()
             for entry in m.items():
                 result[entry.key] = entry.value
             return result^
@@ -202,19 +204,19 @@ struct ParseResult(Copyable, Movable, Stringable, Writable):
         Returns:
             True if the argument was provided.
         """
-        if name in self.flags:
+        if name in self._flags:
             return True
-        if name in self.values:
+        if name in self._values:
             return True
-        if name in self.counts:
+        if name in self._counts:
             return True
-        if name in self.lists:
+        if name in self._lists:
             return True
-        if name in self.maps:
+        if name in self._maps:
             return True
         for i in range(len(self._positional_names)):
             if self._positional_names[i] == name:
-                return i < len(self.positionals)
+                return i < len(self._positionals)
         return False
 
     fn has_subcommand_result(self) -> Bool:
@@ -247,9 +249,9 @@ struct ParseResult(Copyable, Movable, Stringable, Writable):
     fn __str__(self) -> String:
         """Return a string representation of the parse result."""
         var s = String("ParseResult(")
-        s += "flags=" + String(len(self.flags))
-        s += ", values=" + String(len(self.values))
-        s += ", positionals=" + String(len(self.positionals))
+        s += "flags=" + String(len(self._flags))
+        s += ", values=" + String(len(self._values))
+        s += ", positionals=" + String(len(self._positionals))
         if self.subcommand != "":
             s += ", subcommand='" + self.subcommand + "'"
         s += ")"

--- a/tests/test_negative_numbers.mojo
+++ b/tests/test_negative_numbers.mojo
@@ -29,7 +29,7 @@ fn test_negative_integer_auto_detect() raises:
 
     var args: List[String] = ["test", "-9876543"]
     var result = command.parse_arguments(args)
-    assert_equal(result.positionals[0], "-9876543")
+    assert_equal(result._positionals[0], "-9876543")
     print("  ✓ test_negative_integer_auto_detect")
 
 
@@ -42,7 +42,7 @@ fn test_negative_float_auto_detect() raises:
 
     var args: List[String] = ["test", "-3.14"]
     var result = command.parse_arguments(args)
-    assert_equal(result.positionals[0], "-3.14")
+    assert_equal(result._positionals[0], "-3.14")
     print("  ✓ test_negative_float_auto_detect")
 
 
@@ -55,7 +55,7 @@ fn test_negative_leading_dot_auto_detect() raises:
 
     var args: List[String] = ["test", "-.5"]
     var result = command.parse_arguments(args)
-    assert_equal(result.positionals[0], "-.5")
+    assert_equal(result._positionals[0], "-.5")
     print("  ✓ test_negative_leading_dot_auto_detect")
 
 
@@ -69,7 +69,7 @@ fn test_negative_scientific_auto_detect() raises:
 
     var args: List[String] = ["test", "-1.5e10"]
     var result = command.parse_arguments(args)
-    assert_equal(result.positionals[0], "-1.5e10")
+    assert_equal(result._positionals[0], "-1.5e10")
     print("  ✓ test_negative_scientific_auto_detect")
 
 
@@ -82,7 +82,7 @@ fn test_negative_scientific_negative_exp_auto_detect() raises:
 
     var args: List[String] = ["test", "-2.0e-3"]
     var result = command.parse_arguments(args)
-    assert_equal(result.positionals[0], "-2.0e-3")
+    assert_equal(result._positionals[0], "-2.0e-3")
     print("  ✓ test_negative_scientific_negative_exp_auto_detect")
 
 
@@ -98,9 +98,9 @@ fn test_multiple_negative_positionals() raises:
 
     var args: List[String] = ["test", "-1", "-2.5"]
     var result = command.parse_arguments(args)
-    assert_equal(len(result.positionals), 2)
-    assert_equal(result.positionals[0], "-1")
-    assert_equal(result.positionals[1], "-2.5")
+    assert_equal(len(result._positionals), 2)
+    assert_equal(result._positionals[0], "-1")
+    assert_equal(result._positionals[1], "-2.5")
     print("  ✓ test_multiple_negative_positionals")
 
 
@@ -117,7 +117,7 @@ fn test_mixed_negative_and_options() raises:
     var args: List[String] = ["test", "--verbose", "-10.18"]
     var result = command.parse_arguments(args)
     assert_true(result.get_flag("verbose"))
-    assert_equal(result.positionals[0], "-10.18")
+    assert_equal(result._positionals[0], "-10.18")
     print("  ✓ test_mixed_negative_and_options")
 
 
@@ -141,7 +141,7 @@ fn test_explicit_allow_negative_numbers() raises:
     # "-3.14" should still pass through as a positional.
     var args: List[String] = ["test", "-3.14"]
     var result = command.parse_arguments(args)
-    assert_equal(result.positionals[0], "-3.14")
+    assert_equal(result._positionals[0], "-3.14")
     print("  ✓ test_explicit_allow_negative_numbers")
 
 
@@ -162,7 +162,7 @@ fn test_explicit_allow_keeps_digit_short_option() raises:
     # With allow_negative_numbers set, even bare "-3" becomes a positional.
     var args: List[String] = ["test", "-3"]
     var result = command.parse_arguments(args)
-    assert_equal(result.positionals[0], "-3")
+    assert_equal(result._positionals[0], "-3")
     print("  ✓ test_explicit_allow_keeps_digit_short_option")
 
 
@@ -182,7 +182,7 @@ fn test_digit_short_suppresses_auto_detect() raises:
     var result = command.parse_arguments(args)
     # The flag should be set; no positionals.
     assert_true(result.get_flag("triple"))
-    assert_equal(len(result.positionals), 0)
+    assert_equal(len(result._positionals), 0)
     print("  ✓ test_digit_short_suppresses_auto_detect")
 
 
@@ -199,7 +199,7 @@ fn test_double_dash_passes_negative_number() raises:
 
     var args: List[String] = ["test", "--", "-10.18"]
     var result = command.parse_arguments(args)
-    assert_equal(result.positionals[0], "-10.18")
+    assert_equal(result._positionals[0], "-10.18")
     print("  ✓ test_double_dash_passes_negative_number")
 
 
@@ -212,7 +212,7 @@ fn test_double_dash_passes_option_like_string() raises:
 
     var args: List[String] = ["test", "--", "--foo"]
     var result = command.parse_arguments(args)
-    assert_equal(result.positionals[0], "--foo")
+    assert_equal(result._positionals[0], "--foo")
     print("  ✓ test_double_dash_passes_option_like_string")
 
 

--- a/tests/test_parse.mojo
+++ b/tests/test_parse.mojo
@@ -182,8 +182,8 @@ fn test_double_dash_stop() raises:
         result.get_flag("verbose"),
         msg="--verbose after -- should not be parsed as flag",
     )
-    assert_equal(len(result.positionals), 1)
-    assert_equal(result.positionals[0], "--verbose")
+    assert_equal(len(result._positionals), 1)
+    assert_equal(result._positionals[0], "--verbose")
     print("  ✓ test_double_dash_stop")
 
 

--- a/tests/test_subcommands.mojo
+++ b/tests/test_subcommands.mojo
@@ -497,7 +497,7 @@ fn test_parseresult_subcommand_result_stored_and_retrieved() raises:
     """Tests that a child ParseResult can be stored and retrieved."""
     var parent = ParseResult()
     var child = ParseResult()
-    child.values["pattern"] = "hello"
+    child._values["pattern"] = "hello"
     parent.subcommand = "search"
     parent._subcommand_results.append(child^)
     assert_true(parent.has_subcommand_result())
@@ -532,7 +532,7 @@ fn test_parseresult_copy_preserves_subcommand() raises:
     var original = ParseResult()
     original.subcommand = "init"
     var child = ParseResult()
-    child.values["name"] = "myproject"
+    child._values["name"] = "myproject"
     original._subcommand_results.append(child^)
     # Copy explicitly (triggers __copyinit__).
     var copy = original.copy()
@@ -958,7 +958,7 @@ fn test_help_sub_disabled_unknown_word_becomes_positional() raises:
     var args: List[String] = ["app", "help"]
     var result = app.parse_arguments(args)
     assert_equal(result.subcommand, "")
-    assert_equal(result.positionals[0], "help")
+    assert_equal(result._positionals[0], "help")
     print("  ✓ test_help_sub_disabled_unknown_word_becomes_positional")
 
 
@@ -1002,7 +1002,7 @@ fn test_unknown_token_becomes_positional_when_positionals_defined() raises:
     var args: List[String] = ["app", "foo"]
     var result = app.parse_arguments(args)
     assert_equal(result.subcommand, "")
-    assert_equal(result.positionals[0], "foo")
+    assert_equal(result._positionals[0], "foo")
     print("  ✓ test_unknown_token_becomes_positional_when_positionals_defined")
 
 
@@ -1134,7 +1134,7 @@ fn test_allow_positional_with_subcommands_opt_in() raises:
     var args: List[String] = ["app", "hello"]
     var result = app2.parse_arguments(args)
     assert_equal(result.subcommand, "")
-    assert_equal(result.positionals[0], "hello")
+    assert_equal(result._positionals[0], "hello")
     print("  ✓ test_allow_positional_with_subcommands_opt_in")
 
 
@@ -1186,7 +1186,7 @@ fn test_alias_dispatch_basic() raises:
     var result = app.parse_arguments(args)
     assert_equal(result.subcommand, "clone")
     var sub_result = result.get_subcommand_result()
-    assert_equal(sub_result.positionals[0], "https://example.com/repo.git")
+    assert_equal(sub_result._positionals[0], "https://example.com/repo.git")
     print("  ✓ test_alias_dispatch_basic")
 
 


### PR DESCRIPTION
This PR refactors ArgMojo’s core data structures by renaming/making several `Argument` and `ParseResult` attributes “private” (underscore-prefixed), updates `Command` parsing/help/completions to use the renamed fields, and adds a new CLI demo binary to showcase features.

**Changes:**
- Refactor: rename `Argument`/`ParseResult` fields to underscore-prefixed variants and update `Command` internals accordingly.
- Add `examples/demo.mojo` and wire it into `pixi` build/clean plus `.gitignore`.
- Update tests and user docs for the renamed internals and warning message formatting.