### PR TITLE
[core] Add hidden subcommands + NO-COLOR option

### DIFF
--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -63,8 +63,8 @@ These features appear across multiple libraries and depend only on string operat
 | Subcommand aliases                 | —        | —     | ✓     | ✓    | cobra, clap                  | **Done**      |
 | Count with ceiling                 | -        | —     | —     | -    |                              | **Done**      |
 | Cap and floor (clamp) for ranges   | -        | ✓     | —     | —    | Click `IntRange(clamp=True)` | **Done**      |
-| Hidden subcommands                 | —        | —     | ✓     | ✓    |                              | Phase 5       |
-| `NO_COLOR` env variable            | —        | —     | —     | —    | I need it personally         | Phase 5       |
+| Hidden subcommands                 | —        | —     | ✓     | ✓    |                              | **Done**      |
+| `NO_COLOR` env variable            | —        | —     | —     | —    | I need it personally         | **Done**      |
 | Response file (`@args.txt`)        | ✓        | —     | —     | —    | javac, MSBuild               | Phase 5       |
 | Argument parents (shared args)     | ✓        | —     | —     | —    |                              | Phase 5       |
 | Interactive prompting              | —        | ✓     | —     | —    |                              | Phase 5       |
@@ -77,7 +77,7 @@ These features appear across multiple libraries and depend only on string operat
 | Default-if-present (const)         | ✓        | —     | —     | ✓    |                              | Phase 5       |
 | Mutual implication (`implies`)     | —        | —     | —     | —    | ArgMojo unique feature       | Phase 5       |
 | Stdin value (`-` convention)       | —        | —     | ✓     | —    | Unix convention              | Phase 5       |
-| Shell completion script generation | —        | ✓     | ✓     | ✓    | bash / zsh / fish            | Phase 5       |
+| Shell completion script generation | —        | ✓     | ✓     | ✓    | bash / zsh / fish            | **Done**      |
 | CJK-aware help formatting          | —        | —     | —     | —    | I need it personally         | Phase 6       |
 | CJK full-to-half-width correction  | —        | —     | —     | —    | I need it personally         | Phase 6       |
 | CJK punctuation detection          | —        | —     | —     | —    | I need it personally         | Phase 6       |

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,7 +3,7 @@
 This document tracks all notable changes to ArgMojo, including new features, API changes, bug fixes, and documentation updates.
 
 <!--
-Do not add unreleased changes here. This file will be edited just before each release to reflect the final changelog for that version.
+Comment out unreleased changes here. This file will be edited just before each release to reflect the final changelog for that version.
 -->
 
 <!-- 
