### PR TITLE
[core] Parameterize some arguments to enable compile-time check

### DIFF
--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -191,16 +191,16 @@ examples/
 | Append / collect action (`--tag x --tag y` → list)                                                 | ✓      | ✓     |
 | One-required groups (`command.one_required(["json", "yaml"])`)                                     | ✓      | ✓     |
 | Value delimiter (`.delimiter(",")` → split into list)                                              | ✓      | ✓     |
-| Nargs (`.number_of_values(N)` → consume N values per occurrence)                                   | ✓      | ✓     |
+| Nargs (`.number_of_values[N]()` → consume N values per occurrence)                                 | ✓      | ✓     |
 | Conditional requirements (`command.required_if("output", "save")`)                                 | ✓      | ✓     |
-| Numeric range validation (`.range(1, 65535)`)                                                      | ✓      | ✓     |
+| Numeric range validation (`.range[1, 65535]()`)                                                    | ✓      | ✓     |
 | Key-value map option (`.map_option()` → `Dict[String, String]`)                                    | ✓      | ✓     |
 | Aliases (`.aliases(["color"])` for `--colour` / `--color`)                                         | ✓      | ✓     |
 | Deprecated arguments (`.deprecated("msg")` → stderr warning)                                       | ✓      | ✓     |
 | Negative number passthrough (`-9`, `-3.14`, `-1.5e10` as positionals)                              | ✓      | ✓     |
 | Subcommand data model (`add_subcommand()`, dispatch, `help` sub)                                   | ✓      | ✓     |
 | Colored warning and error messages (`_warn()`, `_error()`, all errors printed in colour to stderr) | ✓      | ✓     |
-| Range clamping (`.range(1, 100).clamp()` → adjust + warn instead of error)                         | ✓      | ✓     |
+| Range clamping (`.range[1, 100]().clamp()` → adjust + warn instead of error)                       | ✓      | ✓     |
 
 ### 4.3 API Design (Current)
 
@@ -368,7 +368,7 @@ The practical view — both dimensions checked together at parse time:
 - [x] **colored help output** — ANSI colors (bold+underline headers, colored arg names), with `color=False` opt-out and customisable colors via `header_color()` / `arg_color()`
 - [x] **nargs (multi-value)** — `--point 1 2 3` consumes N values for one option (argparse `nargs`, clap `num_args`)
 - [x] **Conditional requirement** — `--output` required only when `--save` is present (cobra `MarkFlagRequiredWith`, clap `required_if_eq`)
-- [x] **Numeric range validation** — `.range(1, 65535)` validates `--port` value is within range (no major library has this built-in)
+- [x] **Numeric range validation** — `.range[1, 65535]()` validates `--port` value is within range (no major library has this built-in)
 - [x] **Key-value map option** — `--define key=value --define k2=v2` → `Dict[String, String]` (Java `-D`, Docker `-e KEY=VAL`)
 - [x] **Aliases** for long names — `.aliases(["color"])` for `--colour` / `--color`
 - [x] **Deprecated arguments** — `.deprecated("Use --format instead")` prints warning to stderr (argparse 3.13)
@@ -523,7 +523,7 @@ Before adding Phase 5 features, further decompose `parse_arguments()` for readab
 
 - [x] **Typo suggestions** — "Unknown option '--vrb', did you mean '--verbose'?" (Levenshtein distance; cobra, argparse 3.14)
 - [x] **Flag counter with ceiling** — `.count().max(3)` caps `-vvvvv` at 3 with a warning (no major library has this)
-- [x] **Range clamping** — `.range(min, max).clamp()` adjusts out-of-range values to the nearest boundary with a warning instead of erroring (Click has `IntRange(clamp=True)`)
+- [x] **Range clamping** — `.range[min, max]().clamp()` adjusts out-of-range values to the nearest boundary with a warning instead of erroring (Click has `IntRange(clamp=True)`)
 - [x] **Colored error output** — ANSI styled error messages (help output already colored)
 - [x] **Shell completion script generation** — `generate_completion("bash"|"zsh"|"fish")` returns a complete completion script; static approach (no runtime hook), covers options/flags/choices/subcommands (clap `generate`, cobra `completion`, click `shell_complete`)
 - [ ] **Argument groups in help** — group related options under headings (argparse add_argument_group)
@@ -648,7 +648,7 @@ These features represent the "next generation" of CLI parser design, inspired by
 | Enum validation              | `.choices(["debug", "release"])`                                                                                                               | String-level enum; help shows `{debug,release}` |
 | Required / optional          | `.required()` / `.default("...")`                                                                                                              | Parse-time enforcement with coloured errors     |
 | Flag counter (not just bool) | `.count()` + `get_count()`                                                                                                                     | `-vvv → 3`; `.count().max(N)` caps at ceiling   |
-| Range clamping               | `.range(min, max).clamp()`                                                                                                                     | Adjusts out-of-range values with a warning      |
+| Range clamping               | `.range[min, max]().clamp()`                                                                                                                   | Adjusts out-of-range values with a warning      |
 | Subcommand dispatch          | `result.subcommand == "search"` + `get_subcommand_result()`                                                                                    | Same pattern as Go cobra                        |
 
 ## 6. Parsing Algorithm
@@ -729,13 +729,13 @@ ArgMojo follows a consistent naming philosophy. When in doubt, apply these prior
 
 ### Decisions made
 
-| Abbreviation (rejected)   | Full form (adopted)                 | Rationale                                                                                      |
-| ------------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `Arg`                     | `Argument`                          | Internal struct name; aligns with `add_argument()`                                             |
-| `parse_args()`            | `parse_arguments()`                 | Consistent with `Argument` naming; `parse_args` was an argparse legacy                         |
-| `help_on_no_args()`       | `help_on_no_arguments()`            | Same reason                                                                                    |
-| `_aliases`                | `_command_aliases`                  | Disambiguates from `Argument.aliases()` (option-level aliases)                                 |
-| `nargs()` / `nargs_count` | `number_of_values()` / `num_values` | Method uses full descriptive name; field uses short form to avoid Mojo field/method name clash |
+| Abbreviation (rejected)   | Full form (adopted)                    | Rationale                                                                                      |
+| ------------------------- | -------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `Arg`                     | `Argument`                             | Internal struct name; aligns with `add_argument()`                                             |
+| `parse_args()`            | `parse_arguments()`                    | Consistent with `Argument` naming; `parse_args` was an argparse legacy                         |
+| `help_on_no_args()`       | `help_on_no_arguments()`               | Same reason                                                                                    |
+| `_aliases`                | `_command_aliases`                     | Disambiguates from `Argument.aliases()` (option-level aliases)                                 |
+| `nargs()` / `nargs_count` | `number_of_values[N]()` / `num_values` | Method uses full descriptive name; field uses short form to avoid Mojo field/method name clash |
 
 ## 8. Notes on Mojo versions
 

--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -522,7 +522,7 @@ Before adding Phase 5 features, further decompose `parse_arguments()` for readab
 #### Features
 
 - [x] **Typo suggestions** — "Unknown option '--vrb', did you mean '--verbose'?" (Levenshtein distance; cobra, argparse 3.14)
-- [x] **Flag counter with ceiling** — `.count().max(3)` caps `-vvvvv` at 3 with a warning (no major library has this)
+- [x] **Flag counter with ceiling** — `.count().max[3]()` caps `-vvvvv` at 3 with a warning (no major library has this)
 - [x] **Range clamping** — `.range[min, max]().clamp()` adjusts out-of-range values to the nearest boundary with a warning instead of erroring (Click has `IntRange(clamp=True)`)
 - [x] **Colored error output** — ANSI styled error messages (help output already colored)
 - [x] **Shell completion script generation** — `generate_completion("bash"|"zsh"|"fish")` returns a complete completion script; static approach (no runtime hook), covers options/flags/choices/subcommands (clap `generate`, cobra `completion`, click `shell_complete`)
@@ -647,7 +647,7 @@ These features represent the "next generation" of CLI parser design, inspired by
 | Typed retrieval              | `get_flag()->Bool`, `get_int()->Int`, `get_string()->String`, `get_count()->Int`, `get_list()->List[String]`, `get_map()->Dict[String,String]` | Already typed at retrieval                      |
 | Enum validation              | `.choices(["debug", "release"])`                                                                                                               | String-level enum; help shows `{debug,release}` |
 | Required / optional          | `.required()` / `.default("...")`                                                                                                              | Parse-time enforcement with coloured errors     |
-| Flag counter (not just bool) | `.count()` + `get_count()`                                                                                                                     | `-vvv → 3`; `.count().max(N)` caps at ceiling   |
+| Flag counter (not just bool) | `.count()` + `get_count()`                                                                                                                     | `-vvv → 3`; `.count().max[N]()` caps at ceiling |
 | Range clamping               | `.range[min, max]().clamp()`                                                                                                                   | Adjusts out-of-range values with a warning      |
 | Subcommand dispatch          | `result.subcommand == "search"` + `get_subcommand_result()`                                                                                    | Same pattern as Go cobra                        |
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -97,7 +97,7 @@ ArgMojo v0.1.0 is compatible with Mojo v0.26.1.
 1. Negatable flags — `--color` / `--no-color` paired flags with `.negatable()`.
 1. Long option prefix matching — `--verb` auto-resolves to `--verbose` when unambiguous.
 1. Conditional requirements — `--output` required only when `--save` is present.
-1. Numeric range validation — `.range(1, 65535)` validates value is within bounds.
+1. Numeric range validation — `.range[1, 65535]()` validates value is within bounds.
 
 **Groups:**
 
@@ -109,7 +109,7 @@ ArgMojo v0.1.0 is compatible with Mojo v0.26.1.
 
 1. Append / collect action — `--tag x --tag y` collects repeated options into a list with `.append()`.
 1. Value delimiter — `--env dev,staging,prod` splits by delimiter into a list with `.delimiter(",")`.
-1. Multi-value options (nargs) — `--point 10 20` consumes N consecutive values with `.number_of_values(N)`.
+1. Multi-value options (nargs) — `--point 10 20` consumes N consecutive values with `.number_of_values[N]()`.
 1. Key-value map option — `--define key=value` builds a `Dict` with `.key_value()`.
 
 **Help & display:**

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,18 @@ This document tracks all notable changes to ArgMojo, including new features, API
 Do not add unreleased changes here. This file will be edited just before each release to reflect the final changelog for that version.
 -->
 