@@ -16,6 +16,11 @@ ArgMojo v0.3.0 enables shell completion script generation for Bash, Zsh, and Fis
 1. typo suggestions (PR #3)
 1. Command aliases (PR #5)
 1. Range clamping with warning message if users pass out-of-range values (#6)
+1. Compile-time parameter APIs: `.max[ceiling]()`, `.range[min, max]()`, `.number_of_values[N]()` replace the former runtime methods (PR #8). **Breaking change**: callers must update call sites.
+1. Hidden subcommands — `Command.hidden()` excludes a subcommand from help output, shell completions, available-commands error messages, and typo suggestions while keeping it dispatchable by exact name or alias (PR #9)
+1. `NO_COLOR` environment variable support — when `NO_COLOR` is set (any value, including empty), all ANSI colour output from `_generate_help()`, `_warn()`, `_error()`, and `_error_with_usage()` is suppressed, following the [no-color.org](https://no-color.org/) standard (PR #9)
+
+### 🦋 Changed in v0.2.0
 -->
 
 ## 20260228 (v0.2.0)

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -48,6 +48,7 @@ from argmojo import Argument, Command
   - [The help Subcommand](#the-help-subcommand)
   - [Subcommand Aliases](#subcommand-aliases)
   - [Unknown Subcommand Error](#unknown-subcommand-error)
+  - [Hidden Subcommands](#hidden-subcommands)
   - [Mixing Positional Args with Subcommands](#mixing-positional-args-with-subcommands)
 - [Help \& Display](#help--display)
   - [Metavar](#metavar)
@@ -1610,9 +1611,45 @@ app foobar
 # error: app: Unknown command 'foobar'. Available commands: search, init
 ```
 
-The error message excludes the auto-registered `help` subcommand from the list.
+The error message excludes the auto-registered `help` subcommand and hidden subcommands from the list.
 
 If the command has opted in via `allow_positional_with_subcommands()`, unknown tokens are treated as positionals rather than triggering this error.
+
+### Hidden Subcommands
+
+A **hidden** subcommand is fully functional but excluded from user-facing surfaces:
+
+- `--help` output (the `Commands:` section and usage line)
+- Shell completion scripts (bash, zsh, fish)
+- "Available commands" error messages
+- Typo suggestions
+
+The subcommand remains dispatchable by its exact name or alias. This is useful for internal, experimental, or deprecated commands.
+
+```mojo
+var app = Command("myapp", "My application")
+
+var debug = Command("debug", "Internal diagnostics")
+debug.hidden()                          # mark as hidden
+app.add_subcommand(debug^)
+
+var search = Command("search", "Search for items")
+app.add_subcommand(search^)
+
+# 'debug' won't appear in --help or completions, but:
+#   myapp debug ...   still works
+```
+
+Hidden subcommand aliases also remain functional:
+
+```mojo
+var debug = Command("debug", "Internal diagnostics")
+debug.hidden()
+var aliases: List[String] = ["dbg"]
+debug.command_aliases(aliases^)
+app.add_subcommand(debug^)
+# myapp dbg   still dispatches to debug
+```
 
 ### Mixing Positional Args with Subcommands
 
@@ -1865,6 +1902,24 @@ colour is enabled.
 | `.required()`   | Positional args show as `<name>` instead of `[name]`. |
 
 After printing help, the program exits cleanly with exit code 0.
+
+---
+
+**`NO_COLOR` Environment Variable**
+
+ArgMojo respects the [`NO_COLOR`](https://no-color.org/) convention. When the `NO_COLOR` environment variable is **set** (any value, including an empty string), all ANSI colour codes are suppressed in:
+
+- Help output (`_generate_help()`)
+- Warning messages (`_warn()`)
+- Error messages (`_error()` and `_error_with_usage()`)
+
+```bash
+NO_COLOR=1 myapp --help    # plain-text help, no colours
+NO_COLOR= myapp --help     # also suppressed (empty string counts as "set")
+myapp --help               # coloured output (NO_COLOR is unset)
+```
+
+This takes priority over the `color=True` default but does **not** override an explicit `_generate_help(color=False)` call (which already produces plain output regardless).
 
 ---
 

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -1,5 +1,6 @@
 """Defines a CLI command and performs argument parsing."""
 
+from os import getenv
 from sys import argv, exit, stderr
 
 from .argument import Argument
@@ -101,6 +102,10 @@ struct Command(Copyable, Movable, Stringable, Writable):
     """User-defined tips shown at the bottom of the help message.
     Add entries via ``add_tip()``.  Each tip is printed on its own line
     prefixed with the same bold ``Tip:`` label as the built-in hint."""
+    var _is_hidden: Bool
+    """When True, this command is excluded from help output, shell
+    completions, and 'available commands' error lists, but remains
+    dispatchable by exact name or alias.  Set via ``hidden()``."""
 
     # ===------------------------------------------------------------------=== #
     # Life cycle methods
@@ -138,6 +143,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         self._completions_is_subcommand = False
         self._command_aliases = List[String]()
         self._tips = List[String]()
+        self._is_hidden = False
         self._header_color = _DEFAULT_HEADER_COLOR
         self._arg_color = _DEFAULT_ARG_COLOR
         self._warn_color = _DEFAULT_WARN_COLOR
@@ -170,6 +176,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         self._completions_is_subcommand = move._completions_is_subcommand
         self._command_aliases = move._command_aliases^
         self._tips = move._tips^
+        self._is_hidden = move._is_hidden
         self._header_color = move._header_color^
         self._arg_color = move._arg_color^
         self._warn_color = move._warn_color^
@@ -217,6 +224,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         self._completions_is_subcommand = copy._completions_is_subcommand
         self._command_aliases = copy._command_aliases.copy()
         self._tips = copy._tips.copy()
+        self._is_hidden = copy._is_hidden
         self._header_color = copy._header_color
         self._arg_color = copy._arg_color
         self._warn_color = copy._warn_color
@@ -559,6 +567,28 @@ struct Command(Copyable, Movable, Stringable, Writable):
         for i in range(len(names)):
             self._command_aliases.append(names[i])
 
+    fn hidden(mut self):
+        """Marks this subcommand as hidden.
+
+        A hidden subcommand is excluded from help output, shell completion
+        scripts, and the "Available commands" error message, but remains
+        dispatchable by exact name or alias.  Useful for internal,
+        experimental, or deprecated subcommands.
+
+        Example:
+
+        ```mojo
+        from argmojo import Command
+        var app = Command("myapp", "A sample application")
+        var debug = Command("debug", "Internal debug command")
+        debug.hidden()
+        app.add_subcommand(debug^)
+        # 'debug' won't appear in --help or completions, but:
+        #   app debug ...   still works
+        ```
+        """
+        self._is_hidden = True
+
     fn mutually_exclusive(mut self, var names: List[String]):
         """Declares a group of mutually exclusive arguments.
 
@@ -764,9 +794,25 @@ struct Command(Copyable, Movable, Stringable, Writable):
     # Private output helpers
     # ===------------------------------------------------------------------=== #
 
+    @staticmethod
+    fn _no_color_env() -> Bool:
+        """Returns True when the ``NO_COLOR`` environment variable is set.
+
+        Follows the `no-color.org <https://no-color.org/>`_ standard:
+        any value (including empty string) counts as "set".  An unset
+        variable returns the sentinel and is treated as "not set".
+
+        Returns:
+            True if ``NO_COLOR`` is set, False otherwise.
+        """
+        return getenv("NO_COLOR", "\x00") != "\x00"
+
     fn _warn(self, msg: String):
         """Prints a coloured warning message to stderr."""
-        print(self._warn_color + "warning: " + msg + _RESET, file=stderr)
+        if Self._no_color_env():
+            print("warning: " + msg, file=stderr)
+        else:
+            print(self._warn_color + "warning: " + msg + _RESET, file=stderr)
 
     fn _error(self, msg: String) raises:
         """Prints a coloured error message to stderr then raises.
@@ -777,10 +823,16 @@ struct Command(Copyable, Movable, Stringable, Writable):
         The command name is included in the stderr output so that errors
         from subcommands show the full path (e.g. ``app search: ...``).
         """
-        print(
-            self._error_color + "error: " + self.name + ": " + msg + _RESET,
-            file=stderr,
-        )
+        if Self._no_color_env():
+            print(
+                "error: " + self.name + ": " + msg,
+                file=stderr,
+            )
+        else:
+            print(
+                self._error_color + "error: " + self.name + ": " + msg + _RESET,
+                file=stderr,
+            )
         raise Error(msg)
 
     fn _error_with_usage(self, msg: String) raises:
@@ -789,10 +841,16 @@ struct Command(Copyable, Movable, Stringable, Writable):
         Used for validation errors (missing required args, too many positionals)
         where showing the usage line helps the user understand what is expected.
         """
-        print(
-            self._error_color + "error: " + self.name + ": " + msg + _RESET,
-            file=stderr,
-        )
+        if Self._no_color_env():
+            print(
+                "error: " + self.name + ": " + msg,
+                file=stderr,
+            )
+        else:
+            print(
+                self._error_color + "error: " + self.name + ": " + msg + _RESET,
+                file=stderr,
+            )
         print(
             "\n" + self._plain_usage(),
             file=stderr,
@@ -817,7 +875,10 @@ struct Command(Copyable, Movable, Stringable, Writable):
                     s += " [" + self.args[i].name + "]"
         var has_subcommands = False
         for i in range(len(self.subcommands)):
-            if not self.subcommands[i]._is_help_subcommand:
+            if (
+                not self.subcommands[i]._is_help_subcommand
+                and not self.subcommands[i]._is_hidden
+            ):
                 has_subcommands = True
                 break
         if has_subcommands:
@@ -1468,7 +1529,10 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 var avail = String("")
                 var first = True
                 for _si in range(len(self.subcommands)):
-                    if not self.subcommands[_si]._is_help_subcommand:
+                    if (
+                        not self.subcommands[_si]._is_help_subcommand
+                        and not self.subcommands[_si]._is_hidden
+                    ):
                         if not first:
                             avail += ", "
                         avail += self.subcommands[_si].name
@@ -1484,7 +1548,10 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 # Try typo suggestion for subcommand names.
                 var sub_names = List[String]()
                 for _si2 in range(len(self.subcommands)):
-                    if not self.subcommands[_si2]._is_help_subcommand:
+                    if (
+                        not self.subcommands[_si2]._is_help_subcommand
+                        and not self.subcommands[_si2]._is_hidden
+                    ):
                         sub_names.append(self.subcommands[_si2].name)
                         for _ai2 in range(
                             len(self.subcommands[_si2]._command_aliases)
@@ -2065,9 +2132,11 @@ struct Command(Copyable, Movable, Stringable, Writable):
             A formatted help string.
         """
         # Resolve colour tokens — empty strings when colour is off.
-        var arg_color = self._arg_color if color else ""
-        var header_color = (_BOLD_UL + self._header_color) if color else ""
-        var reset_code = _RESET if color else ""
+        # NO_COLOR env var overrides the color parameter.
+        var use_color = color and not Self._no_color_env()
+        var arg_color = self._arg_color if use_color else ""
+        var header_color = (_BOLD_UL + self._header_color) if use_color else ""
+        var reset_code = _RESET if use_color else ""
 
         var s = String("")
         s += self._help_usage_line(arg_color, header_color, reset_code)
@@ -2126,7 +2195,10 @@ struct Command(Copyable, Movable, Stringable, Writable):
         # Show <COMMAND> placeholder when subcommands are registered.
         var has_subcommands = False
         for i in range(len(self.subcommands)):
-            if not self.subcommands[i]._is_help_subcommand:
+            if (
+                not self.subcommands[i]._is_help_subcommand
+                and not self.subcommands[i]._is_hidden
+            ):
                 has_subcommands = True
                 break
         if has_subcommands:
@@ -2443,7 +2515,10 @@ struct Command(Copyable, Movable, Stringable, Writable):
         """
         var has_subcommands = False
         for i in range(len(self.subcommands)):
-            if not self.subcommands[i]._is_help_subcommand:
+            if (
+                not self.subcommands[i]._is_help_subcommand
+                and not self.subcommands[i]._is_hidden
+            ):
                 has_subcommands = True
                 break
         # Also count completions subcommand if in subcommand mode.
@@ -2457,7 +2532,10 @@ struct Command(Copyable, Movable, Stringable, Writable):
         var cmd_colors = List[String]()
         var cmd_helps = List[String]()
         for i in range(len(self.subcommands)):
-            if not self.subcommands[i]._is_help_subcommand:
+            if (
+                not self.subcommands[i]._is_help_subcommand
+                and not self.subcommands[i]._is_hidden
+            ):
                 # Build label: "name" or "name, alias1, alias2".
                 var label = self.subcommands[i].name
                 for _ai in range(len(self.subcommands[i]._command_aliases)):
@@ -2738,7 +2816,10 @@ struct Command(Copyable, Movable, Stringable, Writable):
             # Condition: no subcommand seen yet.
             var sub_names = String("")
             for i in range(len(self.subcommands)):
-                if not self.subcommands[i]._is_help_subcommand:
+                if (
+                    not self.subcommands[i]._is_help_subcommand
+                    and not self.subcommands[i]._is_hidden
+                ):
                     if sub_names:
                         sub_names += " "
                     sub_names += self.subcommands[i].name
@@ -2753,7 +2834,10 @@ struct Command(Copyable, Movable, Stringable, Writable):
             var no_sub_cond = "__fish_seen_subcommand_from " + sub_names
 
             for i in range(len(self.subcommands)):
-                if self.subcommands[i]._is_help_subcommand:
+                if (
+                    self.subcommands[i]._is_help_subcommand
+                    or self.subcommands[i]._is_hidden
+                ):
                     continue
                 var sub = self.subcommands[i].copy()
                 # Register the subcommand itself.
@@ -2913,7 +2997,10 @@ struct Command(Copyable, Movable, Stringable, Writable):
         # If there are subcommands, generate a dispatcher function.
         var has_subcommands = False
         for i in range(len(self.subcommands)):
-            if not self.subcommands[i]._is_help_subcommand:
+            if (
+                not self.subcommands[i]._is_help_subcommand
+                and not self.subcommands[i]._is_hidden
+            ):
                 has_subcommands = True
                 break
         if self._completions_enabled and self._completions_is_subcommand:
@@ -2967,7 +3054,10 @@ struct Command(Copyable, Movable, Stringable, Writable):
         s += "  local -a commands\n"
         s += "  commands=(\n"
         for i in range(len(self.subcommands)):
-            if self.subcommands[i]._is_help_subcommand:
+            if (
+                self.subcommands[i]._is_help_subcommand
+                or self.subcommands[i]._is_hidden
+            ):
                 continue
             var sub = self.subcommands[i].copy()
             var desc = self._zsh_escape(
@@ -3011,7 +3101,10 @@ struct Command(Copyable, Movable, Stringable, Writable):
         s += "    args)\n"
         s += "      case $words[1] in\n"
         for i in range(len(self.subcommands)):
-            if self.subcommands[i]._is_help_subcommand:
+            if (
+                self.subcommands[i]._is_help_subcommand
+                or self.subcommands[i]._is_hidden
+            ):
                 continue
             var sub = self.subcommands[i].copy()
             # Build pattern: name|alias1|alias2
@@ -3149,7 +3242,10 @@ struct Command(Copyable, Movable, Stringable, Writable):
         # Check if there are subcommands.
         var has_subcommands = False
         for i in range(len(self.subcommands)):
-            if not self.subcommands[i]._is_help_subcommand:
+            if (
+                not self.subcommands[i]._is_help_subcommand
+                and not self.subcommands[i]._is_hidden
+            ):
                 has_subcommands = True
                 break
         if self._completions_enabled and self._completions_is_subcommand:
@@ -3200,7 +3296,10 @@ struct Command(Copyable, Movable, Stringable, Writable):
         # Collect subcommand names.
         var sub_names = String("")
         for i in range(len(self.subcommands)):
-            if self.subcommands[i]._is_help_subcommand:
+            if (
+                self.subcommands[i]._is_help_subcommand
+                or self.subcommands[i]._is_hidden
+            ):
                 continue
             if sub_names:
                 sub_names += " "
@@ -3252,7 +3351,10 @@ struct Command(Copyable, Movable, Stringable, Writable):
 
         s += "  case $subcmd in\n"
         for i in range(len(self.subcommands)):
-            if self.subcommands[i]._is_help_subcommand:
+            if (
+                self.subcommands[i]._is_help_subcommand
+                or self.subcommands[i]._is_hidden
+            ):
                 continue
             var sub = self.subcommands[i].copy()
             var sub_words = String("--help")

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -1,6 +1,6 @@
 """Defines a CLI command and performs argument parsing."""
 
-from os import getenv
+from python import Python
 from sys import argv, exit, stderr
 
 from .argument import Argument
@@ -799,13 +799,17 @@ struct Command(Copyable, Movable, Stringable, Writable):
         """Returns True when the ``NO_COLOR`` environment variable is set.
 
         Follows the `no-color.org <https://no-color.org/>`_ standard:
-        any value (including empty string) counts as "set".  An unset
-        variable returns the sentinel and is treated as "not set".
+        any value (including empty string) counts as "set".  Only a
+        genuinely *unset* variable returns ``False``.
 
         Returns:
-            True if ``NO_COLOR`` is set, False otherwise.
+            True if ``NO_COLOR`` is set (to any value), False otherwise.
         """
-        return getenv("NO_COLOR", "\x00") != "\x00"
+        try:
+            var py_os = Python.import_module("os")
+            return py_os.environ.__contains__("NO_COLOR").__bool__()
+        except:
+            return False
 
     fn _warn(self, msg: String):
         """Prints a coloured warning message to stderr."""

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -1,6 +1,6 @@
 """Defines a CLI command and performs argument parsing."""
 
-from python import Python
+from os import getenv
 from sys import argv, exit, stderr
 
 from .argument import Argument
@@ -802,14 +802,18 @@ struct Command(Copyable, Movable, Stringable, Writable):
         any value (including empty string) counts as "set".  Only a
         genuinely *unset* variable returns ``False``.
 
+        Implementation note: we use a long, printable sentinel as the
+        ``getenv`` default.  If the returned value differs from the
+        sentinel, ``NO_COLOR`` is set (even to an empty string).  A raw
+        null-byte sentinel (``"\x00"``) cannot be used because the Mojo
+        compiler on Linux crashes when it encounters one during
+        ``mojo package``.
+
         Returns:
             True if ``NO_COLOR`` is set (to any value), False otherwise.
         """
-        try:
-            var py_os = Python.import_module("os")
-            return py_os.environ.__contains__("NO_COLOR").__bool__()
-        except:
-            return False
+        comptime _SENTINEL = "__ARGMOJO_NO_COLOR_UNSET_SENTINEL__"
+        return getenv("NO_COLOR", _SENTINEL) != _SENTINEL
 
     fn _warn(self, msg: String):
         """Prints a coloured warning message to stderr."""

--- a/tests/test_completion.mojo
+++ b/tests/test_completion.mojo
@@ -993,5 +993,90 @@ fn test_bash_completion_includes_alias() raises:
     print("  ✓ test_bash_completion_includes_alias")
 
 
+# ── Hidden subcommands in completions ─────────────────────────────────────────
+
+
+fn _make_app_with_hidden_sub() raises -> Command:
+    """Helper: app with 'clone' visible and 'debug' hidden."""
+    var app = Command("myapp", "A test app")
+    var clone = Command("clone", "Clone a repository")
+    clone.add_argument(Argument("url", help="Repo URL").long("url"))
+    app.add_subcommand(clone^)
+    var debug = Command("debug", "Internal debug")
+    debug.hidden()
+    debug.add_argument(Argument("level", help="Level").long("level"))
+    app.add_subcommand(debug^)
+    return app^
+
+
+fn test_fish_hidden_sub_excluded() raises:
+    """Tests that hidden subcommands are absent from Fish completion."""
+    var app = _make_app_with_hidden_sub()
+    var script = app.generate_completion("fish")
+    assert_true(
+        "clone" in script,
+        msg="Fish script should include visible sub 'clone'",
+    )
+    assert_false(
+        "debug" in script,
+        msg="Fish script should NOT include hidden sub 'debug'",
+    )
+    print("  ✓ test_fish_hidden_sub_excluded")
+
+
+fn test_zsh_hidden_sub_excluded() raises:
+    """Tests that hidden subcommands are absent from Zsh completion."""
+    var app = _make_app_with_hidden_sub()
+    var script = app.generate_completion("zsh")
+    assert_true(
+        "'clone:" in script,
+        msg="Zsh script should include visible sub 'clone'",
+    )
+    assert_false(
+        "'debug:" in script,
+        msg="Zsh script should NOT include hidden sub 'debug'",
+    )
+    print("  ✓ test_zsh_hidden_sub_excluded")
+
+
+fn test_bash_hidden_sub_excluded() raises:
+    """Tests that hidden subcommands are absent from Bash completion."""
+    var app = _make_app_with_hidden_sub()
+    var script = app.generate_completion("bash")
+    assert_true(
+        "clone" in script,
+        msg="Bash script should include visible sub 'clone'",
+    )
+    assert_false(
+        "debug" in script,
+        msg="Bash script should NOT include hidden sub 'debug'",
+    )
+    print("  ✓ test_bash_hidden_sub_excluded")
+
+
+fn test_all_hidden_no_subcommand_completion() raises:
+    """Tests that when all subs are hidden, completion is simple (no subs)."""
+    var app = Command("myapp", "A test app")
+    app.add_argument(Argument("verbose", help="Verbose").long("verbose").flag())
+    var debug = Command("debug", "Internal debug")
+    debug.hidden()
+    app.add_subcommand(debug^)
+
+    # Fish: should NOT contain subcommand-related directives.
+    var fish = app.generate_completion("fish")
+    assert_false(
+        "__fish_seen_subcommand_from" in fish,
+        msg="Fish should not have subcommand dispatching when all subs hidden",
+    )
+
+    # Bash: should not have case/subcmd detection.
+    var bash = app.generate_completion("bash")
+    assert_false(
+        "subcmd" in bash,
+        msg="Bash should not have subcmd logic when all subs hidden",
+    )
+    print("  ✓ test_all_hidden_no_subcommand_completion")
+
+
 fn main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_help.mojo
+++ b/tests/test_help.mojo
@@ -829,5 +829,71 @@ fn test_multiple_aliases_shown_in_help() raises:
     print("  ✓ test_multiple_aliases_shown_in_help")
 
 
+# ── Hidden subcommands ────────────────────────────────────────────────────────
+
+
+fn test_hidden_subcommand_not_in_help() raises:
+    """Tests that hidden subcommands are excluded from help output."""
+    var app = Command("app", "Test app")
+    var clone = Command("clone", "Clone a repository")
+    app.add_subcommand(clone^)
+    var debug = Command("debug", "Internal debug command")
+    debug.hidden()
+    app.add_subcommand(debug^)
+
+    var help = app._generate_help(color=False)
+    assert_true("clone" in help, msg="visible sub should be in help")
+    assert_false("debug" in help, msg="hidden sub should NOT be in help")
+    print("  ✓ test_hidden_subcommand_not_in_help")
+
+
+fn test_hidden_subcommand_not_in_usage_line() raises:
+    """Tests that usage line omits [command] if all subs are hidden."""
+    var app = Command("app", "Test app")
+    var debug = Command("debug", "Internal debug command")
+    debug.hidden()
+    app.add_subcommand(debug^)
+
+    var help = app._generate_help(color=False)
+    assert_false(
+        "<COMMAND>" in help,
+        msg="usage line should not show <COMMAND> when only subs are hidden",
+    )
+    print("  ✓ test_hidden_subcommand_not_in_usage_line")
+
+
+fn test_hidden_subcommand_usage_line_with_visible() raises:
+    """Tests that usage line shows [command] when visible subs remain."""
+    var app = Command("app", "Test app")
+    var clone = Command("clone", "Clone a repository")
+    app.add_subcommand(clone^)
+    var debug = Command("debug", "Internal debug command")
+    debug.hidden()
+    app.add_subcommand(debug^)
+
+    var help = app._generate_help(color=False)
+    assert_true(
+        "<COMMAND>" in help,
+        msg="usage line should show <COMMAND> when visible subs exist",
+    )
+    print("  ✓ test_hidden_subcommand_usage_line_with_visible")
+
+
+# ── NO_COLOR ──────────────────────────────────────────────────────────────────
+
+
+fn test_no_color_env_static_method() raises:
+    """Tests _no_color_env() returns the correct value based on environment."""
+    # We can't set env vars from Mojo easily, so just verify the method
+    # exists and returns a Bool without crashing.
+    var result = Command._no_color_env()
+    # In the test environment NO_COLOR is typically unset → False.
+    # We just verify it returns without error (type-level check).
+    if result:
+        print("  ✓ test_no_color_env_static_method (NO_COLOR is set)")
+    else:
+        print("  ✓ test_no_color_env_static_method (NO_COLOR is not set)")
+
+
 fn main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_subcommands.mojo
+++ b/tests/test_subcommands.mojo
@@ -1309,5 +1309,65 @@ fn test_alias_multiple_subcommands() raises:
 # ── main ─────────────────────────────────────────────────────────────────────
 
 
+# ── Hidden subcommands — dispatch ─────────────────────────────────────────────
+
+
+fn test_hidden_subcommand_still_dispatchable() raises:
+    """Tests that a hidden subcommand can still be dispatched by exact name."""
+    var app = Command("app", "Test app")
+    var visible = Command("clone", "Clone")
+    visible.add_argument(Argument("url", help="Repo URL").positional())
+    app.add_subcommand(visible^)
+    var hidden = Command("debug", "Debug")
+    hidden.hidden()
+    hidden.add_argument(
+        Argument("level", help="Debug level").long("level").default("info")
+    )
+    app.add_subcommand(hidden^)
+
+    var args: List[String] = ["app", "debug", "--level", "trace"]
+    var result = app.parse_arguments(args)
+    assert_equal(result.subcommand, "debug")
+    var sub = result.get_subcommand_result()
+    assert_equal(sub.get_string("level"), "trace")
+    print("  ✓ test_hidden_subcommand_still_dispatchable")
+
+
+fn test_hidden_subcommand_alias_dispatchable() raises:
+    """Tests that a hidden subcommand can be dispatched via its alias."""
+    var app = Command("app", "Test app")
+    var debug = Command("debug", "Debug")
+    debug.hidden()
+    var debug_aliases: List[String] = ["dbg"]
+    debug.command_aliases(debug_aliases^)
+    app.add_subcommand(debug^)
+    # Add a visible sub so the command has subcommands.
+    var clone = Command("clone", "Clone")
+    app.add_subcommand(clone^)
+
+    var args: List[String] = ["app", "dbg"]
+    var result = app.parse_arguments(args)
+    assert_equal(result.subcommand, "debug")
+    print("  ✓ test_hidden_subcommand_alias_dispatchable")
+
+
+fn test_hidden_is_hidden_field() raises:
+    """Tests that _is_hidden is False by default and True after hidden()."""
+    var cmd = Command("test", "Test")
+    assert_false(cmd._is_hidden, msg="_is_hidden should default to False")
+    cmd.hidden()
+    assert_true(cmd._is_hidden, msg="hidden() should set _is_hidden to True")
+    print("  ✓ test_hidden_is_hidden_field")
+
+
+fn test_hidden_subcommand_copy() raises:
+    """Tests that _is_hidden survives Command copy."""
+    var cmd = Command("debug", "Debug")
+    cmd.hidden()
+    var copy = cmd.copy()
+    assert_true(copy._is_hidden, msg="_is_hidden should survive copy")
+    print("  ✓ test_hidden_subcommand_copy")
+
+
 fn main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_typo_suggestions.mojo
+++ b/tests/test_typo_suggestions.mojo
@@ -196,5 +196,36 @@ fn test_typo_subcommand_alias_suggests() raises:
     print("  ✓ test_typo_subcommand_alias_suggests")
 
 
+fn test_typo_hidden_subcommand_not_suggested() raises:
+    """Tests that hidden subcommands are NOT included in typo suggestions."""
+    var app = Command("app", "Test app")
+    var clone = Command("clone", "Clone a repository")
+    app.add_subcommand(clone^)
+    var debug = Command("debug", "Internal debug")
+    debug.hidden()
+    app.add_subcommand(debug^)
+
+    # 'debu' is close to 'debug', but debug is hidden so no suggestion.
+    var args: List[String] = ["app", "debu"]
+    var caught = False
+    var err_msg = String("")
+    try:
+        _ = app.parse_arguments(args)
+    except e:
+        caught = True
+        err_msg = String(e)
+    assert_true(caught, msg="Should have raised error for 'debu'")
+    assert_false(
+        "debug" in err_msg,
+        msg="Hidden sub 'debug' should NOT appear in typo suggestion",
+    )
+    # But the error should still mention available commands (only clone).
+    assert_true(
+        "clone" in err_msg,
+        msg="Visible sub 'clone' should still be in error message",
+    )
+    print("  ✓ test_typo_hidden_subcommand_not_suggested")
+
+
 fn main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
This PR adds hidden Subcommands and NO-COLOR option:

1. Added `_is_hidden` attribute
2. Added `hidden()` builder method
3. Hidden subs are excluded from help output, shell completions (bash/zsh/fish), "Available commands" error messages, and typo suggestions
4. Added `_no_color_env()` static method
5. When `NO_COLOR` is set (any value including empty), ANSI codes are suppressed in `_generate_help()`, `_warn()`, `_error()`, and `_error_with_usage()`. Follows the no-color.org standard