+<!-- 
+## 20260303 (v0.3.0)
+
+ArgMojo v0.3.0 enables shell completion script generation for Bash, Zsh, and Fish. 
+
+### ⭐️ New in v0.3.0
+1. completion (PR #4)
+1. typo suggestions (PR #3)
+1. Command aliases (PR #5)
+1. Range clamping with warning message if users pass out-of-range values (#6)
+-->
+
 ## 20260228 (v0.2.0)
 
 ArgMojo v0.2.0 is a major release that transforms the library from a single-command parser into a full **subcommand-capable CLI framework**. It introduces hierarchical subcommands with automatic dispatch, persistent (global) flags with bidirectional sync, negative number passthrough, colored error messages, custom tips, and significant help/UX improvements. The public API is also refined: `Arg` → `Argument`, `Result` → `ParseResult` (old names kept as aliases). Two complete example CLIs (`mgrep` and `mgit`) replace the previous demo.
@@ -109,7 +121,7 @@ ArgMojo v0.1.0 is compatible with Mojo v0.26.1.
 
 1. Append / collect action — `--tag x --tag y` collects repeated options into a list with `.append()`.
 1. Value delimiter — `--env dev,staging,prod` splits by delimiter into a list with `.delimiter(",")`.
-1. Multi-value options (nargs) — `--point 10 20` consumes N consecutive values with `.number_of_values[N]()`.
+1. Multi-value options (nargs) — `--point 10 20` consumes N consecutive values with `.number_of_values[N]()` (breaking change from v0.1.0: replaces the old `.number_of_values(N)` runtime form, which no longer works).
 1. Key-value map option — `--define key=value` builds a `Dict` with `.key_value()`.
 
 **Help & display:**

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -24,7 +24,7 @@ from argmojo import Argument, Command
   - [Attached Short Values](#attached-short-values)
 - [Flag Variants](#flag-variants)
   - [Count Flags](#count-flags)
-  - [Count Ceiling (`.max()`)](#count-ceiling-max)
+  - [Count Ceiling (`.max[N]()`)](#count-ceiling-maxn)
   - [Negatable Flags](#negatable-flags)
 - [Collecting Multiple Values](#collecting-multiple-values)
   - [Append / Collect Action](#append--collect-action)
@@ -378,14 +378,14 @@ Count flags are a special kind of boolean flag — calling `.count()` automatica
 
 Merged short flags work seamlessly: `-vvv` is three occurrences of `-v`.
 
-### Count Ceiling (`.max()`)
+### Count Ceiling (`.max[N]()`)
 
-You can cap a count flag at a maximum value with `.max(n)`. Any occurrences beyond the ceiling are clamped to the maximum and a warning is printed to stderr informing the user of the adjustment.
+You can cap a count flag at a maximum value with `.max[n]()`. The ceiling value `n` is a compile-time parameter (must be ≥ 1); invalid values are caught at build time. Any occurrences beyond the ceiling are clamped to the maximum and a warning is printed to stderr informing the user of the adjustment.
 
 ```mojo
 command.add_argument(
     Argument("verbose", help="Increase verbosity (capped at 3)")
-    .long("verbose").short("v").count().max(3)
+    .long("verbose").short("v").count().max[3]()
 )
 ```
 
@@ -695,8 +695,8 @@ command.add_argument(Argument("point", help="X Y coordinates").long("point").num
 command.add_argument(Argument("rgb", help="RGB colour").long("rgb").short("c").number_of_values(3))
 ```
 
-`.number_of_values(N)` automatically implies `.append()` — values are stored in
-`ParseResult._lists` and retrieved with `get_list()`.
+`.number_of_values(N)` automatically implies `.append()` — values are
+retrieved with `get_list()`.
 
 ---
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -970,7 +970,7 @@ myapp --port 50 --port 101
 
 ### Range Clamping (`.clamp()`)
 
-By default, an out-of-range value causes a hard error. If you prefer a gentler approach, chain `.clamp()` after `.range()` to **adjust** the value to the nearest boundary and print a warning instead of failing.
+By default, an out-of-range value causes a hard error. If you prefer a gentler approach, chain `.clamp()` after `.range[min, max]()` to **adjust** the value to the nearest boundary and print a warning instead of failing.
 
 ```mojo
 command.add_argument(

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -688,14 +688,14 @@ This is similar to Python argparse's `nargs=N` and Rust clap's `num_args`.
 
 **Defining a multi-value option**
 
-Use `.number_of_values(N)` to specify how many values the option consumes:
+Use `.number_of_values[N]()` to specify how many values the option consumes:
 
 ```mojo
-command.add_argument(Argument("point", help="X Y coordinates").long("point").number_of_values(2))
-command.add_argument(Argument("rgb", help="RGB colour").long("rgb").short("c").number_of_values(3))
+command.add_argument(Argument("point", help="X Y coordinates").long("point").number_of_values[2]())
+command.add_argument(Argument("rgb", help="RGB colour").long("rgb").short("c").number_of_values[3]())
 ```
 
-`.number_of_values(N)` automatically implies `.append()` — values are
+`.number_of_values[N]()` automatically implies `.append()` — values are
 retrieved with `get_list()`.
 
 ---
@@ -749,7 +749,7 @@ Choices are validated for **each** value individually:
 ```mojo
 var dirs: List[String] = ["north", "south", "east", "west"]
 command.add_argument(
-    Argument("route", help="Start and end").long("route").number_of_values(2).choices(dirs^)
+    Argument("route", help="Start and end").long("route").number_of_values[2]().choices(dirs^)
 )
 ```
 
@@ -925,7 +925,7 @@ myapp "hello" ./src /tmp       # Error: Too many positional arguments: expected 
 ### Numeric Range Validation
 
 Constrain a numeric argument to an inclusive `[min, max]` range
-with `.range(min, max)`.  The validation is applied after parsing,
+with `.range[min, max]()`.  The validation is applied after parsing,
 so the value is still stored as a string; `atol()` is used internally
 to convert and compare.
 
@@ -933,7 +933,7 @@ to convert and compare.
 command.add_argument(
     Argument("port", help="Listening port")
         .long("port")
-        .range(1, 65535)
+        .range[1, 65535]()
 )
 ```
 
@@ -959,7 +959,7 @@ myapp --port 65535   # OK
 
 ```mojo
 command.add_argument(
-    Argument("port", help="Ports").long("port").append().range(1, 100)
+    Argument("port", help="Ports").long("port").append().range[1, 100]()
 )
 ```
 
@@ -976,7 +976,7 @@ By default, an out-of-range value causes a hard error. If you prefer a gentler a
 command.add_argument(
     Argument("level", help="Compression level (0–9)")
         .long("level")
-        .range(0, 9)
+        .range[0, 9]()
         .clamp()
 )
 ```
@@ -999,7 +999,7 @@ warning: '--level' value 20 is out of range [0, 9], clamped to 9
 
 ```mojo
 command.add_argument(
-    Argument("port", help="Ports").long("port").append().range(1, 100).clamp()
+    Argument("port", help="Ports").long("port").append().range[1, 100]().clamp()
 )
 ```
 

--- a/examples/demo.mojo
+++ b/examples/demo.mojo
@@ -109,7 +109,7 @@ fn main() raises:
         .long("verbose")
         .short("v")
         .count()
-        .max(3)
+        .max[3]()
     )
 
     # ── Numeric range with clamping ──────────────────────────────────────

--- a/examples/demo.mojo
+++ b/examples/demo.mojo
@@ -118,7 +118,7 @@ fn main() raises:
         Argument("level", help="Processing level [0–9]")
         .long("level")
         .short("l")
-        .range(0, 9)
+        .range[0, 9]()
         .clamp()
     )
 
@@ -145,7 +145,7 @@ fn main() raises:
         .long("port")
         .short("P")
         .append()
-        .range(1, 65535)
+        .range[1, 65535]()
         .clamp()
     )
     var net_group: List[String] = ["host", "port"]
@@ -171,7 +171,7 @@ fn main() raises:
     app.add_argument(
         Argument("point", help="A 3D point (X Y Z)")
         .long("point")
-        .number_of_values(3)
+        .number_of_values[3]()
         .metavar("COORD")
     )
 
@@ -263,7 +263,7 @@ fn main() raises:
         Argument("workers", help="Number of parallel workers [1-32]")
         .long("workers")
         .short("w")
-        .range(1, 32)
+        .range[1, 32]()
         .clamp()
         .default("4")
     )
@@ -271,7 +271,7 @@ fn main() raises:
         Argument("threshold", help="Confidence threshold [0-100]")
         .long("threshold")
         .metavar("PCT")
-        .range(0, 100)
+        .range[0, 100]()
         .clamp()
     )
     analyze.help_on_no_arguments()

--- a/examples/mgit.mojo
+++ b/examples/mgit.mojo
@@ -78,7 +78,7 @@ fn main() raises:
         Argument("depth", help="Create a shallow clone with N commits")
         .long("depth")
         .metavar("N")
-        .range(1, 999999)
+        .range[1, 999999]()
     )
     clone.add_argument(
         Argument("branch", help="Check out this branch instead of HEAD")
@@ -268,7 +268,7 @@ fn main() raises:
         .long("number")
         .short("n")
         .metavar("N")
-        .range(1, 999999)
+        .range[1, 999999]()
     )
     log.add_argument(
         Argument("author", help="Filter by author")

--- a/examples/mgrep.mojo
+++ b/examples/mgrep.mojo
@@ -140,7 +140,7 @@ fn main() raises:
         .long("max-depth")
         .short("d")
         .metavar("N")
-        .range(0, 999)
+        .range[0, 999]()
     )
 
     # ── Context control (nargs) ──────────────────────────────────────────
@@ -148,7 +148,7 @@ fn main() raises:
         Argument("context", help="Print B lines before and A lines after match")
         .long("context")
         .short("C")
-        .number_of_values(2)
+        .number_of_values[2]()
         .metavar("N")
     )
 

--- a/src/argmojo/argument.mojo
+++ b/src/argmojo/argument.mojo
@@ -38,11 +38,11 @@ struct Argument(Copyable, Movable, Stringable, Writable):
     # Value delimiter  (--env a,b,c → ["a","b","c"])  →  result.get_list("env")
     _ = Argument("env", help="...").long("env").delimiter(",")
     # Multi-value  (--point 1 2 → ["1","2"])  →  result.get_list("point")
-    _ = Argument("point", help="...").long("point").number_of_values(2)
+    _ = Argument("point", help="...").long("point").number_of_values[2]()
     # Numeric range validation  →  result.get_int("port")
-    _ = Argument("port", help="...").long("port").range(1, 65535)
+    _ = Argument("port", help="...").long("port").range[1, 65535]()
     # Numeric range with clamping  (--level 200 → 100 with warning)
-    _ = Argument("level", help="...").long("level").range(0, 100).clamp()
+    _ = Argument("level", help="...").long("level").range[0, 100]().clamp()
     # Key-value map  (--def k=v --def k2=v2)  →  result.get_map("def")
     _ = Argument("def", help="...").long("define").short("D").map_option()
     # Aliases  (--colour and --color both work)
@@ -374,7 +374,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
     # rather than developers, may encounter errors about a wrong ceiling value
     # in the terminal when they use the API, no matter they are using it
     # correctly or not. That would be catastrophic.
-    fn max[ceiling: Int](var self) -> Self:
+    fn max[ceiling: Int](var self) -> Self where ceiling >= 1:
         """Sets a ceiling for a counter flag.
 
         When a counter flag has a ceiling, the count is capped at the
@@ -389,7 +389,6 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         Returns:
             Self with the count ceiling set.
         """
-        constrained[ceiling >= 1, "max(): ceiling must be >= 1"]()
         if not self._is_count:
             print(
                 (
@@ -452,16 +451,16 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         self._is_append = True
         return self^
 
-    fn number_of_values(var self, n: Int) -> Self:
+    fn number_of_values[n: Int](var self) -> Self where n >= 2:
         """Sets the number of values consumed per occurrence.
 
         When set, each use of the option consumes exactly ``n``
-        consecutive arguments.  For example, ``.number_of_values(2)`` on
+        consecutive arguments.  For example, ``.number_of_values[2]()`` on
         ``--point`` causes ``--point 1 2`` to collect ``["1", "2"]``.
         Implies ``.append()`` so values are retrieved with
         ``ParseResult.get_list()``.
 
-        Args:
+        Parameters:
             n: Number of values to consume (must be ≥ 2).
 
         Returns:
@@ -471,7 +470,9 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         self._is_append = True
         return self^
 
-    fn range(var self, min_val: Int, max_val: Int) -> Self:
+    fn range[
+        min_val: Int, max_val: Int
+    ](var self) -> Self where max_val >= min_val:
         """Sets numeric range validation for this argument.
 
         When set, the parsed value must be an integer within
@@ -482,7 +483,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         ``.clamp()`` to silently adjust the value (with a warning)
         instead of erroring.
 
-        Args:
+        Parameters:
             min_val: Minimum allowed value (inclusive).
             max_val: Maximum allowed value (inclusive).
 
@@ -497,12 +498,12 @@ struct Argument(Copyable, Movable, Stringable, Writable):
     fn clamp(var self) -> Self:
         """Enables clamping for numeric range validation.
 
-        When clamping is enabled (used after ``.range(min, max)``),
+        When clamping is enabled (used after ``.range[min, max]()``),
         out-of-range values are adjusted to the nearest boundary
         instead of causing an error.  A warning is printed to stderr
         to inform the user of the adjustment.
 
-        For example, ``.range(1, 100).clamp()`` causes ``--level 200``
+        For example, ``.range[1, 100]().clamp()`` causes ``--level 200``
         to be silently adjusted to 100 with a warning.
 
         Must be used after ``.range()``.

--- a/src/argmojo/argument.mojo
+++ b/src/argmojo/argument.mojo
@@ -30,7 +30,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
     # Count flag  (-vvv → 3)  →  result.get_count("verbose")
     _ = Argument("verbose", help="...").long("verbose").short("v").count()
     # Count flag with ceiling  (-vvvvv capped at 3)
-    _ = Argument("verbose", help="...").long("verbose").short("v").count().max(3)
+    _ = Argument("verbose", help="...").long("verbose").short("v").count().max[3]()
     # Negatable flag  (--color / --no-color)  →  result.get_flag("color")
     _ = Argument("color", help="...").long("color").flag().negatable()
     # Append / collect  (--tag x --tag y → ["x","y"])  →  result.get_list("tag")
@@ -357,7 +357,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         Each occurrence increments a counter. For example, ``-vvv`` sets
         the count to 3. Use ``get_count()`` on ParseResult to retrieve.
 
-        Chain with ``.max(n)`` to cap the counter at a ceiling value.
+        Chain with ``.max[n]()`` to cap the counter at a ceiling value.
 
         Returns:
             Self marked as a counter.
@@ -366,30 +366,30 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         self._is_flag = True
         return self^
 
-    fn max(var self, ceiling: Int) -> Self:
+    # [Mojo Miji]
+    # We set `ceiling` as a parameter, instead of an argument, because we
+    # want to check at compile time that it is a positive integer.
+    # If we made it an argument, we could not check it at compile time,
+    # and the check would be deferred to runtime, which means that the users,
+    # rather than developers, may encounter errors about a wrong ceiling value
+    # in the terminal when they use the API, no matter they are using it
+    # correctly or not. That would be catastrophic.
+    fn max[ceiling: Int](var self) -> Self:
         """Sets a ceiling for a counter flag.
 
         When a counter flag has a ceiling, the count is capped at the
         given value regardless of how many times the flag appears.
-        For example, ``.count().max(3)`` caps ``-vvvvv`` at 3.
+        For example, ``.count().max[3]()`` caps ``-vvvvv`` at 3.
 
         Must be used after ``.count()``.
 
-        Args:
+        Parameters:
             ceiling: The maximum count value (must be ≥ 1).
 
         Returns:
             Self with the count ceiling set.
         """
-        if ceiling < 1:
-            print(
-                (
-                    "Argument.max(): ceiling must be >= 1; call .max() with"
-                    " a value of at least 1."
-                ),
-                file=stderr,
-            )
-            exit(1)
+        constrained[ceiling >= 1, "max(): ceiling must be >= 1"]()
         if not self._is_count:
             print(
                 (
@@ -458,8 +458,8 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         When set, each use of the option consumes exactly ``n``
         consecutive arguments.  For example, ``.number_of_values(2)`` on
         ``--point`` causes ``--point 1 2`` to collect ``["1", "2"]``.
-        Implies ``.append()`` so values are stored in
-        ``ParseResult._lists``.
+        Implies ``.append()`` so values are retrieved with
+        ``ParseResult.get_list()``.
 
         Args:
             n: Number of values to consume (must be ≥ 2).
@@ -517,8 +517,8 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         """Marks this argument as a key-value map option.
 
         Each value must be in ``key=value`` format.  Values are
-        stored in ``ParseResult._maps`` and retrieved with
-        ``get_map()``.  Implies ``.append()`` for repeated uses.
+        retrieved with ``get_map()``.  Implies ``.append()`` for
+        repeated uses.
 
         For example, ``--define DEBUG=1 --define VERSION=2`` produces
         ``{"DEBUG": "1", "VERSION": "2"}``.
@@ -577,8 +577,9 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         The child result also carries the value when the flag appears
         after the subcommand token.
 
-        Persistent arguments may not share a ``_long_name`` or ``_short_name``
-        with any local argument of a registered subcommand — ArgMojo raises
+        Persistent arguments may not use the same long or short option
+        strings (as configured via ``.long()`` and ``.short()``) as any
+        argument that is local to a registered subcommand.  ArgMojo raises
         an error at ``add_subcommand()`` time if a conflict is detected.
 
         Returns:

--- a/tests/test_collect.mojo
+++ b/tests/test_collect.mojo
@@ -418,7 +418,7 @@ fn test_nargs_basic() raises:
     command.add_argument(
         Argument("point", help="X Y coordinates")
         .long("point")
-        .number_of_values(2)
+        .number_of_values[2]()
     )
 
     var args: List[String] = ["test", "--point", "10", "20"]
@@ -434,7 +434,7 @@ fn test_nargs_three() raises:
     """Tests that number_of_values(3) consumes exactly 3 values."""
     var command = Command("test", "Test app")
     command.add_argument(
-        Argument("rgb", help="RGB colour").long("rgb").number_of_values(3)
+        Argument("rgb", help="RGB colour").long("rgb").number_of_values[3]()
     )
 
     var args: List[String] = ["test", "--rgb", "255", "128", "0"]
@@ -454,7 +454,7 @@ fn test_nargs_short_option() raises:
         Argument("point", help="X Y")
         .long("point")
         .short("p")
-        .number_of_values(2)
+        .number_of_values[2]()
     )
 
     var args: List[String] = ["test", "-p", "3", "4"]
@@ -472,7 +472,7 @@ fn test_nargs_repeated() raises:
     """Tests that nargs collects across repeated occurrences."""
     var command = Command("test", "Test app")
     command.add_argument(
-        Argument("point", help="X Y").long("point").number_of_values(2)
+        Argument("point", help="X Y").long("point").number_of_values[2]()
     )
 
     var args: List[String] = [
@@ -500,7 +500,7 @@ fn test_nargs_too_few_values() raises:
     """Tests that nargs raises when not enough values are available."""
     var command = Command("test", "Test app")
     command.add_argument(
-        Argument("point", help="X Y").long("point").number_of_values(2)
+        Argument("point", help="X Y").long("point").number_of_values[2]()
     )
 
     var args: List[String] = ["test", "--point", "10"]
@@ -522,7 +522,7 @@ fn test_nargs_too_few_short() raises:
     """Tests that nargs raises with short option when not enough values."""
     var command = Command("test", "Test app")
     command.add_argument(
-        Argument("point", help="X Y").short("p").number_of_values(2)
+        Argument("point", help="X Y").short("p").number_of_values[2]()
     )
 
     var args: List[String] = ["test", "-p", "10"]
@@ -547,7 +547,7 @@ fn test_nargs_with_choices() raises:
     command.add_argument(
         Argument("dir", help="Two directions")
         .long("dir")
-        .number_of_values(2)
+        .number_of_values[2]()
         .choices(dirs^)
     )
 
@@ -578,7 +578,7 @@ fn test_nargs_with_other_args() raises:
         Argument("verbose", help="Verbose").long("verbose").short("v").flag()
     )
     command.add_argument(
-        Argument("point", help="X Y").long("point").number_of_values(2)
+        Argument("point", help="X Y").long("point").number_of_values[2]()
     )
     command.add_argument(
         Argument("output", help="File").long("output").short("o")
@@ -609,7 +609,7 @@ fn test_nargs_equals_syntax_rejected() raises:
     """Tests that = syntax is rejected for nargs options."""
     var command = Command("test", "Test app")
     command.add_argument(
-        Argument("point", help="X Y").long("point").number_of_values(2)
+        Argument("point", help="X Y").long("point").number_of_values[2]()
     )
 
     var args: List[String] = ["test", "--point=10", "20"]
@@ -631,7 +631,7 @@ fn test_nargs_prefix_match() raises:
     """Tests that prefix matching works with nargs options."""
     var command = Command("test", "Test app")
     command.add_argument(
-        Argument("position", help="X Y").long("position").number_of_values(2)
+        Argument("position", help="X Y").long("position").number_of_values[2]()
     )
 
     var args: List[String] = ["test", "--pos", "7", "8"]

--- a/tests/test_extras.mojo
+++ b/tests/test_extras.mojo
@@ -11,7 +11,7 @@ fn test_range_valid_value() raises:
     """Tests that a value within range is accepted."""
     var command = Command("test", "Test app")
     command.add_argument(
-        Argument("port", help="Port").long("port").range(1, 65535)
+        Argument("port", help="Port").long("port").range[1, 65535]()
     )
 
     var args: List[String] = ["test", "--port", "8080"]
@@ -24,7 +24,7 @@ fn test_range_boundary_min() raises:
     """Tests that the exact minimum boundary value is accepted."""
     var command = Command("test", "Test app")
     command.add_argument(
-        Argument("port", help="Port").long("port").range(1, 65535)
+        Argument("port", help="Port").long("port").range[1, 65535]()
     )
 
     var args: List[String] = ["test", "--port", "1"]
@@ -37,7 +37,7 @@ fn test_range_boundary_max() raises:
     """Tests that the exact maximum boundary value is accepted."""
     var command = Command("test", "Test app")
     command.add_argument(
-        Argument("port", help="Port").long("port").range(1, 65535)
+        Argument("port", help="Port").long("port").range[1, 65535]()
     )
 
     var args: List[String] = ["test", "--port", "65535"]
@@ -50,7 +50,7 @@ fn test_range_below_min() raises:
     """Tests that a value below the minimum is rejected."""
     var command = Command("test", "Test app")
     command.add_argument(
-        Argument("port", help="Port").long("port").range(1, 65535)
+        Argument("port", help="Port").long("port").range[1, 65535]()
     )
 
     var args: List[String] = ["test", "--port", "0"]
@@ -72,7 +72,7 @@ fn test_range_above_max() raises:
     """Tests that a value above the maximum is rejected."""
     var command = Command("test", "Test app")
     command.add_argument(
-        Argument("port", help="Port").long("port").range(1, 65535)
+        Argument("port", help="Port").long("port").range[1, 65535]()
     )
 
     var args: List[String] = ["test", "--port", "70000"]
@@ -93,7 +93,7 @@ fn test_range_not_provided_ok() raises:
     """Tests that an optional range arg is fine when not provided."""
     var command = Command("test", "Test app")
     command.add_argument(
-        Argument("port", help="Port").long("port").range(1, 65535)
+        Argument("port", help="Port").long("port").range[1, 65535]()
     )
 
     var args: List[String] = ["test"]
@@ -106,7 +106,7 @@ fn test_range_with_append() raises:
     """Tests range validation on appended values."""
     var command = Command("test", "Test app")
     command.add_argument(
-        Argument("port", help="Ports").long("port").append().range(1, 100)
+        Argument("port", help="Ports").long("port").append().range[1, 100]()
     )
 
     var args: List[String] = ["test", "--port", "50", "--port", "101"]
@@ -128,7 +128,7 @@ fn test_range_with_short_option() raises:
     """Tests range validation with a short option."""
     var command = Command("test", "Test app")
     command.add_argument(
-        Argument("level", help="Level").long("level").short("l").range(0, 5)
+        Argument("level", help="Level").long("level").short("l").range[0, 5]()
     )
 
     var args: List[String] = ["test", "-l", "3"]
@@ -144,7 +144,7 @@ fn test_clamp_above_max() raises:
     """Tests that .clamp() adjusts a value above max to max."""
     var command = Command("test", "Test app")
     command.add_argument(
-        Argument("level", help="Level").long("level").range(1, 100).clamp()
+        Argument("level", help="Level").long("level").range[1, 100]().clamp()
     )
 
     var args: List[String] = ["test", "--level", "200"]
@@ -161,7 +161,7 @@ fn test_clamp_below_min() raises:
     """Tests that .clamp() adjusts a value below min to min."""
     var command = Command("test", "Test app")
     command.add_argument(
-        Argument("level", help="Level").long("level").range(1, 100).clamp()
+        Argument("level", help="Level").long("level").range[1, 100]().clamp()
     )
 
     var args: List[String] = ["test", "--level", "-5"]
@@ -178,7 +178,7 @@ fn test_clamp_within_range_no_change() raises:
     """Tests that .clamp() does not affect a value within range."""
     var command = Command("test", "Test app")
     command.add_argument(
-        Argument("level", help="Level").long("level").range(1, 100).clamp()
+        Argument("level", help="Level").long("level").range[1, 100]().clamp()
     )
 
     var args: List[String] = ["test", "--level", "50"]
@@ -195,7 +195,7 @@ fn test_clamp_at_boundary() raises:
     """Tests that .clamp() does not trigger at exact boundaries."""
     var command = Command("test", "Test app")
     command.add_argument(
-        Argument("port", help="Port").long("port").range(1, 65535).clamp()
+        Argument("port", help="Port").long("port").range[1, 65535]().clamp()
     )
 
     var args1: List[String] = ["test", "--port", "1"]
@@ -217,7 +217,7 @@ fn test_clamp_with_short_option() raises:
         Argument("level", help="Level")
         .long("level")
         .short("l")
-        .range(0, 10)
+        .range[0, 10]()
         .clamp()
     )
 
@@ -238,7 +238,7 @@ fn test_clamp_with_append() raises:
         Argument("port", help="Ports")
         .long("port")
         .append()
-        .range(1, 100)
+        .range[1, 100]()
         .clamp()
     )
 
@@ -263,7 +263,7 @@ fn test_range_without_clamp_still_errors() raises:
     """Tests that .range() without .clamp() still raises errors."""
     var command = Command("test", "Test app")
     command.add_argument(
-        Argument("port", help="Port").long("port").range(1, 65535)
+        Argument("port", help="Port").long("port").range[1, 65535]()
     )
 
     var args: List[String] = ["test", "--port", "99999"]

--- a/tests/test_help.mojo
+++ b/tests/test_help.mojo
@@ -500,12 +500,12 @@ fn test_nargs_in_help() raises:
     """Tests that nargs options show repeated placeholders in help."""
     var command = Command("test", "Test app")
     command.add_argument(
-        Argument("point", help="X Y coords").long("point").number_of_values(2)
+        Argument("point", help="X Y coords").long("point").number_of_values[2]()
     )
     command.add_argument(
         Argument("rgb", help="RGB colour")
         .long("rgb")
-        .number_of_values(3)
+        .number_of_values[3]()
         .metavar("N")
     )
 
@@ -534,7 +534,7 @@ fn test_nargs_with_metavar() raises:
     command.add_argument(
         Argument("size", help="Width and height")
         .long("size")
-        .number_of_values(2)
+        .number_of_values[2]()
         .metavar("PX")
     )
 

--- a/tests/test_negative_numbers.mojo
+++ b/tests/test_negative_numbers.mojo
@@ -29,7 +29,7 @@ fn test_negative_integer_auto_detect() raises:
 
     var args: List[String] = ["test", "-9876543"]
     var result = command.parse_arguments(args)
-    assert_equal(result._positionals[0], "-9876543")
+    assert_equal(result.get_string("value"), "-9876543")
     print("  ✓ test_negative_integer_auto_detect")
 
 
@@ -42,7 +42,7 @@ fn test_negative_float_auto_detect() raises:
 
     var args: List[String] = ["test", "-3.14"]
     var result = command.parse_arguments(args)
-    assert_equal(result._positionals[0], "-3.14")
+    assert_equal(result.get_string("value"), "-3.14")
     print("  ✓ test_negative_float_auto_detect")
 
 
@@ -55,7 +55,7 @@ fn test_negative_leading_dot_auto_detect() raises:
 
     var args: List[String] = ["test", "-.5"]
     var result = command.parse_arguments(args)
-    assert_equal(result._positionals[0], "-.5")
+    assert_equal(result.get_string("value"), "-.5")
     print("  ✓ test_negative_leading_dot_auto_detect")
 
 
@@ -69,7 +69,7 @@ fn test_negative_scientific_auto_detect() raises:
 
     var args: List[String] = ["test", "-1.5e10"]
     var result = command.parse_arguments(args)
-    assert_equal(result._positionals[0], "-1.5e10")
+    assert_equal(result.get_string("value"), "-1.5e10")
     print("  ✓ test_negative_scientific_auto_detect")
 
 
@@ -82,7 +82,7 @@ fn test_negative_scientific_negative_exp_auto_detect() raises:
 
     var args: List[String] = ["test", "-2.0e-3"]
     var result = command.parse_arguments(args)
-    assert_equal(result._positionals[0], "-2.0e-3")
+    assert_equal(result.get_string("value"), "-2.0e-3")
     print("  ✓ test_negative_scientific_negative_exp_auto_detect")
 
 
@@ -99,8 +99,8 @@ fn test_multiple_negative_positionals() raises:
     var args: List[String] = ["test", "-1", "-2.5"]
     var result = command.parse_arguments(args)
     assert_equal(len(result._positionals), 2)
-    assert_equal(result._positionals[0], "-1")
-    assert_equal(result._positionals[1], "-2.5")
+    assert_equal(result.get_string("a"), "-1")
+    assert_equal(result.get_string("b"), "-2.5")
     print("  ✓ test_multiple_negative_positionals")
 
 
@@ -117,7 +117,7 @@ fn test_mixed_negative_and_options() raises:
     var args: List[String] = ["test", "--verbose", "-10.18"]
     var result = command.parse_arguments(args)
     assert_true(result.get_flag("verbose"))
-    assert_equal(result._positionals[0], "-10.18")
+    assert_equal(result.get_string("value"), "-10.18")
     print("  ✓ test_mixed_negative_and_options")
 
 
@@ -141,7 +141,7 @@ fn test_explicit_allow_negative_numbers() raises:
     # "-3.14" should still pass through as a positional.
     var args: List[String] = ["test", "-3.14"]
     var result = command.parse_arguments(args)
-    assert_equal(result._positionals[0], "-3.14")
+    assert_equal(result.get_string("value"), "-3.14")
     print("  ✓ test_explicit_allow_negative_numbers")
 
 
@@ -162,7 +162,7 @@ fn test_explicit_allow_keeps_digit_short_option() raises:
     # With allow_negative_numbers set, even bare "-3" becomes a positional.
     var args: List[String] = ["test", "-3"]
     var result = command.parse_arguments(args)
-    assert_equal(result._positionals[0], "-3")
+    assert_equal(result.get_string("value"), "-3")
     print("  ✓ test_explicit_allow_keeps_digit_short_option")
 
 
@@ -199,7 +199,7 @@ fn test_double_dash_passes_negative_number() raises:
 
     var args: List[String] = ["test", "--", "-10.18"]
     var result = command.parse_arguments(args)
-    assert_equal(result._positionals[0], "-10.18")
+    assert_equal(result.get_string("value"), "-10.18")
     print("  ✓ test_double_dash_passes_negative_number")
 
 
@@ -212,7 +212,7 @@ fn test_double_dash_passes_option_like_string() raises:
 
     var args: List[String] = ["test", "--", "--foo"]
     var result = command.parse_arguments(args)
-    assert_equal(result._positionals[0], "--foo")
+    assert_equal(result.get_string("value"), "--foo")
     print("  ✓ test_double_dash_passes_option_like_string")
 
 

--- a/tests/test_negative_numbers.mojo
+++ b/tests/test_negative_numbers.mojo
@@ -98,7 +98,8 @@ fn test_multiple_negative_positionals() raises:
 
     var args: List[String] = ["test", "-1", "-2.5"]
     var result = command.parse_arguments(args)
-    assert_equal(len(result._positionals), 2)
+    assert_true(result.has("a"))
+    assert_true(result.has("b"))
     assert_equal(result.get_string("a"), "-1")
     assert_equal(result.get_string("b"), "-2.5")
     print("  ✓ test_multiple_negative_positionals")

--- a/tests/test_parse.mojo
+++ b/tests/test_parse.mojo
@@ -430,14 +430,14 @@ fn test_count_default_zero() raises:
 
 
 fn test_count_max_caps_merged_short() raises:
-    """Tests that .count().max(3) caps -vvvvv at 3."""
+    """Tests that .count().max[3]() caps -vvvvv at 3."""
     var command = Command("test", "Test app")
     command.add_argument(
         Argument("verbose", help="Verbosity level")
         .long("verbose")
         .short("v")
         .count()
-        .max(3)
+        .max[3]()
     )
 
     var args: List[String] = ["test", "-vvvvv"]
@@ -445,20 +445,20 @@ fn test_count_max_caps_merged_short() raises:
     assert_equal(
         result.get_count("verbose"),
         3,
-        msg="-vvvvv with max(3) should cap at 3",
+        msg="-vvvvv with max[3] should cap at 3",
     )
     print("  ✓ test_count_max_caps_merged_short")
 
 
 fn test_count_max_caps_repeated_long() raises:
-    """Tests that .max(2) caps repeated --verbose at 2."""
+    """Tests that .max[2]() caps repeated --verbose at 2."""
     var command = Command("test", "Test app")
     command.add_argument(
         Argument("verbose", help="Verbosity level")
         .long("verbose")
         .short("v")
         .count()
-        .max(2)
+        .max[2]()
     )
 
     var args: List[String] = [
@@ -472,20 +472,20 @@ fn test_count_max_caps_repeated_long() raises:
     assert_equal(
         result.get_count("verbose"),
         2,
-        msg="4x --verbose with max(2) should cap at 2",
+        msg="4x --verbose with max[2] should cap at 2",
     )
     print("  ✓ test_count_max_caps_repeated_long")
 
 
 fn test_count_max_caps_mixed() raises:
-    """Tests that .max(3) caps mixed -vv --verbose --verbose at 3."""
+    """Tests that .max[3]() caps mixed -vv --verbose --verbose at 3."""
     var command = Command("test", "Test app")
     command.add_argument(
         Argument("verbose", help="Verbosity level")
         .long("verbose")
         .short("v")
         .count()
-        .max(3)
+        .max[3]()
     )
 
     var args: List[String] = ["test", "-vv", "--verbose", "--verbose"]
@@ -493,20 +493,20 @@ fn test_count_max_caps_mixed() raises:
     assert_equal(
         result.get_count("verbose"),
         3,
-        msg="Mixed 4 occurrences with max(3) should cap at 3",
+        msg="Mixed 4 occurrences with max[3] should cap at 3",
     )
     print("  ✓ test_count_max_caps_mixed")
 
 
 fn test_count_max_below_ceiling() raises:
-    """Tests that .max(5) does not affect -vv (below ceiling)."""
+    """Tests that .max[5]() does not affect -vv (below ceiling)."""
     var command = Command("test", "Test app")
     command.add_argument(
         Argument("verbose", help="Verbosity level")
         .long("verbose")
         .short("v")
         .count()
-        .max(5)
+        .max[5]()
     )
 
     var args: List[String] = ["test", "-vv"]
@@ -514,20 +514,20 @@ fn test_count_max_below_ceiling() raises:
     assert_equal(
         result.get_count("verbose"),
         2,
-        msg="-vv with max(5) should remain 2",
+        msg="-vv with max[5] should remain 2",
     )
     print("  ✓ test_count_max_below_ceiling")
 
 
 fn test_count_max_exact_ceiling() raises:
-    """Tests that -vvv with .max(3) returns exactly 3."""
+    """Tests that -vvv with .max[3]() returns exactly 3."""
     var command = Command("test", "Test app")
     command.add_argument(
         Argument("verbose", help="Verbosity level")
         .long("verbose")
         .short("v")
         .count()
-        .max(3)
+        .max[3]()
     )
 
     var args: List[String] = ["test", "-vvv"]
@@ -535,20 +535,20 @@ fn test_count_max_exact_ceiling() raises:
     assert_equal(
         result.get_count("verbose"),
         3,
-        msg="-vvv with max(3) should be exactly 3",
+        msg="-vvv with max[3] should be exactly 3",
     )
     print("  ✓ test_count_max_exact_ceiling")
 
 
 fn test_count_max_single_short() raises:
-    """Tests that .max(2) caps -v -v -v via separate short flags at 2."""
+    """Tests that .max[2]() caps -v -v -v via separate short flags at 2."""
     var command = Command("test", "Test app")
     command.add_argument(
         Argument("verbose", help="Verbosity level")
         .long("verbose")
         .short("v")
         .count()
-        .max(2)
+        .max[2]()
     )
 
     var args: List[String] = ["test", "-v", "-v", "-v"]
@@ -556,7 +556,7 @@ fn test_count_max_single_short() raises:
     assert_equal(
         result.get_count("verbose"),
         2,
-        msg="3x -v with max(2) should cap at 2",
+        msg="3x -v with max[2] should cap at 2",
     )
     print("  ✓ test_count_max_single_short")
 
@@ -582,14 +582,14 @@ fn test_count_without_max_no_ceiling() raises:
 
 
 fn test_count_max_one() raises:
-    """Tests that .max(1) caps any number of flags at 1 (boolean-like)."""
+    """Tests that .max[1]() caps any number of flags at 1 (boolean-like)."""
     var command = Command("test", "Test app")
     command.add_argument(
         Argument("verbose", help="Verbosity level")
         .long("verbose")
         .short("v")
         .count()
-        .max(1)
+        .max[1]()
     )
 
     var args: List[String] = ["test", "-vvv"]
@@ -597,7 +597,7 @@ fn test_count_max_one() raises:
     assert_equal(
         result.get_count("verbose"),
         1,
-        msg="-vvv with max(1) should cap at 1",
+        msg="-vvv with max[1] should cap at 1",
     )
     print("  ✓ test_count_max_one")
 

--- a/tests/test_subcommands.mojo
+++ b/tests/test_subcommands.mojo
@@ -958,7 +958,7 @@ fn test_help_sub_disabled_unknown_word_becomes_positional() raises:
     var args: List[String] = ["app", "help"]
     var result = app.parse_arguments(args)
     assert_equal(result.subcommand, "")
-    assert_equal(result._positionals[0], "help")
+    assert_equal(result.get_string("query"), "help")
     print("  ✓ test_help_sub_disabled_unknown_word_becomes_positional")
 
 
@@ -1002,7 +1002,7 @@ fn test_unknown_token_becomes_positional_when_positionals_defined() raises:
     var args: List[String] = ["app", "foo"]
     var result = app.parse_arguments(args)
     assert_equal(result.subcommand, "")
-    assert_equal(result._positionals[0], "foo")
+    assert_equal(result.get_string("query"), "foo")
     print("  ✓ test_unknown_token_becomes_positional_when_positionals_defined")
 
 
@@ -1134,7 +1134,7 @@ fn test_allow_positional_with_subcommands_opt_in() raises:
     var args: List[String] = ["app", "hello"]
     var result = app2.parse_arguments(args)
     assert_equal(result.subcommand, "")
-    assert_equal(result._positionals[0], "hello")
+    assert_equal(result.get_string("query"), "hello")
     print("  ✓ test_allow_positional_with_subcommands_opt_in")
 
 
@@ -1186,7 +1186,7 @@ fn test_alias_dispatch_basic() raises:
     var result = app.parse_arguments(args)
     assert_equal(result.subcommand, "clone")
     var sub_result = result.get_subcommand_result()
-    assert_equal(sub_result._positionals[0], "https://example.com/repo.git")
+    assert_equal(sub_result.get_string("url"), "https://example.com/repo.git")
     print("  ✓ test_alias_dispatch_basic")
 
 

--- a/tests/test_subcommands.mojo
+++ b/tests/test_subcommands.mojo
@@ -300,7 +300,7 @@ fn test_validate_range_out_of_bounds() raises:
     """Tests that a value outside numeric range fails validation."""
     var command = Command("test", "Test app")
     command.add_argument(
-        Argument("port", help="Port").long("port").range(1, 100)
+        Argument("port", help="Port").long("port").range[1, 100]()
     )
 
     var args: List[String] = ["test", "--port", "200"]
@@ -321,7 +321,7 @@ fn test_validate_range_in_bounds() raises:
     """Tests that a value within numeric range passes validation."""
     var command = Command("test", "Test app")
     command.add_argument(
-        Argument("port", help="Port").long("port").range(1, 100)
+        Argument("port", help="Port").long("port").range[1, 100]()
     )
 
     var args: List[String] = ["test", "--port", "50"]
@@ -358,7 +358,7 @@ fn test_full_parse_with_defaults_and_range() raises:
     """Tests that default values also pass range validation."""
     var command = Command("test", "Test app")
     command.add_argument(
-        Argument("port", help="Port").long("port").range(1, 100).default("50")
+        Argument("port", help="Port").long("port").range[1, 100]().default("50")
     )
 
     # Not providing --port should use default "50" which is in range.


### PR DESCRIPTION
Currently, the check on whether the ranges are valid (max_val >= min_value) or whether the ceiling of counts are valid (ceiling >= 1) are done at runtime. This would pass the error message to users instead of developers, which is a big bug.

This PR updates ArgMojo’s public `Argument` builder API to use compile-time parameters for validations that were previously enforced at runtime (e.g., count ceilings and numeric range ordering), and then updates tests/docs/examples to use the new call syntax.

**Changes:**
- Parameterize `Argument.max`, `Argument.number_of_values`, and `Argument.range` (e.g., `.max[3]()`, `.number_of_values[2]()`, `.range[1, 100]()`), enabling compile-time constraints.
- Update tests and examples to use the new parametric call syntax.
- Update documentation to reflect the new API and (in some places) shift tests away from internal `_positionals` access.