### PR TITLE
[core] Add mutual implication functionality

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -44,10 +44,34 @@ jobs:
         run: |
           pixi install
 
-      - name: Build package
+      - name: Build package (with retry for Mojo compiler intermittent crashes)
         run: |
-          pixi run package
+          for attempt in 1 2 3; do
+            echo "=== mojo package attempt $attempt ==="
+            if pixi run package; then
+              echo "=== package succeeded on attempt $attempt ==="
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "=== package failed after 3 attempts ==="
+              exit 1
+            fi
+            echo "=== package crashed, retrying in 5s... ==="
+            sleep 5
+          done
 
-      - name: Run tests
+      - name: Run tests (with retry for Mojo compiler intermittent crashes)
         run: |
-          pixi run test
+          for attempt in 1 2 3; do
+            echo "=== test attempt $attempt ==="
+            if pixi run test; then
+              echo "=== tests passed on attempt $attempt ==="
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "=== tests failed after 3 attempts ==="
+              exit 1
+            fi
+            echo "=== test run crashed, retrying in 5s... ==="
+            sleep 5
+          done

--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -75,7 +75,7 @@ These features appear across multiple libraries and depend only on string operat
 | Partial parsing (known args)       | ✓        | —     | —     | ✓    |                              | Phase 5       |
 | Require equals syntax              | —        | —     | —     | ✓    |                              | Phase 5       |
 | Default-if-present (const)         | ✓        | —     | —     | ✓    |                              | Phase 5       |
-| Mutual implication (`implies`)     | —        | —     | —     | —    | ArgMojo unique feature       | Phase 5       |
+| Mutual implication (`implies`)     | —        | —     | —     | —    | ArgMojo unique feature       | **Done**      |
 | Stdin value (`-` convention)       | —        | —     | ✓     | —    | Unix convention              | Phase 5       |
 | Shell completion script generation | —        | ✓     | ✓     | ✓    | bash / zsh / fish            | **Done**      |
 | CJK-aware help formatting          | —        | —     | —     | —    | I need it personally         | Phase 6       |
@@ -539,7 +539,7 @@ Before adding Phase 5 features, further decompose `parse_arguments()` for readab
 - [ ] **Pre/Post run hooks** — callbacks before/after main logic (cobra `PreRun`/`PostRun`)
 - [ ] **REMAINDER nargs** — capture all remaining args including `-` prefixed ones (argparse `nargs=REMAINDER`)
 - [ ] **Regex validation** — `.pattern(r"^\d{4}-\d{2}-\d{2}$")` validates value format (no major library has this)
-- [ ] **Mutual implication** — `command.implies("debug", "verbose")` — after parsing, if the trigger flag is set, automatically set the implied flag; support chained implication (`debug → verbose → log`); detect circular cycles at registration time (no major library has this built-in)
+- [x] **Mutual implication** — `command.implies("debug", "verbose")` — after parsing, if the trigger flag is set, automatically set the implied flag; support chained implication (`debug → verbose → log`); detect circular cycles at registration time (no major library has this built-in)
 - [ ] **Stdin value** — `.stdin_value()` on `Argument` — when parsed value is `"-"`, read from stdin; Unix convention (`cat file.txt | mytool --input -`) (cobra supports; depends on Mojo stdin API)
 - [x] **Subcommand aliases** — `sub.command_aliases(["co"])` registers shorthand names; typo suggestions and completions search aliases too (cobra `Command.Aliases`, clap `Command::alias`)
 - [ ] **Hidden subcommands** — `sub.hidden()` — exclude from the "Commands:" section in help, still dispatchable by exact name (clap `Command::hide`, cobra `Hidden`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,7 @@ ArgMojo v0.3.0 enables shell completion script generation for Bash, Zsh, and Fis
 1. Compile-time parameter APIs: `.max[ceiling]()`, `.range[min, max]()`, `.number_of_values[N]()` replace the former runtime methods (PR #8). **Breaking change**: callers must update call sites.
 1. Hidden subcommands — `Command.hidden()` excludes a subcommand from help output, shell completions, available-commands error messages, and typo suggestions while keeping it dispatchable by exact name or alias (PR #9)
 1. `NO_COLOR` environment variable support — when `NO_COLOR` is set (any value, including empty), all ANSI colour output from `_generate_help()`, `_warn()`, `_error()`, and `_error_with_usage()` is suppressed, following the [no-color.org](https://no-color.org/) standard (PR #9)
+1. Mutual implication — `Command.implies(trigger, implied)` automatically sets one argument when another is present. Supports chained implications (A → B → C) with cycle detection at registration time. Works with flags, count arguments, and integrates with existing constraints (`required_if`, `mutually_exclusive`) (PR #10)
 
 ### 🦋 Changed in v0.2.0
 -->

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -41,6 +41,7 @@ from argmojo import Argument, Command
   - [One-Required Groups](#one-required-groups)
   - [Required-Together Groups](#required-together-groups)
   - [Conditional Requirements](#conditional-requirements)
+  - [Mutual Implication](#mutual-implication)
 - [Subcommands](#subcommands)
   - [Defining Subcommands](#defining-subcommands)
   - [Parsing Subcommand Results](#parsing-subcommand-results)
@@ -1323,6 +1324,108 @@ Error: Argument '--output' is required when '--save' is provided
 > symmetric — if *any* argument from the group appears, *all* must
 > appear. `required_if()` is one-directional — only the target is
 > required when the condition is present, not vice versa.
+
+### Mutual Implication
+
+Use `implies()` to declare that setting one argument automatically sets another. This is useful when one mode logically entails another — for example, debug mode should always enable verbose output.
+
+---
+
+```mojo
+command.add_argument(Argument("debug", help="Debug mode").long("debug").flag())
+command.add_argument(Argument("verbose", help="Verbose output").long("verbose").short("v").flag())
+command.implies("debug", "verbose")
+```
+
+This means: **if `--debug` is provided, `--verbose` is automatically set too.**
+
+```bash
+myapp --debug          # OK — --verbose is auto-set
+myapp --debug -v       # OK — --verbose already set, no conflict
+myapp --verbose        # OK — --debug is NOT set (one-directional)
+myapp                  # OK — neither set
+```
+
+---
+
+**Chained implications**
+
+Implications can be chained. If A implies B and B implies C, then setting A will also set C:
+
+```mojo
+command.implies("debug", "verbose")
+command.implies("verbose", "log")
+# --debug → --verbose → --log (all three are set)
+```
+
+---
+
+**Multiple implications from one trigger**
+
+A single argument can imply multiple targets:
+
+```mojo
+command.implies("debug", "verbose")
+command.implies("debug", "log")
+# --debug sets both --verbose and --log
+```
+
+---
+
+**Works with count arguments**
+
+When the implied argument is a count (`.count()`), it is set to 1 if not already present. Explicit counts are preserved:
+
+```mojo
+command.add_argument(Argument("verbose", help="Verbosity").long("verbose").short("v").count())
+command.implies("debug", "verbose")
+# --debug        → verbose count = 1
+# --debug -vvv   → verbose count = 3 (explicit value kept)
+```
+
+---
+
+**Cycle detection**
+
+Circular implications are detected at registration time and raise an error:
+
+```mojo
+command.implies("a", "b")
+command.implies("b", "a")   # Error: cycle detected
+```
+
+This also catches indirect cycles (A → B → C → A).
+
+---
+
+**Integration with other constraints**
+
+Implications are applied *after* defaults and *before* validation, so implied arguments participate in all subsequent constraint checks:
+
+```mojo
+command.implies("debug", "verbose")
+command.required_if("output", "verbose")
+# --debug implies --verbose, which triggers the conditional requirement for --output
+```
+
+```mojo
+command.implies("debug", "verbose")
+var excl: List[String] = ["verbose", "quiet"]
+command.mutually_exclusive(excl^)
+# --debug --quiet fails: --debug implies --verbose, which conflicts with --quiet
+```
+
+---
+
+| Scenario                  | Example                                                        |
+| ------------------------- | -------------------------------------------------------------- |
+| Debug enables verbose     | `implies("debug", "verbose")`                                  |
+| Verbose enables logging   | `implies("verbose", "log")`                                    |
+| Strict enables all checks | `implies("strict", "lint")` + `implies("strict", "typecheck")` |
+
+> **Difference from `required_if()`:** `required_if()` *requires* the
+> user to provide the target argument — parsing fails if they don't.
+> `implies()` *automatically sets* the target — no user action needed.
 
 ## Subcommands
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -1760,7 +1760,7 @@ By default, ArgMojo **prevents** mixing positional arguments and subcommands on 
 
 ```mojo
 var app = Command("app", "My app")
-app.add_subcommand(Command("search", "Search")^)
+app.add_subcommand(Command("search", "Search"))
 app.add_argument(Argument("query", help="Query").positional())  # raises!
 ```
 
@@ -1769,7 +1769,7 @@ The same guard triggers if you add a subcommand to a command that already has po
 ```mojo
 var app = Command("app", "My app")
 app.add_argument(Argument("file", help="File").positional())
-app.add_subcommand(Command("init", "Init")^)  # raises!
+app.add_subcommand(Command("init", "Init"))  # raises!
 ```
 
 If you genuinely need both (e.g., `--` stopping dispatch so the subcommand name becomes a positional), call `allow_positional_with_subcommands()` before adding either:
@@ -1777,7 +1777,7 @@ If you genuinely need both (e.g., `--` stopping dispatch so the subcommand name 
 ```mojo
 var app = Command("app", "My app")
 app.allow_positional_with_subcommands()
-app.add_subcommand(Command("search", "Search")^)
+app.add_subcommand(Command("search", "Search"))
 app.add_argument(Argument("fallback", help="Fallback").positional())
 
 # "foo" doesn't match any subcommand → treated as positional

--- a/pixi.toml
+++ b/pixi.toml
@@ -36,7 +36,8 @@ test = """\
     && mojo run -I src tests/test_negative_numbers.mojo \
     && mojo run -I src tests/test_persistent.mojo \
     && mojo run -I src tests/test_typo_suggestions.mojo \
-    && mojo run -I src tests/test_completion.mojo"""
+    && mojo run -I src tests/test_completion.mojo \
+    && mojo run -I src tests/test_implies.mojo"""
 
 # build example binaries
 build = """pixi run package \

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -52,6 +52,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
     """Groups where at least one argument must be provided."""
     var _conditional_reqs: List[List[String]]
     """Pairs [target, condition]: target is required when condition is present."""
+    var _implications: List[List[String]]
+    """Pairs [trigger, implied]: when trigger is set, implied is auto-set."""
     var _help_on_no_arguments: Bool
     """When True, show help and exit if no arguments are provided."""
     var _header_color: String
@@ -133,6 +135,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         self._required_groups = List[List[String]]()
         self._one_required_groups = List[List[String]]()
         self._conditional_reqs = List[List[String]]()
+        self._implications = List[List[String]]()
         self._help_on_no_arguments = False
         self._is_help_subcommand = False
         self._help_subcommand_enabled = True
@@ -164,6 +167,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         self._required_groups = move._required_groups^
         self._one_required_groups = move._one_required_groups^
         self._conditional_reqs = move._conditional_reqs^
+        self._implications = move._implications^
         self._help_on_no_arguments = move._help_on_no_arguments
         self._is_help_subcommand = move._is_help_subcommand
         self._help_subcommand_enabled = move._help_subcommand_enabled
@@ -212,6 +216,9 @@ struct Command(Copyable, Movable, Stringable, Writable):
         self._conditional_reqs = List[List[String]]()
         for i in range(len(copy._conditional_reqs)):
             self._conditional_reqs.append(copy._conditional_reqs[i].copy())
+        self._implications = List[List[String]]()
+        for i in range(len(copy._implications)):
+            self._implications.append(copy._implications[i].copy())
         self._help_on_no_arguments = copy._help_on_no_arguments
         self._is_help_subcommand = copy._is_help_subcommand
         self._help_subcommand_enabled = copy._help_subcommand_enabled
@@ -678,6 +685,69 @@ struct Command(Copyable, Movable, Stringable, Writable):
         var pair: List[String] = [target, condition]
         self._conditional_reqs.append(pair^)
 
+    fn implies(mut self, trigger: String, implied: String) raises:
+        """Declares that setting one argument automatically sets another.
+
+        When ``trigger`` is present in the parse result, ``implied`` is
+        automatically set (as a flag set to ``True``, or a count
+        incremented by 1).  Chains are supported: if A implies B and B
+        implies C, setting A will also set C.  Circular implications are
+        detected at registration time and raise an error.
+
+        Args:
+            trigger: The argument whose presence triggers the implication.
+            implied: The argument that is automatically set.
+
+        Raises:
+            Error if adding this implication would create a cycle.
+
+        Example:
+
+        ```mojo
+        from argmojo import Command, Argument
+        var command = Command("myapp", "A sample application")
+        command.add_argument(Argument("debug", help="Debug mode").long("debug").flag())
+        command.add_argument(Argument("verbose", help="Verbose output").long("verbose").flag())
+        command.implies("debug", "verbose")
+        # --debug now automatically sets --verbose as well
+        ```
+        """
+        # Cycle detection: check if `trigger` is reachable from `implied`.
+        # If so, adding implied→...→trigger would form a cycle.
+        if trigger == implied:
+            raise Error(
+                "Implication cycle detected: '" + trigger + "' implies itself"
+            )
+        # BFS from `implied` following existing edges.
+        var visited = List[String]()
+        var queue = List[String]()
+        queue.append(implied)
+        while len(queue) > 0:
+            var current = queue.pop()
+            # Check existing implications where `current` is the trigger.
+            for i in range(len(self._implications)):
+                if self._implications[i][0] == current:
+                    var target = self._implications[i][1]
+                    if target == trigger:
+                        raise Error(
+                            "Implication cycle detected: adding '"
+                            + trigger
+                            + "' implies '"
+                            + implied
+                            + "' would create a cycle"
+                        )
+                    # Only visit each node once.
+                    var already = False
+                    for v in range(len(visited)):
+                        if visited[v] == target:
+                            already = True
+                            break
+                    if not already:
+                        visited.append(target)
+                        queue.append(target)
+        var imp_pair: List[String] = [trigger, implied]
+        self._implications.append(imp_pair^)
+
     fn help_on_no_arguments(mut self):
         """Enables showing help when invoked with no arguments.
 
@@ -1108,8 +1178,9 @@ struct Command(Copyable, Movable, Stringable, Writable):
             result._positionals.append(arg)
             i += 1
 
-        # Apply defaults and validate constraints.
+        # Apply defaults, propagate implications, then validate constraints.
         self._apply_defaults(result)
+        self._apply_implications(result)
         self._validate(result)
 
         return result^
@@ -1610,6 +1681,48 @@ struct Command(Copyable, Movable, Stringable, Writable):
                                 result._positionals[k] = a._default_value
                 else:
                     result._values[a.name] = a._default_value
+
+    fn _apply_implications(self, mut result: ParseResult):
+        """Propagates implication rules on the parse result.
+
+        For each registered ``implies(trigger, implied)`` pair, if ``trigger``
+        is present in ``result``, ``implied`` is automatically set.  Uses a
+        fixed-point loop to support chained implications (A → B → C).
+
+        Flags are set to ``True``; count arguments are incremented by 1.
+        Arguments that are already present are left untouched.
+
+        Args:
+            result: The parse result to mutate in-place.
+        """
+        if len(self._implications) == 0:
+            return
+
+        # Fixed-point iteration: keep looping until no new values are set.
+        var changed = True
+        while changed:
+            changed = False
+            for i in range(len(self._implications)):
+                var trigger = self._implications[i][0]
+                var implied = self._implications[i][1]
+                if result.has(trigger) and not result.has(implied):
+                    # Determine the type of the implied argument.
+                    var is_count = False
+                    var is_flag = False
+                    for j in range(len(self.args)):
+                        if self.args[j].name == implied:
+                            is_count = self.args[j]._is_count
+                            is_flag = self.args[j]._is_flag
+                            break
+                    if is_count:
+                        result._counts[implied] = 1
+                    elif is_flag:
+                        result._flags[implied] = True
+                    else:
+                        # Value-taking argument: set to "true" as a
+                        # sentinel so that result.has() returns True.
+                        result._values[implied] = "true"
+                    changed = True
 
     fn _validate(self, mut result: ParseResult) raises:
         """Runs all post-parse validation checks on the result.

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -694,12 +694,19 @@ struct Command(Copyable, Movable, Stringable, Writable):
         implies C, setting A will also set C.  Circular implications are
         detected at registration time and raise an error.
 
+        Both ``trigger`` and ``implied`` must be registered arguments.
+        The ``implied`` argument must be a ``.flag()`` or ``.count()``
+        argument — value-taking, positional, append, and map arguments
+        are not supported as implication targets.
+
         Args:
             trigger: The argument whose presence triggers the implication.
             implied: The argument that is automatically set.
 
         Raises:
-            Error if adding this implication would create a cycle.
+            Error if adding this implication would create a cycle, if
+            either argument is unknown, or if the implied argument is
+            not a flag or count.
 
         Example:
 
@@ -712,18 +719,44 @@ struct Command(Copyable, Movable, Stringable, Writable):
         # --debug now automatically sets --verbose as well
         ```
         """
+        # Validate that both trigger and implied are registered arguments.
+        var trigger_found = False
+        for i in range(len(self.args)):
+            if self.args[i].name == trigger:
+                trigger_found = True
+                break
+        if not trigger_found:
+            raise Error("implies(): unknown trigger argument '" + trigger + "'")
+
+        var implied_found = False
+        var implied_kind = String("flag")  # "flag" or "count"
+        for i in range(len(self.args)):
+            if self.args[i].name == implied:
+                implied_found = True
+                if self.args[i]._is_count:
+                    implied_kind = "count"
+                elif not self.args[i]._is_flag:
+                    raise Error(
+                        "implies(): implied argument '"
+                        + implied
+                        + "' must be a flag() or count()"
+                    )
+                break
+        if not implied_found:
+            raise Error("implies(): unknown implied argument '" + implied + "'")
+
         # Cycle detection: check if `trigger` is reachable from `implied`.
         # If so, adding implied→...→trigger would form a cycle.
         if trigger == implied:
             raise Error(
                 "Implication cycle detected: '" + trigger + "' implies itself"
             )
-        # BFS from `implied` following existing edges.
+        # DFS from `implied` following existing edges.
         var visited = List[String]()
-        var queue = List[String]()
-        queue.append(implied)
-        while len(queue) > 0:
-            var current = queue.pop()
+        var stack = List[String]()
+        stack.append(implied)
+        while len(stack) > 0:
+            var current = stack.pop()
             # Check existing implications where `current` is the trigger.
             for i in range(len(self._implications)):
                 if self._implications[i][0] == current:
@@ -744,9 +777,12 @@ struct Command(Copyable, Movable, Stringable, Writable):
                             break
                     if not already:
                         visited.append(target)
-                        queue.append(target)
-        var imp_pair: List[String] = [trigger, implied]
-        self._implications.append(imp_pair^)
+                        stack.append(target)
+        # Store [trigger, implied, kind] triple.  The kind is used by
+        # _apply_implications() to set the correct result field without
+        # re-scanning self.args at parse time.
+        var imp_triple: List[String] = [trigger, implied, implied_kind]
+        self._implications.append(imp_triple^)
 
     fn help_on_no_arguments(mut self):
         """Enables showing help when invoked with no arguments.
@@ -1685,12 +1721,13 @@ struct Command(Copyable, Movable, Stringable, Writable):
     fn _apply_implications(self, mut result: ParseResult):
         """Propagates implication rules on the parse result.
 
-        For each registered ``implies(trigger, implied)`` pair, if ``trigger``
-        is present in ``result``, ``implied`` is automatically set.  Uses a
-        fixed-point loop to support chained implications (A → B → C).
+        For each registered ``implies(trigger, implied)`` triple, if
+        ``trigger`` is present in ``result``, ``implied`` is automatically
+        set.  Uses a fixed-point loop to support chained implications
+        (A → B → C).
 
-        Flags are set to ``True``; count arguments are incremented by 1.
-        Arguments that are already present are left untouched.
+        The implied-argument kind (``"flag"`` or ``"count"``) is stored at
+        registration time, so no argument scan is needed here.
 
         Args:
             result: The parse result to mutate in-place.
@@ -1705,23 +1742,12 @@ struct Command(Copyable, Movable, Stringable, Writable):
             for i in range(len(self._implications)):
                 var trigger = self._implications[i][0]
                 var implied = self._implications[i][1]
+                var kind = self._implications[i][2]  # "flag" or "count"
                 if result.has(trigger) and not result.has(implied):
-                    # Determine the type of the implied argument.
-                    var is_count = False
-                    var is_flag = False
-                    for j in range(len(self.args)):
-                        if self.args[j].name == implied:
-                            is_count = self.args[j]._is_count
-                            is_flag = self.args[j]._is_flag
-                            break
-                    if is_count:
+                    if kind == "count":
                         result._counts[implied] = 1
-                    elif is_flag:
-                        result._flags[implied] = True
                     else:
-                        # Value-taking argument: set to "true" as a
-                        # sentinel so that result.has() returns True.
-                        result._values[implied] = "true"
+                        result._flags[implied] = True
                     changed = True
 
     fn _validate(self, mut result: ParseResult) raises:

--- a/tests/test_collect.mojo
+++ b/tests/test_collect.mojo
@@ -20,7 +20,6 @@ fn test_append_single() raises:
     assert_equal(len(tags), 1)
     assert_equal(tags[0], "alpha")
     assert_true(result.has("tag"), msg="tag should be present")
-    print("  ✓ test_append_single")
 
 
 fn test_append_multiple() raises:
@@ -45,7 +44,6 @@ fn test_append_multiple() raises:
     assert_equal(tags[0], "alpha")
     assert_equal(tags[1], "beta")
     assert_equal(tags[2], "gamma")
-    print("  ✓ test_append_multiple")
 
 
 fn test_append_short_option() raises:
@@ -61,7 +59,6 @@ fn test_append_short_option() raises:
     assert_equal(len(tags), 2)
     assert_equal(tags[0], "alpha")
     assert_equal(tags[1], "beta")
-    print("  ✓ test_append_short_option")
 
 
 fn test_append_equals_syntax() raises:
@@ -77,7 +74,6 @@ fn test_append_equals_syntax() raises:
     assert_equal(len(tags), 2)
     assert_equal(tags[0], "alpha")
     assert_equal(tags[1], "beta")
-    print("  ✓ test_append_equals_syntax")
 
 
 fn test_append_attached_short() raises:
@@ -93,7 +89,6 @@ fn test_append_attached_short() raises:
     assert_equal(len(tags), 2)
     assert_equal(tags[0], "alpha")
     assert_equal(tags[1], "beta")
-    print("  ✓ test_append_attached_short")
 
 
 fn test_append_mixed_syntax() raises:
@@ -111,7 +106,6 @@ fn test_append_mixed_syntax() raises:
     assert_equal(tags[1], "b")
     assert_equal(tags[2], "c")
     assert_equal(tags[3], "d")
-    print("  ✓ test_append_mixed_syntax")
 
 
 fn test_append_empty() raises:
@@ -126,7 +120,6 @@ fn test_append_empty() raises:
     var tags = result.get_list("tag")
     assert_equal(len(tags), 0)
     assert_false(result.has("tag"), msg="tag should not be present")
-    print("  ✓ test_append_empty")
 
 
 fn test_append_with_choices() raises:
@@ -163,7 +156,6 @@ fn test_append_with_choices() raises:
             msg="Error should mention invalid value",
         )
     assert_true(caught, msg="Should have raised error for invalid choice")
-    print("  ✓ test_append_with_choices")
 
 
 fn test_append_with_other_args() raises:
@@ -195,7 +187,6 @@ fn test_append_with_other_args() raises:
     assert_equal(len(includes), 2)
     assert_equal(includes[0], "/usr/lib")
     assert_equal(includes[1], "/opt/lib")
-    print("  ✓ test_append_with_other_args")
 
 
 # ===------------------------------------------------------------------=== #
@@ -217,7 +208,6 @@ fn test_delimiter_comma() raises:
     assert_equal(tags[0], "a")
     assert_equal(tags[1], "b")
     assert_equal(tags[2], "c")
-    print("  ✓ test_delimiter_comma")
 
 
 fn test_delimiter_equals_syntax() raises:
@@ -234,7 +224,6 @@ fn test_delimiter_equals_syntax() raises:
     assert_equal(tags[0], "x")
     assert_equal(tags[1], "y")
     assert_equal(tags[2], "z")
-    print("  ✓ test_delimiter_equals_syntax")
 
 
 fn test_delimiter_short_option() raises:
@@ -250,7 +239,6 @@ fn test_delimiter_short_option() raises:
     assert_equal(len(tags), 2)
     assert_equal(tags[0], "foo")
     assert_equal(tags[1], "bar")
-    print("  ✓ test_delimiter_short_option")
 
 
 fn test_delimiter_attached_short() raises:
@@ -271,7 +259,6 @@ fn test_delimiter_attached_short() raises:
     assert_equal(len(tags), 2)
     assert_equal(tags[0], "a")
     assert_equal(tags[1], "b")
-    print("  ✓ test_delimiter_attached_short")
 
 
 fn test_delimiter_repeated() raises:
@@ -289,7 +276,6 @@ fn test_delimiter_repeated() raises:
     assert_equal(tags[1], "b")
     assert_equal(tags[2], "c")
     assert_equal(tags[3], "d")
-    print("  ✓ test_delimiter_repeated")
 
 
 fn test_delimiter_single_value() raises:
@@ -304,7 +290,6 @@ fn test_delimiter_single_value() raises:
     var tags = result.get_list("tag")
     assert_equal(len(tags), 1)
     assert_equal(tags[0], "single")
-    print("  ✓ test_delimiter_single_value")
 
 
 fn test_delimiter_with_choices() raises:
@@ -339,7 +324,6 @@ fn test_delimiter_with_choices() raises:
     assert_true(
         caught, msg="Should raise error for invalid choice in delimited value"
     )
-    print("  ✓ test_delimiter_with_choices")
 
 
 fn test_delimiter_semicolon() raises:
@@ -356,7 +340,6 @@ fn test_delimiter_semicolon() raises:
     assert_equal(paths[0], "/usr/lib")
     assert_equal(paths[1], "/opt/lib")
     assert_equal(paths[2], "/home/lib")
-    print("  ✓ test_delimiter_semicolon")
 
 
 fn test_delimiter_implies_append() raises:
@@ -374,7 +357,6 @@ fn test_delimiter_implies_append() raises:
     assert_equal(len(tags), 2)
     assert_equal(tags[0], "x")
     assert_equal(tags[1], "y")
-    print("  ✓ test_delimiter_implies_append")
 
 
 fn test_delimiter_empty_not_provided() raises:
@@ -388,7 +370,6 @@ fn test_delimiter_empty_not_provided() raises:
     var result = command.parse_arguments(args)
     var tags = result.get_list("tag")
     assert_equal(len(tags), 0)
-    print("  ✓ test_delimiter_empty_not_provided")
 
 
 fn test_delimiter_trailing_comma() raises:
@@ -404,7 +385,6 @@ fn test_delimiter_trailing_comma() raises:
     assert_equal(len(tags), 2)
     assert_equal(tags[0], "a")
     assert_equal(tags[1], "b")
-    print("  ✓ test_delimiter_trailing_comma")
 
 
 # ===------------------------------------------------------------------=== #
@@ -427,7 +407,6 @@ fn test_nargs_basic() raises:
     assert_equal(len(lst), 2, msg="number_of_values(2) should produce 2 values")
     assert_equal(lst[0], "10", msg="First value should be '10'")
     assert_equal(lst[1], "20", msg="Second value should be '20'")
-    print("  ✓ test_nargs_basic")
 
 
 fn test_nargs_three() raises:
@@ -444,7 +423,6 @@ fn test_nargs_three() raises:
     assert_equal(lst[0], "255", msg="First = 255")
     assert_equal(lst[1], "128", msg="Second = 128")
     assert_equal(lst[2], "0", msg="Third = 0")
-    print("  ✓ test_nargs_three")
 
 
 fn test_nargs_short_option() raises:
@@ -465,7 +443,6 @@ fn test_nargs_short_option() raises:
     )
     assert_equal(lst[0], "3", msg="First = 3")
     assert_equal(lst[1], "4", msg="Second = 4")
-    print("  ✓ test_nargs_short_option")
 
 
 fn test_nargs_repeated() raises:
@@ -493,7 +470,6 @@ fn test_nargs_repeated() raises:
     assert_equal(lst[1], "2", msg="2nd = 2")
     assert_equal(lst[2], "3", msg="3rd = 3")
     assert_equal(lst[3], "4", msg="4th = 4")
-    print("  ✓ test_nargs_repeated")
 
 
 fn test_nargs_too_few_values() raises:
@@ -515,7 +491,6 @@ fn test_nargs_too_few_values() raises:
             msg="Error should mention 'requires 2 values'",
         )
     assert_true(caught, msg="Should raise when not enough values for nargs")
-    print("  ✓ test_nargs_too_few_values")
 
 
 fn test_nargs_too_few_short() raises:
@@ -537,7 +512,6 @@ fn test_nargs_too_few_short() raises:
             msg="Error should mention 'requires 2 values'",
         )
     assert_true(caught, msg="Should raise when not enough values for nargs")
-    print("  ✓ test_nargs_too_few_short")
 
 
 fn test_nargs_with_choices() raises:
@@ -568,7 +542,6 @@ fn test_nargs_with_choices() raises:
         var msg = String(e)
         assert_true("Invalid value" in msg, msg="Should mention invalid value")
     assert_true(caught, msg="Bad choice in nargs should raise")
-    print("  ✓ test_nargs_with_choices")
 
 
 fn test_nargs_with_other_args() raises:
@@ -602,7 +575,6 @@ fn test_nargs_with_other_args() raises:
     assert_equal(
         result.get_string("output"), "out.txt", msg="output should be out.txt"
     )
-    print("  ✓ test_nargs_with_other_args")
 
 
 fn test_nargs_equals_syntax_rejected() raises:
@@ -624,7 +596,6 @@ fn test_nargs_equals_syntax_rejected() raises:
             msg="Error should mention = syntax not supported",
         )
     assert_true(caught, msg="nargs with = should raise")
-    print("  ✓ test_nargs_equals_syntax_rejected")
 
 
 fn test_nargs_prefix_match() raises:
@@ -640,7 +611,6 @@ fn test_nargs_prefix_match() raises:
     assert_equal(len(lst), 2, msg="prefix --pos should resolve to --position")
     assert_equal(lst[0], "7", msg="First = 7")
     assert_equal(lst[1], "8", msg="Second = 8")
-    print("  ✓ test_nargs_prefix_match")
 
 
 fn main() raises:

--- a/tests/test_completion.mojo
+++ b/tests/test_completion.mojo
@@ -22,7 +22,6 @@ fn test_fish_dispatch() raises:
         "complete -c myapp" in script,
         msg="Fish script should contain 'complete -c myapp'",
     )
-    print("  ✓ test_fish_dispatch")
 
 
 fn test_zsh_dispatch() raises:
@@ -43,7 +42,6 @@ fn test_zsh_dispatch() raises:
         "compdef _myapp myapp" in script,
         msg="Zsh script should register with 'compdef'",
     )
-    print("  ✓ test_zsh_dispatch")
 
 
 fn test_bash_dispatch() raises:
@@ -60,7 +58,6 @@ fn test_bash_dispatch() raises:
         "complete -F _myapp_completion myapp" in script,
         msg="Bash script should register with 'complete -F'",
     )
-    print("  ✓ test_bash_dispatch")
 
 
 fn test_case_insensitive_shell() raises:
@@ -81,7 +78,6 @@ fn test_case_insensitive_shell() raises:
         "complete -F" in bash_mixed,
         msg="Bash (mixed case) should work",
     )
-    print("  ✓ test_case_insensitive_shell")
 
 
 fn test_unknown_shell_raises() raises:
@@ -93,7 +89,6 @@ fn test_unknown_shell_raises() raises:
     except:
         raised = True
     assert_true(raised, msg="Unknown shell should raise an error")
-    print("  ✓ test_unknown_shell_raises")
 
 
 # ── Fish completion details ──────────────────────────────────────────────────
@@ -114,7 +109,6 @@ fn test_fish_long_option() raises:
         "-s o" in script,
         msg="Fish script should contain '-s o'",
     )
-    print("  ✓ test_fish_long_option")
 
 
 fn test_fish_flag_no_require_value() raises:
@@ -132,7 +126,7 @@ fn test_fish_flag_no_require_value() raises:
                 " -r" in lines[i],
                 msg="Flag should not have -r in Fish completion",
             )
-            print("  ✓ test_fish_flag_no_require_value")
+
             return
     assert_true(False, msg="Should have found --verbose in Fish output")
 
@@ -149,7 +143,7 @@ fn test_fish_value_option_has_require() raises:
                 " -r" in lines[i],
                 msg="Value option should have -r in Fish completion",
             )
-            print("  ✓ test_fish_value_option_has_require")
+
             return
     assert_true(False, msg="Should have found --output in Fish output")
 
@@ -168,7 +162,6 @@ fn test_fish_choices() raises:
         "-a 'json csv table'" in script,
         msg="Fish script should list choices with -a",
     )
-    print("  ✓ test_fish_choices")
 
 
 fn test_fish_help_text() raises:
@@ -180,7 +173,6 @@ fn test_fish_help_text() raises:
         "-d 'Output file'" in script,
         msg="Fish script should include help text with -d",
     )
-    print("  ✓ test_fish_help_text")
 
 
 fn test_fish_hidden_excluded() raises:
@@ -204,7 +196,6 @@ fn test_fish_hidden_excluded() raises:
         "-l visible" in script,
         msg="Visible args should appear in Fish completion",
     )
-    print("  ✓ test_fish_hidden_excluded")
 
 
 fn test_fish_builtin_help_version() raises:
@@ -219,7 +210,6 @@ fn test_fish_builtin_help_version() raises:
         "-l version" in script,
         msg="Fish script should include --version",
     )
-    print("  ✓ test_fish_builtin_help_version")
 
 
 fn test_fish_subcommands() raises:
@@ -248,7 +238,6 @@ fn test_fish_subcommands() raises:
         "-l max-depth" in script,
         msg="Fish script should include subcommand options",
     )
-    print("  ✓ test_fish_subcommands")
 
 
 fn test_fish_escape_single_quote() raises:
@@ -262,7 +251,6 @@ fn test_fish_escape_single_quote() raises:
         "It\\'s a test" in script,
         msg="Fish script should escape single quotes",
     )
-    print("  ✓ test_fish_escape_single_quote")
 
 
 # ── Zsh completion details ───────────────────────────────────────────────────
@@ -286,7 +274,6 @@ fn test_zsh_simple_flag() raises:
         "-v" in script,
         msg="Zsh script should contain -v",
     )
-    print("  ✓ test_zsh_simple_flag")
 
 
 fn test_zsh_choices() raises:
@@ -303,7 +290,6 @@ fn test_zsh_choices() raises:
         "json csv" in script,
         msg="Zsh script should include choice values",
     )
-    print("  ✓ test_zsh_choices")
 
 
 fn test_zsh_subcommands() raises:
@@ -327,7 +313,6 @@ fn test_zsh_subcommands() raises:
         "--release" in script,
         msg="Zsh script should include subcommand options",
     )
-    print("  ✓ test_zsh_subcommands")
 
 
 fn test_zsh_escape_brackets() raises:
@@ -341,7 +326,6 @@ fn test_zsh_escape_brackets() raises:
         "Test \\[option\\]" in script,
         msg="Zsh script should escape brackets",
     )
-    print("  ✓ test_zsh_escape_brackets")
 
 
 fn test_zsh_escape_colon() raises:
@@ -355,7 +339,6 @@ fn test_zsh_escape_colon() raises:
         "Key\\: value" in script,
         msg="Zsh script should escape colons",
     )
-    print("  ✓ test_zsh_escape_colon")
 
 
 fn test_zsh_builtin_help() raises:
@@ -370,7 +353,6 @@ fn test_zsh_builtin_help() raises:
         "--version" in script,
         msg="Zsh script should include --version",
     )
-    print("  ✓ test_zsh_builtin_help")
 
 
 # ── Bash completion details ──────────────────────────────────────────────────
@@ -402,7 +384,6 @@ fn test_bash_simple_options() raises:
         "-o" in script,
         msg="Bash script should contain -o",
     )
-    print("  ✓ test_bash_simple_options")
 
 
 fn test_bash_subcommands() raises:
@@ -424,7 +405,6 @@ fn test_bash_subcommands() raises:
         "subcmd" in script,
         msg="Bash script should detect subcommand",
     )
-    print("  ✓ test_bash_subcommands")
 
 
 fn test_bash_choices_prev() raises:
@@ -443,7 +423,6 @@ fn test_bash_choices_prev() raises:
         "debug info warn" in script,
         msg="Bash script should include choice values",
     )
-    print("  ✓ test_bash_choices_prev")
 
 
 fn test_bash_hidden_excluded() raises:
@@ -464,7 +443,6 @@ fn test_bash_hidden_excluded() raises:
         "--public" in script,
         msg="Visible args should appear in Bash completion",
     )
-    print("  ✓ test_bash_hidden_excluded")
 
 
 fn test_bash_builtin_help_version() raises:
@@ -479,7 +457,6 @@ fn test_bash_builtin_help_version() raises:
         "--version" in script,
         msg="Bash script should include --version",
     )
-    print("  ✓ test_bash_builtin_help_version")
 
 
 # ── Cross-shell consistency ──────────────────────────────────────────────────
@@ -515,7 +492,6 @@ fn test_all_shells_include_same_options() raises:
     assert_true("--verbose" in bash, msg="bash should include --verbose")
     assert_true("--output" in bash, msg="bash should include --output")
     assert_true("--format" in bash, msg="bash should include --format")
-    print("  ✓ test_all_shells_include_same_options")
 
 
 fn test_count_option_no_value() raises:
@@ -540,7 +516,6 @@ fn test_count_option_no_value() raises:
             )
             break
     assert_true(found, msg="Fish script should contain '-l verbose' line")
-    print("  ✓ test_count_option_no_value")
 
 
 fn test_persistent_flags_in_root() raises:
@@ -557,7 +532,6 @@ fn test_persistent_flags_in_root() raises:
         "-l debug" in fish,
         msg="Persistent flag should appear in Fish root completions",
     )
-    print("  ✓ test_persistent_flags_in_root")
 
 
 fn test_positional_excluded() raises:
@@ -581,7 +555,6 @@ fn test_positional_excluded() raises:
         "--pattern" in bash,
         msg="Positional args should not appear as Bash options",
     )
-    print("  ✓ test_positional_excluded")
 
 
 fn test_generated_by_comment() raises:
@@ -602,7 +575,6 @@ fn test_generated_by_comment() raises:
         "Generated by ArgMojo" in bash,
         msg="Bash script should have ArgMojo attribution",
     )
-    print("  ✓ test_generated_by_comment")
 
 
 # ── Built-in --completions flag ───────────────────────────────────────────────
@@ -620,7 +592,6 @@ fn test_fish_builtin_completions() raises:
         "bash zsh fish" in script,
         msg="Fish script should list 'bash zsh fish' as completion choices",
     )
-    print("  ✓ test_fish_builtin_completions")
 
 
 fn test_zsh_builtin_completions() raises:
@@ -635,7 +606,6 @@ fn test_zsh_builtin_completions() raises:
         "(bash zsh fish)" in script,
         msg="Zsh script should list '(bash zsh fish)' as choices",
     )
-    print("  ✓ test_zsh_builtin_completions")
 
 
 fn test_bash_builtin_completions() raises:
@@ -650,7 +620,6 @@ fn test_bash_builtin_completions() raises:
         "bash zsh fish" in script,
         msg="Bash script should list 'bash zsh fish' as prev-case choices",
     )
-    print("  ✓ test_bash_builtin_completions")
 
 
 fn test_disable_default_completions_not_in_script() raises:
@@ -682,7 +651,6 @@ fn test_disable_default_completions_not_in_script() raises:
             " disable_default_completions()"
         ),
     )
-    print("  ✓ test_disable_default_completions_not_in_script")
 
 
 fn test_disable_default_completions_not_in_help() raises:
@@ -698,7 +666,6 @@ fn test_disable_default_completions_not_in_help() raises:
             " disable_default_completions()"
         ),
     )
-    print("  ✓ test_disable_default_completions_not_in_help")
 
 
 fn test_completions_in_help_by_default() raises:
@@ -714,7 +681,6 @@ fn test_completions_in_help_by_default() raises:
         "bash,zsh,fish" in help_text or "{bash,zsh,fish}" in help_text,
         msg="Help text should show shell choices for --completions",
     )
-    print("  ✓ test_completions_in_help_by_default")
 
 
 # ── completions_name() ──────────────────────────────────────────────────────
@@ -747,7 +713,6 @@ fn test_completions_custom_name_in_scripts() raises:
         "--completions" in bash,
         msg="Bash script should NOT have '--completions' after rename",
     )
-    print("  ✓ test_completions_custom_name_in_scripts")
 
 
 fn test_completions_custom_name_in_help() raises:
@@ -763,7 +728,6 @@ fn test_completions_custom_name_in_help() raises:
         "--completions" in help_text,
         msg="Help text should NOT show '--completions' after rename",
     )
-    print("  ✓ test_completions_custom_name_in_help")
 
 
 fn test_completions_custom_name_in_bash_prev() raises:
@@ -779,7 +743,6 @@ fn test_completions_custom_name_in_bash_prev() raises:
         "--completions)" in bash,
         msg="Bash prev-case should NOT have '--completions)' after rename",
     )
-    print("  ✓ test_completions_custom_name_in_bash_prev")
 
 
 # ── completions_as_subcommand() ─────────────────────────────────────────────
@@ -809,7 +772,6 @@ fn test_completions_as_subcommand_in_help() raises:
             " when using subcommand mode"
         ),
     )
-    print("  ✓ test_completions_as_subcommand_in_help")
 
 
 fn test_completions_as_subcommand_in_fish() raises:
@@ -835,7 +797,6 @@ fn test_completions_as_subcommand_in_fish() raises:
             " in subcommand mode"
         ),
     )
-    print("  ✓ test_completions_as_subcommand_in_fish")
 
 
 fn test_completions_as_subcommand_in_zsh() raises:
@@ -860,7 +821,6 @@ fn test_completions_as_subcommand_in_zsh() raises:
         "completions)" in zsh,
         msg="Zsh script should have completions) case handler",
     )
-    print("  ✓ test_completions_as_subcommand_in_zsh")
 
 
 fn test_completions_as_subcommand_in_bash() raises:
@@ -886,7 +846,6 @@ fn test_completions_as_subcommand_in_bash() raises:
             " names in subcommand mode"
         ),
     )
-    print("  ✓ test_completions_as_subcommand_in_bash")
 
 
 fn test_completions_custom_name_with_subcommand() raises:
@@ -924,7 +883,6 @@ fn test_completions_custom_name_with_subcommand() raises:
         "comp)" in bash,
         msg="Bash should have 'comp)' case handler with custom name",
     )
-    print("  ✓ test_completions_custom_name_with_subcommand")
 
 
 # ── Alias in completion scripts ──────────────────────────────────────────────
@@ -951,7 +909,6 @@ fn test_fish_completion_includes_alias() raises:
         "__fish_seen_subcommand_from clone cl" in script,
         msg="Fish should include alias in seen_subcommand_from",
     )
-    print("  ✓ test_fish_completion_includes_alias")
 
 
 fn test_zsh_completion_includes_alias() raises:
@@ -970,7 +927,6 @@ fn test_zsh_completion_includes_alias() raises:
         "clone|cl)" in script,
         msg="Zsh script should dispatch clone|cl pattern",
     )
-    print("  ✓ test_zsh_completion_includes_alias")
 
 
 fn test_bash_completion_includes_alias() raises:
@@ -990,7 +946,6 @@ fn test_bash_completion_includes_alias() raises:
         "clone cl" in script,
         msg="Bash should list alias in subcommand names",
     )
-    print("  ✓ test_bash_completion_includes_alias")
 
 
 # ── Hidden subcommands in completions ─────────────────────────────────────────
@@ -1021,7 +976,6 @@ fn test_fish_hidden_sub_excluded() raises:
         "debug" in script,
         msg="Fish script should NOT include hidden sub 'debug'",
     )
-    print("  ✓ test_fish_hidden_sub_excluded")
 
 
 fn test_zsh_hidden_sub_excluded() raises:
@@ -1036,7 +990,6 @@ fn test_zsh_hidden_sub_excluded() raises:
         "'debug:" in script,
         msg="Zsh script should NOT include hidden sub 'debug'",
     )
-    print("  ✓ test_zsh_hidden_sub_excluded")
 
 
 fn test_bash_hidden_sub_excluded() raises:
@@ -1051,7 +1004,6 @@ fn test_bash_hidden_sub_excluded() raises:
         "debug" in script,
         msg="Bash script should NOT include hidden sub 'debug'",
     )
-    print("  ✓ test_bash_hidden_sub_excluded")
 
 
 fn test_all_hidden_no_subcommand_completion() raises:
@@ -1075,7 +1027,6 @@ fn test_all_hidden_no_subcommand_completion() raises:
         "subcmd" in bash,
         msg="Bash should not have subcmd logic when all subs hidden",
     )
-    print("  ✓ test_all_hidden_no_subcommand_completion")
 
 
 fn main() raises:

--- a/tests/test_extras.mojo
+++ b/tests/test_extras.mojo
@@ -17,7 +17,6 @@ fn test_range_valid_value() raises:
     var args: List[String] = ["test", "--port", "8080"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("port"), "8080")
-    print("  ✓ test_range_valid_value")
 
 
 fn test_range_boundary_min() raises:
@@ -30,7 +29,6 @@ fn test_range_boundary_min() raises:
     var args: List[String] = ["test", "--port", "1"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("port"), "1")
-    print("  ✓ test_range_boundary_min")
 
 
 fn test_range_boundary_max() raises:
@@ -43,7 +41,6 @@ fn test_range_boundary_max() raises:
     var args: List[String] = ["test", "--port", "65535"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("port"), "65535")
-    print("  ✓ test_range_boundary_max")
 
 
 fn test_range_below_min() raises:
@@ -65,7 +62,6 @@ fn test_range_below_min() raises:
         )
         assert_true("[1, 65535]" in msg, msg="error should show range bounds")
     assert_true(caught, msg="Should have raised for value below min")
-    print("  ✓ test_range_below_min")
 
 
 fn test_range_above_max() raises:
@@ -86,7 +82,6 @@ fn test_range_above_max() raises:
             "out of range" in msg, msg="error should mention 'out of range'"
         )
     assert_true(caught, msg="Should have raised for value above max")
-    print("  ✓ test_range_above_max")
 
 
 fn test_range_not_provided_ok() raises:
@@ -99,7 +94,6 @@ fn test_range_not_provided_ok() raises:
     var args: List[String] = ["test"]
     var result = command.parse_arguments(args)
     assert_false(result.has("port"), msg="port should not be set")
-    print("  ✓ test_range_not_provided_ok")
 
 
 fn test_range_with_append() raises:
@@ -121,7 +115,6 @@ fn test_range_with_append() raises:
         )
         assert_true("101" in msg, msg="error should mention the bad value")
     assert_true(caught, msg="Should have raised for one value out of range")
-    print("  ✓ test_range_with_append")
 
 
 fn test_range_with_short_option() raises:
@@ -134,7 +127,6 @@ fn test_range_with_short_option() raises:
     var args: List[String] = ["test", "-l", "3"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("level"), "3")
-    print("  ✓ test_range_with_short_option")
 
 
 # ── Range clamping (.clamp()) ────────────────────────────────────────────────
@@ -154,7 +146,6 @@ fn test_clamp_above_max() raises:
         100,
         msg="200 should be clamped to 100",
     )
-    print("  ✓ test_clamp_above_max")
 
 
 fn test_clamp_below_min() raises:
@@ -171,7 +162,6 @@ fn test_clamp_below_min() raises:
         1,
         msg="-5 should be clamped to 1",
     )
-    print("  ✓ test_clamp_below_min")
 
 
 fn test_clamp_within_range_no_change() raises:
@@ -188,7 +178,6 @@ fn test_clamp_within_range_no_change() raises:
         50,
         msg="50 should remain 50",
     )
-    print("  ✓ test_clamp_within_range_no_change")
 
 
 fn test_clamp_at_boundary() raises:
@@ -207,7 +196,6 @@ fn test_clamp_at_boundary() raises:
     assert_equal(
         result2.get_int("port"), 65535, msg="65535 at max boundary is fine"
     )
-    print("  ✓ test_clamp_at_boundary")
 
 
 fn test_clamp_with_short_option() raises:
@@ -228,7 +216,6 @@ fn test_clamp_with_short_option() raises:
         10,
         msg="99 with range [0,10] should clamp to 10",
     )
-    print("  ✓ test_clamp_with_short_option")
 
 
 fn test_clamp_with_append() raises:
@@ -256,7 +243,6 @@ fn test_clamp_with_append() raises:
     assert_equal(lst[0], "50", msg="50 should remain 50")
     assert_equal(lst[1], "100", msg="200 should clamp to 100")
     assert_equal(lst[2], "1", msg="0 should clamp to 1")
-    print("  ✓ test_clamp_with_append")
 
 
 fn test_range_without_clamp_still_errors() raises:
@@ -275,7 +261,6 @@ fn test_range_without_clamp_still_errors() raises:
         var msg = String(e)
         assert_true("out of range" in msg, msg="should error on out of range")
     assert_true(caught, msg="Should have raised for out-of-range without clamp")
-    print("  ✓ test_range_without_clamp_still_errors")
 
 
 # ── Key-value map option ─────────────────────────────────────────────────────
@@ -295,7 +280,6 @@ fn test_map_single_pair() raises:
     var result = command.parse_arguments(args)
     var m = result.get_map("define")
     assert_equal(m["CC"], "gcc")
-    print("  ✓ test_map_single_pair")
 
 
 fn test_map_multiple_pairs() raises:
@@ -313,7 +297,6 @@ fn test_map_multiple_pairs() raises:
     var m = result.get_map("define")
     assert_equal(m["CC"], "gcc")
     assert_equal(m["CXX"], "g++")
-    print("  ✓ test_map_multiple_pairs")
 
 
 fn test_map_equals_syntax() raises:
@@ -327,7 +310,6 @@ fn test_map_equals_syntax() raises:
     var result = command.parse_arguments(args)
     var m = result.get_map("define")
     assert_equal(m["CC"], "gcc")
-    print("  ✓ test_map_equals_syntax")
 
 
 fn test_map_with_delimiter() raises:
@@ -346,7 +328,6 @@ fn test_map_with_delimiter() raises:
     var m = result.get_map("define")
     assert_equal(m["CC"], "gcc")
     assert_equal(m["CXX"], "g++")
-    print("  ✓ test_map_with_delimiter")
 
 
 fn test_map_invalid_no_equals() raises:
@@ -365,7 +346,6 @@ fn test_map_invalid_no_equals() raises:
         var msg = String(e)
         assert_true("key=value" in msg, msg="error should mention format")
     assert_true(caught, msg="Should have raised for missing '='")
-    print("  ✓ test_map_invalid_no_equals")
 
 
 fn test_map_has_check() raises:
@@ -378,7 +358,6 @@ fn test_map_has_check() raises:
     var args: List[String] = ["test", "--define", "A=1"]
     var result = command.parse_arguments(args)
     assert_true(result.has("define"), msg="has() should be True for map arg")
-    print("  ✓ test_map_has_check")
 
 
 fn test_map_empty_value() raises:
@@ -392,7 +371,6 @@ fn test_map_empty_value() raises:
     var result = command.parse_arguments(args)
     var m = result.get_map("define")
     assert_equal(m["KEY"], "")
-    print("  ✓ test_map_empty_value")
 
 
 fn test_map_value_with_equals() raises:
@@ -406,7 +384,6 @@ fn test_map_value_with_equals() raises:
     var result = command.parse_arguments(args)
     var m = result.get_map("env")
     assert_equal(m["PATH"], "/usr/bin:/bin")
-    print("  ✓ test_map_value_with_equals")
 
 
 # ── Aliases ──────────────────────────────────────────────────────────────────
@@ -425,7 +402,6 @@ fn test_alias_basic() raises:
     var args: List[String] = ["test", "--color", "red"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("colour"), "red")
-    print("  ✓ test_alias_basic")
 
 
 fn test_alias_primary_still_works() raises:
@@ -441,7 +417,6 @@ fn test_alias_primary_still_works() raises:
     var args: List[String] = ["test", "--colour", "blue"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("colour"), "blue")
-    print("  ✓ test_alias_primary_still_works")
 
 
 fn test_alias_multiple() raises:
@@ -461,7 +436,6 @@ fn test_alias_multiple() raises:
     var args2: List[String] = ["test", "--out", "yaml"]
     var result2 = command.parse_arguments(args2)
     assert_equal(result2.get_string("output"), "yaml")
-    print("  ✓ test_alias_multiple")
 
 
 fn test_alias_prefix_match() raises:
@@ -477,7 +451,6 @@ fn test_alias_prefix_match() raises:
     var args: List[String] = ["test", "--colo", "green"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("colour"), "green")
-    print("  ✓ test_alias_prefix_match")
 
 
 fn test_alias_with_flag() raises:
@@ -496,7 +469,6 @@ fn test_alias_with_flag() raises:
     assert_true(
         result.get_flag("verbose"), msg="--debug alias should set verbose flag"
     )
-    print("  ✓ test_alias_with_flag")
 
 
 # ── Deprecated arguments ─────────────────────────────────────────────────────
@@ -514,7 +486,6 @@ fn test_deprecated_still_parses() raises:
     var args: List[String] = ["test", "--format-old", "csv"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("format_old"), "csv")
-    print("  ✓ test_deprecated_still_parses")
 
 
 fn test_deprecated_short_option() raises:
@@ -531,7 +502,6 @@ fn test_deprecated_short_option() raises:
     var args: List[String] = ["test", "-C"]
     var result = command.parse_arguments(args)
     assert_true(result.get_flag("compat"), msg="-C should still set the flag")
-    print("  ✓ test_deprecated_short_option")
 
 
 fn test_deprecated_not_provided_ok() raises:
@@ -548,7 +518,6 @@ fn test_deprecated_not_provided_ok() raises:
     var result = command.parse_arguments(args)
     assert_false(result.has("old"), msg="old should not be present")
     assert_equal(result.get_string("new"), "val")
-    print("  ✓ test_deprecated_not_provided_ok")
 
 
 fn test_deprecated_with_alias() raises:
@@ -565,7 +534,6 @@ fn test_deprecated_with_alias() raises:
     var args: List[String] = ["test", "--out", "json"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("output"), "json")
-    print("  ✓ test_deprecated_with_alias")
 
 
 # ── Help display: deprecated tag and map placeholder ─────────────────────────
@@ -586,7 +554,6 @@ fn test_help_deprecated_tag() raises:
         "[deprecated: Use --new instead]" in help,
         msg="help should contain deprecated tag",
     )
-    print("  ✓ test_help_deprecated_tag")
 
 
 fn test_help_map_placeholder() raises:
@@ -604,7 +571,6 @@ fn test_help_map_placeholder() raises:
         "<key=value>" in help,
         msg="help should show <key=value> placeholder for map options",
     )
-    print("  ✓ test_help_map_placeholder")
 
 
 fn test_help_alias_shown() raises:
@@ -623,7 +589,6 @@ fn test_help_alias_shown() raises:
         "--colour, --color" in help,
         msg="help should show '--colour, --color' for aliased option",
     )
-    print("  ✓ test_help_alias_shown")
 
 
 fn main() raises:

--- a/tests/test_groups.mojo
+++ b/tests/test_groups.mojo
@@ -26,7 +26,6 @@ fn test_exclusive_one_provided() raises:
     var result = command.parse_arguments(args)
     assert_true(result.get_flag("json"), msg="--json should be True")
     assert_false(result.get_flag("yaml"), msg="--yaml should be False")
-    print("  ✓ test_exclusive_one_provided")
 
 
 fn test_exclusive_none_provided() raises:
@@ -45,7 +44,6 @@ fn test_exclusive_none_provided() raises:
     var result = command.parse_arguments(args)
     assert_false(result.get_flag("json"), msg="--json should be False")
     assert_false(result.get_flag("yaml"), msg="--yaml should be False")
-    print("  ✓ test_exclusive_none_provided")
 
 
 fn test_exclusive_conflict() raises:
@@ -83,7 +81,6 @@ fn test_exclusive_conflict() raises:
             msg="Error should mention --yaml",
         )
     assert_true(caught, msg="Should have raised error for exclusive conflict")
-    print("  ✓ test_exclusive_conflict")
 
 
 fn test_exclusive_value_args() raises:
@@ -108,7 +105,6 @@ fn test_exclusive_value_args() raises:
             msg="Error should mention mutually exclusive",
         )
     assert_true(caught, msg="Should have raised error for exclusive conflict")
-    print("  ✓ test_exclusive_value_args")
 
 
 # ── Required-together groups ─────────────────────────────────────────────────────
@@ -136,7 +132,6 @@ fn test_required_together_all_provided() raises:
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("username"), "admin")
     assert_equal(result.get_string("password"), "secret")
-    print("  ✓ test_required_together_all_provided")
 
 
 fn test_required_together_none_provided() raises:
@@ -155,7 +150,6 @@ fn test_required_together_none_provided() raises:
     var result = command.parse_arguments(args)
     assert_false(result.has("username"), msg="username should not be set")
     assert_false(result.has("password"), msg="password should not be set")
-    print("  ✓ test_required_together_none_provided")
 
 
 fn test_required_together_partial() raises:
@@ -187,7 +181,6 @@ fn test_required_together_partial() raises:
             msg="Error should mention --password",
         )
     assert_true(caught, msg="Should have raised error for partial group")
-    print("  ✓ test_required_together_partial")
 
 
 fn test_required_together_three_args() raises:
@@ -215,7 +208,6 @@ fn test_required_together_three_args() raises:
             msg="Error should mention --proto",
         )
     assert_true(caught, msg="Should have raised error for partial group")
-    print("  ✓ test_required_together_three_args")
 
 
 # ===------------------------------------------------------------------=== #
@@ -243,7 +235,6 @@ fn test_one_required_one_provided() raises:
     assert_true(result.get_flag("yaml"), msg="--yaml should be True")
     assert_false(result.get_flag("json"), msg="--json should be False")
     assert_false(result.get_flag("toml"), msg="--toml should be False")
-    print("  ✓ test_one_required_one_provided")
 
 
 fn test_one_required_multiple_provided() raises:
@@ -263,7 +254,6 @@ fn test_one_required_multiple_provided() raises:
     var result = command.parse_arguments(args)
     assert_true(result.get_flag("json"), msg="--json should be True")
     assert_true(result.get_flag("yaml"), msg="--yaml should be True")
-    print("  ✓ test_one_required_multiple_provided")
 
 
 fn test_one_required_none_provided() raises:
@@ -298,7 +288,6 @@ fn test_one_required_none_provided() raises:
             msg="Error should mention '--yaml'",
         )
     assert_true(caught, msg="Should have raised error for one-required group")
-    print("  ✓ test_one_required_none_provided")
 
 
 fn test_one_required_with_value_args() raises:
@@ -317,7 +306,6 @@ fn test_one_required_with_value_args() raises:
     var args: List[String] = ["test", "--input", "data.txt"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("input"), "data.txt")
-    print("  ✓ test_one_required_with_value_args")
 
 
 fn test_one_required_with_short_option() raises:
@@ -335,7 +323,6 @@ fn test_one_required_with_short_option() raises:
     var args: List[String] = ["test", "-j"]
     var result = command.parse_arguments(args)
     assert_true(result.get_flag("json"), msg="-j should satisfy one_required")
-    print("  ✓ test_one_required_with_short_option")
 
 
 fn test_one_required_error_shows_display_names() raises:
@@ -362,7 +349,6 @@ fn test_one_required_error_shows_display_names() raises:
         assert_true("'--json'" in msg, msg="Should show '--json' in error")
         assert_true("'--yaml'" in msg, msg="Should show '--yaml' in error")
     assert_true(caught, msg="Should have raised error")
-    print("  ✓ test_one_required_error_shows_display_names")
 
 
 fn test_one_required_combined_with_exclusive() raises:
@@ -403,7 +389,6 @@ fn test_one_required_combined_with_exclusive() raises:
     except:
         caught_both = True
     assert_true(caught_both, msg="Should error when both provided")
-    print("  ✓ test_one_required_combined_with_exclusive")
 
 
 fn test_one_required_multiple_groups() raises:
@@ -439,7 +424,6 @@ fn test_one_required_multiple_groups() raises:
             msg="Error should mention missing group",
         )
     assert_true(caught, msg="Should error when second group unsatisfied")
-    print("  ✓ test_one_required_multiple_groups")
 
 
 fn test_one_required_with_append_arg() raises:
@@ -458,7 +442,6 @@ fn test_one_required_with_append_arg() raises:
     var tags = result.get_list("tag")
     assert_equal(len(tags), 1)
     assert_equal(tags[0], "v1")
-    print("  ✓ test_one_required_with_append_arg")
 
 
 # ===------------------------------------------------------------------=== #
@@ -481,7 +464,6 @@ fn test_conditional_req_satisfied() raises:
     var result = command.parse_arguments(args)
     assert_true(result.get_flag("save"), msg="--save should be True")
     assert_equal(result.get_string("output"), "out.txt")
-    print("  ✓ test_conditional_req_satisfied")
 
 
 fn test_conditional_req_condition_absent() raises:
@@ -501,7 +483,6 @@ fn test_conditional_req_condition_absent() raises:
     var result = command.parse_arguments(args)
     assert_false(result.has("save"), msg="save should not be present")
     assert_false(result.has("output"), msg="output should not be present")
-    print("  ✓ test_conditional_req_condition_absent")
 
 
 fn test_conditional_req_violated() raises:
@@ -536,7 +517,6 @@ fn test_conditional_req_violated() raises:
             msg="Error should say 'is required when'",
         )
     assert_true(caught, msg="Should raise error for missing conditional arg")
-    print("  ✓ test_conditional_req_violated")
 
 
 fn test_conditional_req_target_alone_ok() raises:
@@ -555,7 +535,6 @@ fn test_conditional_req_target_alone_ok() raises:
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("output"), "out.txt")
     assert_false(result.has("save"), msg="save should not be present")
-    print("  ✓ test_conditional_req_target_alone_ok")
 
 
 fn test_conditional_req_multiple_rules() raises:
@@ -620,7 +599,6 @@ fn test_conditional_req_multiple_rules() raises:
             msg="Error should mention '--compress'",
         )
     assert_true(caught, msg="Should raise error for second conditional rule")
-    print("  ✓ test_conditional_req_multiple_rules")
 
 
 fn test_conditional_req_with_short_option() raises:
@@ -653,7 +631,6 @@ fn test_conditional_req_with_short_option() raises:
     var result = command.parse_arguments(args2)
     assert_true(result.get_flag("save"), msg="-s should set save")
     assert_equal(result.get_string("output"), "out.txt")
-    print("  ✓ test_conditional_req_with_short_option")
 
 
 fn test_conditional_req_with_value_condition() raises:
@@ -676,7 +653,6 @@ fn test_conditional_req_with_value_condition() raises:
         assert_true("'--output'" in msg, msg="Error should mention --output")
         assert_true("'--format'" in msg, msg="Error should mention --format")
     assert_true(caught, msg="Value condition should trigger requirement")
-    print("  ✓ test_conditional_req_with_value_condition")
 
 
 fn test_conditional_req_error_uses_display_names() raises:
@@ -708,7 +684,6 @@ fn test_conditional_req_error_uses_display_names() raises:
             msg="Should show '--save' not 'do-save'",
         )
     assert_true(caught, msg="Should raise error")
-    print("  ✓ test_conditional_req_error_uses_display_names")
 
 
 fn main() raises:

--- a/tests/test_help.mojo
+++ b/tests/test_help.mojo
@@ -27,7 +27,6 @@ fn test_hidden_not_in_help() raises:
     var help = command._generate_help()
     assert_true("verbose" in help, msg="visible arg should be in help")
     assert_false("debug" in help, msg="hidden arg should NOT be in help")
-    print("  ✓ test_hidden_not_in_help")
 
 
 fn test_hidden_still_works() raises:
@@ -44,7 +43,6 @@ fn test_hidden_still_works() raises:
     var args: List[String] = ["test", "--debug"]
     var result = command.parse_arguments(args)
     assert_true(result.get_flag("debug"), msg="hidden --debug should work")
-    print("  ✓ test_hidden_still_works")
 
 
 # ── Metavar ──────────────────────────────────────────────────────────────────────
@@ -67,7 +65,6 @@ fn test_metavar_in_help() raises:
         "<output>" in help,
         msg="default placeholder should not appear when metavar is set",
     )
-    print("  ✓ test_metavar_in_help")
 
 
 fn test_choices_in_help() raises:
@@ -86,7 +83,6 @@ fn test_choices_in_help() raises:
         "{json,csv,table}" in help,
         msg="choices should appear in help as {json,csv,table}",
     )
-    print("  ✓ test_choices_in_help")
 
 
 # ── Count action ──────────────────────────────────────────────────────────────────
@@ -109,7 +105,6 @@ fn test_negatable_in_help() raises:
         "--color / --no-color" in help,
         msg="Help should show --color / --no-color",
     )
-    print("  ✓ test_negatable_in_help")
 
 
 fn test_append_in_help() raises:
@@ -131,7 +126,6 @@ fn test_append_in_help() raises:
         "ENV..." in help,
         msg="append arg with metavar should show ENV... in help",
     )
-    print("  ✓ test_append_in_help")
 
 
 # ===------------------------------------------------------------------=== #
@@ -151,7 +145,6 @@ fn test_help_question_mark_in_help_output() raises:
         "-h, --help" in help,
         msg="help output should show -h, --help",
     )
-    print("  ✓ test_help_question_mark_in_help_output")
 
 
 fn test_dynamic_padding_short_options() raises:
@@ -173,7 +166,6 @@ fn test_dynamic_padding_short_options() raises:
                 msg="-v line should contain help text",
             )
             break
-    print("  ✓ test_dynamic_padding_short_options")
 
 
 fn test_dynamic_padding_long_options() raises:
@@ -212,7 +204,6 @@ fn test_dynamic_padding_long_options() raises:
         desc_col_short,
         msg="Help descriptions should be aligned at the same column",
     )
-    print("  ✓ test_dynamic_padding_long_options")
 
 
 fn test_help_and_version_aligned() raises:
@@ -249,7 +240,6 @@ fn test_help_and_version_aligned() raises:
         desc_col_version,
         msg="output and version should be aligned",
     )
-    print("  ✓ test_help_and_version_aligned")
 
 
 fn test_help_on_no_arguments_disabled_by_default() raises:
@@ -264,7 +254,6 @@ fn test_help_on_no_arguments_disabled_by_default() raises:
     # Should NOT exit — just parse with defaults.
     var result = command.parse_arguments(args)
     assert_false(result.get_flag("verbose"), msg="verbose should be False")
-    print("  ✓ test_help_on_no_arguments_disabled_by_default")
 
 
 fn test_positional_args_aligned_in_help() raises:
@@ -295,7 +284,6 @@ fn test_positional_args_aligned_in_help() raises:
         desc_col_long,
         msg="positional arg descriptions should be aligned",
     )
-    print("  ✓ test_positional_args_aligned_in_help")
 
 
 fn test_help_contains_ansi_colors() raises:
@@ -325,7 +313,6 @@ fn test_help_contains_ansi_colors() raises:
         "Options:" in colored, msg="colored help should have 'Options:'"
     )
     assert_true("Options:" in plain, msg="plain help should have 'Options:'")
-    print("  ✓ test_help_contains_ansi_colors")
 
 
 fn test_help_color_false_no_codes() raises:
@@ -341,7 +328,6 @@ fn test_help_color_false_no_codes() raises:
     assert_true("Options:\n" in help, msg="Options header should be plain")
     # No escape character anywhere.
     assert_false("\x1b" in help, msg="No escape chars in plain mode")
-    print("  ✓ test_help_color_false_no_codes")
 
 
 fn test_custom_header_color() raises:
@@ -361,7 +347,6 @@ fn test_custom_header_color() raises:
         "\x1b[93m" in help,
         msg="Default yellow header code should be absent",
     )
-    print("  ✓ test_custom_header_color")
 
 
 fn test_custom_arg_color() raises:
@@ -383,7 +368,6 @@ fn test_custom_arg_color() raises:
         "\x1b[95m" in help,
         msg="Default magenta arg code should be absent",
     )
-    print("  ✓ test_custom_arg_color")
 
 
 fn test_custom_both_colors() raises:
@@ -400,7 +384,6 @@ fn test_custom_both_colors() raises:
     assert_true(
         "\x1b[1;4m" in help, msg="Bold+underline should still be present"
     )
-    print("  ✓ test_custom_both_colors")
 
 
 fn test_default_colors_unchanged() raises:
@@ -412,7 +395,6 @@ fn test_default_colors_unchanged() raises:
     # Default header = yellow \x1b[93m , default arg = magenta \x1b[95m
     assert_true("\x1b[93m" in help, msg="Default header should be yellow (93)")
     assert_true("\x1b[95m" in help, msg="Default arg should be magenta (95)")
-    print("  ✓ test_default_colors_unchanged")
 
 
 fn test_color_case_insensitive() raises:
@@ -434,7 +416,6 @@ fn test_color_case_insensitive() raises:
     command3.header_color("GREEN")
     var h3 = command3._generate_help(color=True)
     assert_true("\x1b[92m" in h3, msg="'GREEN' uppercase should resolve")
-    print("  ✓ test_color_case_insensitive")
 
 
 fn test_pink_alias_for_magenta() raises:
@@ -448,7 +429,6 @@ fn test_pink_alias_for_magenta() raises:
         "\x1b[95m" in help,
         msg="PINK alias should produce magenta ANSI code",
     )
-    print("  ✓ test_pink_alias_for_magenta")
 
 
 fn test_invalid_color_raises() raises:
@@ -475,7 +455,6 @@ fn test_invalid_color_raises() raises:
             msg="Error message should mention 'Unknown colour'",
         )
     assert_true(raised, msg="arg_color('LIME') should raise an error")
-    print("  ✓ test_invalid_color_raises")
 
 
 fn test_custom_color_plain_mode_unaffected() raises:
@@ -488,7 +467,6 @@ fn test_custom_color_plain_mode_unaffected() raises:
     var help = command._generate_help(color=False)
     assert_false("\x1b" in help, msg="Plain mode should have no ANSI codes")
     assert_true("Options:" in help, msg="Plain mode should still have content")
-    print("  ✓ test_custom_color_plain_mode_unaffected")
 
 
 # ===------------------------------------------------------------------=== #
@@ -525,7 +503,6 @@ fn test_nargs_in_help() raises:
         "<point>..." in help,
         msg="nargs should NOT show '...' suffix",
     )
-    print("  ✓ test_nargs_in_help")
 
 
 fn test_nargs_with_metavar() raises:
@@ -543,7 +520,6 @@ fn test_nargs_with_metavar() raises:
         "PX PX" in help,
         msg="number_of_values(2) with metavar PX should show 'PX PX'",
     )
-    print("  ✓ test_nargs_with_metavar")
 
 
 # ── Subcommand help UX ───────────────────────────────────────────────────────────
@@ -576,7 +552,6 @@ fn test_root_help_shows_commands_section() raises:
         "Initialize a new project" in help,
         msg="Help should include init description",
     )
-    print("  ✓ test_root_help_shows_commands_section")
 
 
 fn test_root_help_no_commands_when_no_subcommands() raises:
@@ -589,14 +564,13 @@ fn test_root_help_no_commands_when_no_subcommands() raises:
 
     var help = command._generate_help(color=False)
     assert_false("Commands:" in help, msg="No Commands: without subcommands")
-    print("  ✓ test_root_help_no_commands_when_no_subcommands")
 
 
 fn test_root_help_commands_excludes_help_sub() raises:
     """Tests that the auto-inserted 'help' subcommand is not listed in Commands.
     """
     var app = Command("app", "My app")
-    app.add_subcommand(Command("search", "Search")^)
+    app.add_subcommand(Command("search", "Search"))
     # 'help' subcommand is auto-added.
 
     var help = app._generate_help(color=False)
@@ -627,21 +601,19 @@ fn test_root_help_commands_excludes_help_sub() raises:
     assert_false(
         found_help_cmd, msg="'help' sub should not appear in Commands:"
     )
-    print("  ✓ test_root_help_commands_excludes_help_sub")
 
 
 fn test_root_help_usage_shows_command_placeholder() raises:
     """Tests that usage line includes <COMMAND> when subcommands are registered.
     """
     var app = Command("app", "My app")
-    app.add_subcommand(Command("search", "Search")^)
+    app.add_subcommand(Command("search", "Search"))
 
     var help = app._generate_help(color=False)
     assert_true(
         "<COMMAND>" in help,
         msg="Usage should show <COMMAND> placeholder",
     )
-    print("  ✓ test_root_help_usage_shows_command_placeholder")
 
 
 fn test_root_help_usage_no_command_placeholder_without_subs() raises:
@@ -656,7 +628,6 @@ fn test_root_help_usage_no_command_placeholder_without_subs() raises:
         "<COMMAND>" in help,
         msg="Usage should NOT show <COMMAND> without subcommands",
     )
-    print("  ✓ test_root_help_usage_no_command_placeholder_without_subs")
 
 
 fn test_persistent_args_under_global_options() raises:
@@ -672,7 +643,7 @@ fn test_persistent_args_under_global_options() raises:
     app.add_argument(
         Argument("output", help="Output file").long("output").short("o")
     )
-    app.add_subcommand(Command("search", "Search")^)
+    app.add_subcommand(Command("search", "Search"))
 
     var help = app._generate_help(color=False)
     assert_true(
@@ -688,7 +659,6 @@ fn test_persistent_args_under_global_options() raises:
         opt_pos < global_pos,
         msg="Options: should come before Global Options:",
     )
-    print("  ✓ test_persistent_args_under_global_options")
 
 
 fn test_no_global_options_without_persistent() raises:
@@ -697,14 +667,13 @@ fn test_no_global_options_without_persistent() raises:
     app.add_argument(
         Argument("verbose", help="Verbose output").long("verbose").flag()
     )
-    app.add_subcommand(Command("search", "Search")^)
+    app.add_subcommand(Command("search", "Search"))
 
     var help = app._generate_help(color=False)
     assert_false(
         "Global Options:" in help,
         msg="No Global Options: without persistent args",
     )
-    print("  ✓ test_no_global_options_without_persistent")
 
 
 fn test_child_help_shows_full_command_path() raises:
@@ -730,7 +699,6 @@ fn test_child_help_shows_full_command_path() raises:
         "app search" in help,
         msg="Child help should show full command path",
     )
-    print("  ✓ test_child_help_shows_full_command_path")
 
 
 fn test_child_help_shows_inherited_persistent_args() raises:
@@ -773,7 +741,6 @@ fn test_child_help_shows_inherited_persistent_args() raises:
         "--max-depth" in help,
         msg="Local --max-depth should appear in child help",
     )
-    print("  ✓ test_child_help_shows_inherited_persistent_args")
 
 
 fn test_add_tip_appears_in_help() raises:
@@ -791,7 +758,6 @@ fn test_add_tip_appears_in_help() raises:
         "Config: ~/.config/test/config.toml" in help,
         msg="Second tip should appear in help",
     )
-    print("  ✓ test_add_tip_appears_in_help")
 
 
 # ── Alias in help output ──────────────────────────────────────────────────────
@@ -810,7 +776,6 @@ fn test_alias_shown_inline_in_help() raises:
         "clone, cl" in help,
         msg="Help should show alias inline: 'clone, cl'",
     )
-    print("  ✓ test_alias_shown_inline_in_help")
 
 
 fn test_multiple_aliases_shown_in_help() raises:
@@ -826,7 +791,6 @@ fn test_multiple_aliases_shown_in_help() raises:
         "commit, ci, cm" in help,
         msg="Help should show all aliases: 'commit, ci, cm'",
     )
-    print("  ✓ test_multiple_aliases_shown_in_help")
 
 
 # ── Hidden subcommands ────────────────────────────────────────────────────────
@@ -844,7 +808,6 @@ fn test_hidden_subcommand_not_in_help() raises:
     var help = app._generate_help(color=False)
     assert_true("clone" in help, msg="visible sub should be in help")
     assert_false("debug" in help, msg="hidden sub should NOT be in help")
-    print("  ✓ test_hidden_subcommand_not_in_help")
 
 
 fn test_hidden_subcommand_not_in_usage_line() raises:
@@ -859,7 +822,6 @@ fn test_hidden_subcommand_not_in_usage_line() raises:
         "<COMMAND>" in help,
         msg="usage line should not show <COMMAND> when only subs are hidden",
     )
-    print("  ✓ test_hidden_subcommand_not_in_usage_line")
 
 
 fn test_hidden_subcommand_usage_line_with_visible() raises:
@@ -876,7 +838,6 @@ fn test_hidden_subcommand_usage_line_with_visible() raises:
         "<COMMAND>" in help,
         msg="usage line should show <COMMAND> when visible subs exist",
     )
-    print("  ✓ test_hidden_subcommand_usage_line_with_visible")
 
 
 # ── NO_COLOR ──────────────────────────────────────────────────────────────────

--- a/tests/test_implies.mojo
+++ b/tests/test_implies.mojo
@@ -1,0 +1,390 @@
+"""Tests for argmojo — mutual implication (implies) feature."""
+
+from testing import assert_true, assert_false, assert_equal, TestSuite
+import argmojo
+from argmojo import Argument, Command, ParseResult
+
+# ── Basic implication ─────────────────────────────────────────────────────────
+
+
+fn test_implies_basic_flag() raises:
+    """Tests that --debug implies --verbose (both flags)."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("debug", help="Debug mode").long("debug").flag()
+    )
+    command.add_argument(
+        Argument("verbose", help="Verbose output").long("verbose").flag()
+    )
+    command.implies("debug", "verbose")
+
+    var args: List[String] = ["test", "--debug"]
+    var result = command.parse_arguments(args)
+    assert_true(result.get_flag("debug"), msg="debug should be True")
+    assert_true(
+        result.get_flag("verbose"), msg="verbose should be implied by debug"
+    )
+    print("  ✓ test_implies_basic_flag")
+
+
+fn test_implies_no_trigger() raises:
+    """Tests that without --debug, --verbose is not auto-set."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("debug", help="Debug mode").long("debug").flag()
+    )
+    command.add_argument(
+        Argument("verbose", help="Verbose output").long("verbose").flag()
+    )
+    command.implies("debug", "verbose")
+
+    var args: List[String] = ["test"]
+    var result = command.parse_arguments(args)
+    assert_false(result.has("debug"), msg="debug should not be set")
+    assert_false(result.has("verbose"), msg="verbose should not be set")
+    print("  ✓ test_implies_no_trigger")
+
+
+fn test_implies_both_set_explicitly() raises:
+    """Tests that both --debug --verbose works without conflict."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("debug", help="Debug mode").long("debug").flag()
+    )
+    command.add_argument(
+        Argument("verbose", help="Verbose output").long("verbose").flag()
+    )
+    command.implies("debug", "verbose")
+
+    var args: List[String] = ["test", "--debug", "--verbose"]
+    var result = command.parse_arguments(args)
+    assert_true(result.get_flag("debug"), msg="debug should be True")
+    assert_true(result.get_flag("verbose"), msg="verbose should be True")
+    print("  ✓ test_implies_both_set_explicitly")
+
+
+fn test_implies_unidirectional() raises:
+    """Tests that implication is unidirectional: --verbose alone doesn't set --debug.
+    """
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("debug", help="Debug mode").long("debug").flag()
+    )
+    command.add_argument(
+        Argument("verbose", help="Verbose output").long("verbose").flag()
+    )
+    command.implies("debug", "verbose")
+
+    var args: List[String] = ["test", "--verbose"]
+    var result = command.parse_arguments(args)
+    assert_false(result.has("debug"), msg="debug should not be set")
+    assert_true(result.get_flag("verbose"), msg="verbose should be True")
+    print("  ✓ test_implies_unidirectional")
+
+
+# ── Chained implication ──────────────────────────────────────────────────────
+
+
+fn test_implies_chain() raises:
+    """Tests chained implication: --debug → --verbose → --log."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("debug", help="Debug mode").long("debug").flag()
+    )
+    command.add_argument(
+        Argument("verbose", help="Verbose output").long("verbose").flag()
+    )
+    command.add_argument(
+        Argument("log", help="Enable logging").long("log").flag()
+    )
+    command.implies("debug", "verbose")
+    command.implies("verbose", "log")
+
+    var args: List[String] = ["test", "--debug"]
+    var result = command.parse_arguments(args)
+    assert_true(result.get_flag("debug"), msg="debug should be True")
+    assert_true(
+        result.get_flag("verbose"), msg="verbose should be implied by debug"
+    )
+    assert_true(
+        result.get_flag("log"), msg="log should be implied by verbose (chain)"
+    )
+    print("  ✓ test_implies_chain")
+
+
+fn test_implies_chain_middle() raises:
+    """Tests chain from middle: --verbose sets --log but not --debug."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("debug", help="Debug mode").long("debug").flag()
+    )
+    command.add_argument(
+        Argument("verbose", help="Verbose output").long("verbose").flag()
+    )
+    command.add_argument(
+        Argument("log", help="Enable logging").long("log").flag()
+    )
+    command.implies("debug", "verbose")
+    command.implies("verbose", "log")
+
+    var args: List[String] = ["test", "--verbose"]
+    var result = command.parse_arguments(args)
+    assert_false(result.has("debug"), msg="debug should NOT be set")
+    assert_true(result.get_flag("verbose"), msg="verbose should be True")
+    assert_true(result.get_flag("log"), msg="log should be implied by verbose")
+    print("  ✓ test_implies_chain_middle")
+
+
+# ── Multiple implications from same trigger ──────────────────────────────────
+
+
+fn test_implies_multiple_from_same_trigger() raises:
+    """Tests that one trigger can imply multiple targets."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("debug", help="Debug mode").long("debug").flag()
+    )
+    command.add_argument(
+        Argument("verbose", help="Verbose output").long("verbose").flag()
+    )
+    command.add_argument(
+        Argument("log", help="Enable logging").long("log").flag()
+    )
+    command.implies("debug", "verbose")
+    command.implies("debug", "log")
+
+    var args: List[String] = ["test", "--debug"]
+    var result = command.parse_arguments(args)
+    assert_true(result.get_flag("debug"), msg="debug should be True")
+    assert_true(result.get_flag("verbose"), msg="verbose should be implied")
+    assert_true(result.get_flag("log"), msg="log should be implied")
+    print("  ✓ test_implies_multiple_from_same_trigger")
+
+
+# ── Count arguments ──────────────────────────────────────────────────────────
+
+
+fn test_implies_count_argument() raises:
+    """Tests that implication works with count-type arguments."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("debug", help="Debug mode").long("debug").flag()
+    )
+    command.add_argument(
+        Argument("verbose", help="Verbosity level")
+        .long("verbose")
+        .short("v")
+        .count()
+    )
+    command.implies("debug", "verbose")
+
+    var args: List[String] = ["test", "--debug"]
+    var result = command.parse_arguments(args)
+    assert_true(result.get_flag("debug"), msg="debug should be True")
+    assert_equal(
+        result.get_count("verbose"),
+        1,
+        msg="verbose count should be 1 (implied)",
+    )
+    print("  ✓ test_implies_count_argument")
+
+
+fn test_implies_count_already_set() raises:
+    """Tests that explicit count is preserved when trigger is also set."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("debug", help="Debug mode").long("debug").flag()
+    )
+    command.add_argument(
+        Argument("verbose", help="Verbosity level")
+        .long("verbose")
+        .short("v")
+        .count()
+    )
+    command.implies("debug", "verbose")
+
+    var args: List[String] = ["test", "--debug", "-vvv"]
+    var result = command.parse_arguments(args)
+    assert_true(result.get_flag("debug"), msg="debug should be True")
+    assert_equal(
+        result.get_count("verbose"),
+        3,
+        msg="verbose count should stay at 3 (explicit)",
+    )
+    print("  ✓ test_implies_count_already_set")
+
+
+# ── Cycle detection ──────────────────────────────────────────────────────────
+
+
+fn test_implies_self_cycle() raises:
+    """Tests that A implies A is rejected."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("debug", help="Debug mode").long("debug").flag()
+    )
+
+    var caught = False
+    try:
+        command.implies("debug", "debug")
+    except e:
+        caught = True
+        var msg = String(e)
+        assert_true(
+            "cycle" in String.lower(msg),
+            msg="error should mention 'cycle'",
+        )
+    assert_true(caught, msg="self-cycle should raise an error")
+    print("  ✓ test_implies_self_cycle")
+
+
+fn test_implies_direct_cycle() raises:
+    """Tests that A→B, B→A cycle is detected at registration."""
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("a", help="Flag A").long("a").flag())
+    command.add_argument(Argument("b", help="Flag B").long("b").flag())
+    command.implies("a", "b")
+
+    var caught = False
+    try:
+        command.implies("b", "a")
+    except e:
+        caught = True
+        var msg = String(e)
+        assert_true(
+            "cycle" in String.lower(msg),
+            msg="error should mention 'cycle'",
+        )
+    assert_true(caught, msg="direct cycle should raise an error")
+    print("  ✓ test_implies_direct_cycle")
+
+
+fn test_implies_indirect_cycle() raises:
+    """Tests that A→B→C, C→A cycle is detected at registration."""
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("a", help="Flag A").long("a").flag())
+    command.add_argument(Argument("b", help="Flag B").long("b").flag())
+    command.add_argument(Argument("c", help="Flag C").long("c").flag())
+    command.implies("a", "b")
+    command.implies("b", "c")
+
+    var caught = False
+    try:
+        command.implies("c", "a")
+    except e:
+        caught = True
+        var msg = String(e)
+        assert_true(
+            "cycle" in String.lower(msg),
+            msg="error should mention 'cycle'",
+        )
+    assert_true(caught, msg="indirect cycle should raise an error")
+    print("  ✓ test_implies_indirect_cycle")
+
+
+fn test_implies_no_false_cycle() raises:
+    """Tests that non-cyclic diamond shape is allowed: A→B, A→C, B→D, C→D."""
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("a", help="A").long("a").flag())
+    command.add_argument(Argument("b", help="B").long("b").flag())
+    command.add_argument(Argument("c", help="C").long("c").flag())
+    command.add_argument(Argument("d", help="D").long("d").flag())
+    command.implies("a", "b")
+    command.implies("a", "c")
+    command.implies("b", "d")
+    command.implies("c", "d")  # Diamond, not a cycle — should succeed
+
+    var args: List[String] = ["test", "--a"]
+    var result = command.parse_arguments(args)
+    assert_true(result.get_flag("a"), msg="a should be True")
+    assert_true(result.get_flag("b"), msg="b should be implied")
+    assert_true(result.get_flag("c"), msg="c should be implied")
+    assert_true(result.get_flag("d"), msg="d should be implied")
+    print("  ✓ test_implies_no_false_cycle")
+
+
+# ── Integration with other constraints ───────────────────────────────────────
+
+
+fn test_implies_with_required_if() raises:
+    """Tests implies combined with required_if: debug implies verbose,
+    verbose requires output."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("debug", help="Debug mode").long("debug").flag()
+    )
+    command.add_argument(
+        Argument("verbose", help="Verbose output").long("verbose").flag()
+    )
+    command.add_argument(Argument("output", help="Output path").long("output"))
+    command.implies("debug", "verbose")
+    command.required_if("output", "verbose")
+
+    # --debug implies --verbose, which triggers required_if for --output.
+    # Without --output, this should fail.
+    var args: List[String] = ["test", "--debug"]
+    var caught = False
+    try:
+        _ = command.parse_arguments(args)
+    except e:
+        caught = True
+    assert_true(
+        caught,
+        msg=(
+            "should fail because --output is required when --verbose is present"
+        ),
+    )
+    print("  ✓ test_implies_with_required_if")
+
+
+fn test_implies_with_required_if_satisfied() raises:
+    """Tests implies + required_if when the requirement is satisfied."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("debug", help="Debug mode").long("debug").flag()
+    )
+    command.add_argument(
+        Argument("verbose", help="Verbose output").long("verbose").flag()
+    )
+    command.add_argument(Argument("output", help="Output path").long("output"))
+    command.implies("debug", "verbose")
+    command.required_if("output", "verbose")
+
+    var args: List[String] = ["test", "--debug", "--output", "/tmp/log"]
+    var result = command.parse_arguments(args)
+    assert_true(result.get_flag("debug"), msg="debug should be True")
+    assert_true(result.get_flag("verbose"), msg="verbose should be implied")
+    assert_equal(result.get_string("output"), "/tmp/log")
+    print("  ✓ test_implies_with_required_if_satisfied")
+
+
+fn test_implies_with_mutually_exclusive() raises:
+    """Tests that implies does not override mutual exclusion checks.
+    If debug implies verbose, and verbose is exclusive with quiet,
+    then --debug --quiet should fail."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("debug", help="Debug mode").long("debug").flag()
+    )
+    command.add_argument(
+        Argument("verbose", help="Verbose output").long("verbose").flag()
+    )
+    command.add_argument(
+        Argument("quiet", help="Quiet mode").long("quiet").flag()
+    )
+    command.implies("debug", "verbose")
+    var excl: List[String] = ["verbose", "quiet"]
+    command.mutually_exclusive(excl^)
+
+    var args: List[String] = ["test", "--debug", "--quiet"]
+    var caught = False
+    try:
+        _ = command.parse_arguments(args)
+    except e:
+        caught = True
+    assert_true(caught, msg="debug implies verbose, which conflicts with quiet")
+    print("  ✓ test_implies_with_mutually_exclusive")
+
+
+fn main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_implies.mojo
+++ b/tests/test_implies.mojo
@@ -24,7 +24,6 @@ fn test_implies_basic_flag() raises:
     assert_true(
         result.get_flag("verbose"), msg="verbose should be implied by debug"
     )
-    print("  ✓ test_implies_basic_flag")
 
 
 fn test_implies_no_trigger() raises:
@@ -42,7 +41,6 @@ fn test_implies_no_trigger() raises:
     var result = command.parse_arguments(args)
     assert_false(result.has("debug"), msg="debug should not be set")
     assert_false(result.has("verbose"), msg="verbose should not be set")
-    print("  ✓ test_implies_no_trigger")
 
 
 fn test_implies_both_set_explicitly() raises:
@@ -60,7 +58,6 @@ fn test_implies_both_set_explicitly() raises:
     var result = command.parse_arguments(args)
     assert_true(result.get_flag("debug"), msg="debug should be True")
     assert_true(result.get_flag("verbose"), msg="verbose should be True")
-    print("  ✓ test_implies_both_set_explicitly")
 
 
 fn test_implies_unidirectional() raises:
@@ -79,7 +76,6 @@ fn test_implies_unidirectional() raises:
     var result = command.parse_arguments(args)
     assert_false(result.has("debug"), msg="debug should not be set")
     assert_true(result.get_flag("verbose"), msg="verbose should be True")
-    print("  ✓ test_implies_unidirectional")
 
 
 # ── Chained implication ──────────────────────────────────────────────────────
@@ -109,7 +105,6 @@ fn test_implies_chain() raises:
     assert_true(
         result.get_flag("log"), msg="log should be implied by verbose (chain)"
     )
-    print("  ✓ test_implies_chain")
 
 
 fn test_implies_chain_middle() raises:
@@ -132,7 +127,6 @@ fn test_implies_chain_middle() raises:
     assert_false(result.has("debug"), msg="debug should NOT be set")
     assert_true(result.get_flag("verbose"), msg="verbose should be True")
     assert_true(result.get_flag("log"), msg="log should be implied by verbose")
-    print("  ✓ test_implies_chain_middle")
 
 
 # ── Multiple implications from same trigger ──────────────────────────────────
@@ -158,7 +152,6 @@ fn test_implies_multiple_from_same_trigger() raises:
     assert_true(result.get_flag("debug"), msg="debug should be True")
     assert_true(result.get_flag("verbose"), msg="verbose should be implied")
     assert_true(result.get_flag("log"), msg="log should be implied")
-    print("  ✓ test_implies_multiple_from_same_trigger")
 
 
 # ── Count arguments ──────────────────────────────────────────────────────────
@@ -186,7 +179,6 @@ fn test_implies_count_argument() raises:
         1,
         msg="verbose count should be 1 (implied)",
     )
-    print("  ✓ test_implies_count_argument")
 
 
 fn test_implies_count_already_set() raises:
@@ -211,7 +203,6 @@ fn test_implies_count_already_set() raises:
         3,
         msg="verbose count should stay at 3 (explicit)",
     )
-    print("  ✓ test_implies_count_already_set")
 
 
 # ── Cycle detection ──────────────────────────────────────────────────────────
@@ -235,7 +226,6 @@ fn test_implies_self_cycle() raises:
             msg="error should mention 'cycle'",
         )
     assert_true(caught, msg="self-cycle should raise an error")
-    print("  ✓ test_implies_self_cycle")
 
 
 fn test_implies_direct_cycle() raises:
@@ -256,7 +246,6 @@ fn test_implies_direct_cycle() raises:
             msg="error should mention 'cycle'",
         )
     assert_true(caught, msg="direct cycle should raise an error")
-    print("  ✓ test_implies_direct_cycle")
 
 
 fn test_implies_indirect_cycle() raises:
@@ -279,7 +268,6 @@ fn test_implies_indirect_cycle() raises:
             msg="error should mention 'cycle'",
         )
     assert_true(caught, msg="indirect cycle should raise an error")
-    print("  ✓ test_implies_indirect_cycle")
 
 
 fn test_implies_no_false_cycle() raises:
@@ -300,7 +288,6 @@ fn test_implies_no_false_cycle() raises:
     assert_true(result.get_flag("b"), msg="b should be implied")
     assert_true(result.get_flag("c"), msg="c should be implied")
     assert_true(result.get_flag("d"), msg="d should be implied")
-    print("  ✓ test_implies_no_false_cycle")
 
 
 # ── Integration with other constraints ───────────────────────────────────────
@@ -334,7 +321,6 @@ fn test_implies_with_required_if() raises:
             "should fail because --output is required when --verbose is present"
         ),
     )
-    print("  ✓ test_implies_with_required_if")
 
 
 fn test_implies_with_required_if_satisfied() raises:
@@ -355,7 +341,6 @@ fn test_implies_with_required_if_satisfied() raises:
     assert_true(result.get_flag("debug"), msg="debug should be True")
     assert_true(result.get_flag("verbose"), msg="verbose should be implied")
     assert_equal(result.get_string("output"), "/tmp/log")
-    print("  ✓ test_implies_with_required_if_satisfied")
 
 
 fn test_implies_with_mutually_exclusive() raises:
@@ -383,7 +368,70 @@ fn test_implies_with_mutually_exclusive() raises:
     except e:
         caught = True
     assert_true(caught, msg="debug implies verbose, which conflicts with quiet")
-    print("  ✓ test_implies_with_mutually_exclusive")
+
+
+# ── Registration validation ──────────────────────────────────────────────────
+
+
+fn test_implies_unknown_trigger() raises:
+    """Tests that implies() rejects unknown trigger argument."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("verbose", help="Verbose output").long("verbose").flag()
+    )
+
+    var caught = False
+    try:
+        command.implies("nonexistent", "verbose")
+    except e:
+        caught = True
+        var msg = String(e)
+        assert_true(
+            "unknown" in String.lower(msg),
+            msg="error should mention 'unknown'",
+        )
+    assert_true(caught, msg="unknown trigger should raise an error")
+
+
+fn test_implies_unknown_implied() raises:
+    """Tests that implies() rejects unknown implied argument."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("debug", help="Debug mode").long("debug").flag()
+    )
+
+    var caught = False
+    try:
+        command.implies("debug", "nonexistent")
+    except e:
+        caught = True
+        var msg = String(e)
+        assert_true(
+            "unknown" in String.lower(msg),
+            msg="error should mention 'unknown'",
+        )
+    assert_true(caught, msg="unknown implied should raise an error")
+
+
+fn test_implies_rejects_value_taking_implied() raises:
+    """Tests that implies() rejects value-taking argument as implied target."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("debug", help="Debug mode").long("debug").flag()
+    )
+    command.add_argument(Argument("output", help="Output file").long("output"))
+
+    var caught = False
+    try:
+        command.implies("debug", "output")
+    except e:
+        caught = True
+        var msg = String(e)
+        assert_true(
+            "flag" in String.lower(msg) or "count" in String.lower(msg),
+            msg="error should mention flag or count",
+        )
+    assert_true(caught, msg="value-taking implied should raise an error")
 
 
 fn main() raises:

--- a/tests/test_negative_numbers.mojo
+++ b/tests/test_negative_numbers.mojo
@@ -30,7 +30,6 @@ fn test_negative_integer_auto_detect() raises:
     var args: List[String] = ["test", "-9876543"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("value"), "-9876543")
-    print("  ✓ test_negative_integer_auto_detect")
 
 
 fn test_negative_float_auto_detect() raises:
@@ -43,7 +42,6 @@ fn test_negative_float_auto_detect() raises:
     var args: List[String] = ["test", "-3.14"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("value"), "-3.14")
-    print("  ✓ test_negative_float_auto_detect")
 
 
 fn test_negative_leading_dot_auto_detect() raises:
@@ -56,7 +54,6 @@ fn test_negative_leading_dot_auto_detect() raises:
     var args: List[String] = ["test", "-.5"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("value"), "-.5")
-    print("  ✓ test_negative_leading_dot_auto_detect")
 
 
 fn test_negative_scientific_auto_detect() raises:
@@ -70,7 +67,6 @@ fn test_negative_scientific_auto_detect() raises:
     var args: List[String] = ["test", "-1.5e10"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("value"), "-1.5e10")
-    print("  ✓ test_negative_scientific_auto_detect")
 
 
 fn test_negative_scientific_negative_exp_auto_detect() raises:
@@ -83,7 +79,6 @@ fn test_negative_scientific_negative_exp_auto_detect() raises:
     var args: List[String] = ["test", "-2.0e-3"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("value"), "-2.0e-3")
-    print("  ✓ test_negative_scientific_negative_exp_auto_detect")
 
 
 fn test_multiple_negative_positionals() raises:
@@ -102,7 +97,6 @@ fn test_multiple_negative_positionals() raises:
     assert_true(result.has("b"))
     assert_equal(result.get_string("a"), "-1")
     assert_equal(result.get_string("b"), "-2.5")
-    print("  ✓ test_multiple_negative_positionals")
 
 
 fn test_mixed_negative_and_options() raises:
@@ -119,7 +113,6 @@ fn test_mixed_negative_and_options() raises:
     var result = command.parse_arguments(args)
     assert_true(result.get_flag("verbose"))
     assert_equal(result.get_string("value"), "-10.18")
-    print("  ✓ test_mixed_negative_and_options")
 
 
 # ── Explicit allow_negative_numbers() tests ─────────────────────────────────
@@ -143,7 +136,6 @@ fn test_explicit_allow_negative_numbers() raises:
     var args: List[String] = ["test", "-3.14"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("value"), "-3.14")
-    print("  ✓ test_explicit_allow_negative_numbers")
 
 
 fn test_explicit_allow_keeps_digit_short_option() raises:
@@ -164,7 +156,6 @@ fn test_explicit_allow_keeps_digit_short_option() raises:
     var args: List[String] = ["test", "-3"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("value"), "-3")
-    print("  ✓ test_explicit_allow_keeps_digit_short_option")
 
 
 # ── Digit short option blocks auto-detect ───────────────────────────────────
@@ -184,7 +175,6 @@ fn test_digit_short_suppresses_auto_detect() raises:
     # The flag should be set; no positionals.
     assert_true(result.get_flag("triple"))
     assert_equal(len(result._positionals), 0)
-    print("  ✓ test_digit_short_suppresses_auto_detect")
 
 
 # ── '--' separator ───────────────────────────────────────────────────────────
@@ -201,7 +191,6 @@ fn test_double_dash_passes_negative_number() raises:
     var args: List[String] = ["test", "--", "-10.18"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("value"), "-10.18")
-    print("  ✓ test_double_dash_passes_negative_number")
 
 
 fn test_double_dash_passes_option_like_string() raises:
@@ -214,7 +203,6 @@ fn test_double_dash_passes_option_like_string() raises:
     var args: List[String] = ["test", "--", "--foo"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("value"), "--foo")
-    print("  ✓ test_double_dash_passes_option_like_string")
 
 
 # ── Non-numeric dash tokens still error ─────────────────────────────────────
@@ -233,7 +221,6 @@ fn test_unknown_short_option_still_errors() raises:
     except:
         raised = True
     assert_true(raised, msg="'-x' should raise Unknown option error")
-    print("  ✓ test_unknown_short_option_still_errors")
 
 
 fn test_invalid_numeric_form_still_errors() raises:
@@ -248,7 +235,6 @@ fn test_invalid_numeric_form_still_errors() raises:
     except:
         raised = True
     assert_true(raised, msg="'-1abc' is not a number and should raise an error")
-    print("  ✓ test_invalid_numeric_form_still_errors")
 
 
 fn main() raises:

--- a/tests/test_parse.mojo
+++ b/tests/test_parse.mojo
@@ -18,7 +18,6 @@ fn test_flag_long() raises:
     var args: List[String] = ["test", "--verbose"]
     var result = command.parse_arguments(args)
     assert_true(result.get_flag("verbose"), msg="--verbose should be True")
-    print("  ✓ test_flag_long")
 
 
 fn test_flag_short() raises:
@@ -34,7 +33,6 @@ fn test_flag_short() raises:
     var args: List[String] = ["test", "-v"]
     var result = command.parse_arguments(args)
     assert_true(result.get_flag("verbose"), msg="-v should be True")
-    print("  ✓ test_flag_short")
 
 
 fn test_flag_default_false() raises:
@@ -50,7 +48,6 @@ fn test_flag_default_false() raises:
     var args: List[String] = ["test"]
     var result = command.parse_arguments(args)
     assert_false(result.get_flag("verbose"), msg="unset flag should be False")
-    print("  ✓ test_flag_default_false")
 
 
 fn test_key_value_long_space() raises:
@@ -63,7 +60,6 @@ fn test_key_value_long_space() raises:
     var args: List[String] = ["test", "--output", "file.txt"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("output"), "file.txt")
-    print("  ✓ test_key_value_long_space")
 
 
 fn test_key_value_long_equals() raises:
@@ -76,7 +72,6 @@ fn test_key_value_long_equals() raises:
     var args: List[String] = ["test", "--output=file.txt"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("output"), "file.txt")
-    print("  ✓ test_key_value_long_equals")
 
 
 fn test_key_value_short() raises:
@@ -89,7 +84,6 @@ fn test_key_value_short() raises:
     var args: List[String] = ["test", "-o", "file.txt"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("output"), "file.txt")
-    print("  ✓ test_key_value_short")
 
 
 fn test_positional_args() raises:
@@ -106,7 +100,6 @@ fn test_positional_args() raises:
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("pattern"), "hello")
     assert_equal(result.get_string("path"), "./src")
-    print("  ✓ test_positional_args")
 
 
 fn test_positional_with_default() raises:
@@ -123,7 +116,6 @@ fn test_positional_with_default() raises:
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("pattern"), "hello")
     assert_equal(result.get_string("path"), ".")
-    print("  ✓ test_positional_with_default")
 
 
 fn test_mixed_args() raises:
@@ -168,7 +160,6 @@ fn test_mixed_args() raises:
     assert_true(result.get_flag("ling"), msg="--ling should be True")
     assert_true(result.get_flag("ignore-case"), msg="-i should be True")
     assert_equal(result.get_string("max-depth"), "3")
-    print("  ✓ test_mixed_args")
 
 
 fn test_double_dash_stop() raises:
@@ -184,7 +175,6 @@ fn test_double_dash_stop() raises:
     )
     assert_equal(len(result._positionals), 1)
     assert_equal(result._positionals[0], "--verbose")
-    print("  ✓ test_double_dash_stop")
 
 
 fn test_has() raises:
@@ -197,7 +187,6 @@ fn test_has() raises:
     var result = command.parse_arguments(args)
     assert_true(result.has("verbose"), msg="verbose should exist")
     assert_false(result.has("output"), msg="output should not exist")
-    print("  ✓ test_has")
 
 
 # ── Short flag merging ────────────────────────────────────────────────────────────
@@ -215,7 +204,6 @@ fn test_merged_short_flags() raises:
     assert_true(result.get_flag("all"), msg="-a should be True from -abc")
     assert_true(result.get_flag("brief"), msg="-b should be True from -abc")
     assert_true(result.get_flag("color"), msg="-c should be True from -abc")
-    print("  ✓ test_merged_short_flags")
 
 
 fn test_merged_flags_partial() raises:
@@ -230,7 +218,6 @@ fn test_merged_flags_partial() raises:
     assert_true(result.get_flag("all"), msg="-a should be True from -ab")
     assert_true(result.get_flag("brief"), msg="-b should be True from -ab")
     assert_false(result.get_flag("color"), msg="-c should be False (not given)")
-    print("  ✓ test_merged_flags_partial")
 
 
 fn test_merged_flags_with_trailing_value() raises:
@@ -245,7 +232,6 @@ fn test_merged_flags_with_trailing_value() raises:
     assert_true(result.get_flag("all"), msg="-a should be True")
     assert_true(result.get_flag("verbose"), msg="-v should be True")
     assert_equal(result.get_string("output"), "file.txt")
-    print("  ✓ test_merged_flags_with_trailing_value")
 
 
 # ── Attached short value ─────────────────────────────────────────────────────────
@@ -259,7 +245,6 @@ fn test_attached_short_value() raises:
     var args: List[String] = ["test", "-ofile.txt"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("output"), "file.txt")
-    print("  ✓ test_attached_short_value")
 
 
 fn test_merged_flags_with_attached_value() raises:
@@ -274,7 +259,6 @@ fn test_merged_flags_with_attached_value() raises:
     assert_true(result.get_flag("all"), msg="-a should be True")
     assert_true(result.get_flag("brief"), msg="-b should be True")
     assert_equal(result.get_string("output"), "file.txt")
-    print("  ✓ test_merged_flags_with_attached_value")
 
 
 # ── Choices validation ───────────────────────────────────────────────────────────
@@ -294,7 +278,6 @@ fn test_choices_valid() raises:
     var args: List[String] = ["test", "--format", "json"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("format"), "json")
-    print("  ✓ test_choices_valid")
 
 
 fn test_choices_invalid() raises:
@@ -323,7 +306,6 @@ fn test_choices_invalid() raises:
             "xml" in msg, msg="Error should mention the bad value 'xml'"
         )
     assert_true(caught, msg="Should have raised an error for invalid choice")
-    print("  ✓ test_choices_invalid")
 
 
 fn test_choices_with_short_attached() raises:
@@ -340,7 +322,6 @@ fn test_choices_with_short_attached() raises:
     var args: List[String] = ["test", "-fjson"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("format"), "json")
-    print("  ✓ test_choices_with_short_attached")
 
 
 # ── Count action ─────────────────────────────────────────────────────────────────
@@ -359,7 +340,6 @@ fn test_count_single() raises:
     var args: List[String] = ["test", "-v"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_count("verbose"), 1)
-    print("  ✓ test_count_single")
 
 
 fn test_count_triple() raises:
@@ -375,7 +355,6 @@ fn test_count_triple() raises:
     var args: List[String] = ["test", "-vvv"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_count("verbose"), 3)
-    print("  ✓ test_count_triple")
 
 
 fn test_count_long_repeated() raises:
@@ -391,7 +370,6 @@ fn test_count_long_repeated() raises:
     var args: List[String] = ["test", "--verbose", "--verbose"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_count("verbose"), 2)
-    print("  ✓ test_count_long_repeated")
 
 
 fn test_count_mixed_short_long() raises:
@@ -407,7 +385,6 @@ fn test_count_mixed_short_long() raises:
     var args: List[String] = ["test", "-vv", "--verbose"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_count("verbose"), 3)
-    print("  ✓ test_count_mixed_short_long")
 
 
 fn test_count_default_zero() raises:
@@ -423,7 +400,6 @@ fn test_count_default_zero() raises:
     var args: List[String] = ["test"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_count("verbose"), 0)
-    print("  ✓ test_count_default_zero")
 
 
 # ── Count ceiling (.max()) ───────────────────────────────────────────────────────
@@ -447,7 +423,6 @@ fn test_count_max_caps_merged_short() raises:
         3,
         msg="-vvvvv with max[3] should cap at 3",
     )
-    print("  ✓ test_count_max_caps_merged_short")
 
 
 fn test_count_max_caps_repeated_long() raises:
@@ -474,7 +449,6 @@ fn test_count_max_caps_repeated_long() raises:
         2,
         msg="4x --verbose with max[2] should cap at 2",
     )
-    print("  ✓ test_count_max_caps_repeated_long")
 
 
 fn test_count_max_caps_mixed() raises:
@@ -495,7 +469,6 @@ fn test_count_max_caps_mixed() raises:
         3,
         msg="Mixed 4 occurrences with max[3] should cap at 3",
     )
-    print("  ✓ test_count_max_caps_mixed")
 
 
 fn test_count_max_below_ceiling() raises:
@@ -516,7 +489,6 @@ fn test_count_max_below_ceiling() raises:
         2,
         msg="-vv with max[5] should remain 2",
     )
-    print("  ✓ test_count_max_below_ceiling")
 
 
 fn test_count_max_exact_ceiling() raises:
@@ -537,7 +509,6 @@ fn test_count_max_exact_ceiling() raises:
         3,
         msg="-vvv with max[3] should be exactly 3",
     )
-    print("  ✓ test_count_max_exact_ceiling")
 
 
 fn test_count_max_single_short() raises:
@@ -558,7 +529,6 @@ fn test_count_max_single_short() raises:
         2,
         msg="3x -v with max[2] should cap at 2",
     )
-    print("  ✓ test_count_max_single_short")
 
 
 fn test_count_without_max_no_ceiling() raises:
@@ -578,7 +548,6 @@ fn test_count_without_max_no_ceiling() raises:
         10,
         msg="-vvvvvvvvvv without max should be 10",
     )
-    print("  ✓ test_count_without_max_no_ceiling")
 
 
 fn test_count_max_one() raises:
@@ -599,7 +568,6 @@ fn test_count_max_one() raises:
         1,
         msg="-vvv with max[1] should cap at 1",
     )
-    print("  ✓ test_count_max_one")
 
 
 # ── Positional arg count validation ──────────────────────────────────────────────
@@ -626,7 +594,6 @@ fn test_too_many_positionals() raises:
     assert_true(
         caught, msg="Should have raised error for extra positional args"
     )
-    print("  ✓ test_too_many_positionals")
 
 
 fn test_exact_positionals_ok() raises:
@@ -643,7 +610,6 @@ fn test_exact_positionals_ok() raises:
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("pattern"), "hello")
     assert_equal(result.get_string("path"), "./src")
-    print("  ✓ test_exact_positionals_ok")
 
 
 # ── Negatable flags (--no-X) ─────────────────────────────────────────────────────
@@ -662,7 +628,6 @@ fn test_negatable_positive() raises:
     var args: List[String] = ["test", "--color"]
     var result = command.parse_arguments(args)
     assert_true(result.get_flag("color"), msg="--color should be True")
-    print("  ✓ test_negatable_positive")
 
 
 fn test_negatable_negative() raises:
@@ -681,7 +646,6 @@ fn test_negatable_negative() raises:
     assert_true(
         result.has("color"), msg="color should be present after --no-color"
     )
-    print("  ✓ test_negatable_negative")
 
 
 fn test_negatable_default() raises:
@@ -702,7 +666,6 @@ fn test_negatable_default() raises:
     assert_false(
         result.has("color"), msg="unset negatable should not be present"
     )
-    print("  ✓ test_negatable_default")
 
 
 fn test_non_negatable_rejects_no_prefix() raises:
@@ -726,7 +689,6 @@ fn test_non_negatable_rejects_no_prefix() raises:
     assert_true(
         caught, msg="Should have raised error for --no-verbose on non-negatable"
     )
-    print("  ✓ test_non_negatable_rejects_no_prefix")
 
 
 fn test_prefix_match_unambiguous() raises:
@@ -747,7 +709,6 @@ fn test_prefix_match_unambiguous() raises:
     assert_true(
         result.get_flag("verbose"), msg="--verb should resolve to --verbose"
     )
-    print("  ✓ test_prefix_match_unambiguous")
 
 
 fn test_prefix_match_value() raises:
@@ -760,7 +721,6 @@ fn test_prefix_match_value() raises:
     var args: List[String] = ["test", "--out", "file.txt"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("output"), "file.txt")
-    print("  ✓ test_prefix_match_value")
 
 
 fn test_prefix_match_equals() raises:
@@ -773,7 +733,6 @@ fn test_prefix_match_equals() raises:
     var args: List[String] = ["test", "--out=file.txt"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("output"), "file.txt")
-    print("  ✓ test_prefix_match_equals")
 
 
 fn test_prefix_match_ambiguous() raises:
@@ -800,7 +759,6 @@ fn test_prefix_match_ambiguous() raises:
         var msg = String(e)
         assert_true("Ambiguous" in msg, msg="Error should mention ambiguity")
     assert_true(caught, msg="Should have raised error for ambiguous prefix")
-    print("  ✓ test_prefix_match_ambiguous")
 
 
 fn test_prefix_match_exact_preferred() raises:
@@ -824,7 +782,6 @@ fn test_prefix_match_exact_preferred() raises:
         result.get_flag("colorize"),
         msg="--colorize should not be set",
     )
-    print("  ✓ test_prefix_match_exact_preferred")
 
 
 fn test_prefix_match_negatable() raises:
@@ -843,7 +800,6 @@ fn test_prefix_match_negatable() raises:
     assert_true(
         result.has("color"), msg="color should be present after --no-col"
     )
-    print("  ✓ test_prefix_match_negatable")
 
 
 fn main() raises:

--- a/tests/test_persistent.mojo
+++ b/tests/test_persistent.mojo
@@ -38,7 +38,6 @@ fn test_persistent_flag_on_root_no_subcommand() raises:
     )
     var r = command.parse_arguments(["app", "--verbose"])
     assert_true(r.get_flag("verbose"), msg="root verbose should be True")
-    print("  ✓ test_persistent_flag_on_root_no_subcommand")
 
 
 fn test_persistent_flag_absent_on_root() raises:
@@ -53,7 +52,6 @@ fn test_persistent_flag_absent_on_root() raises:
     )
     var r = command.parse_arguments(["app"])
     assert_false(r.get_flag("verbose"), msg="absent verbose should be False")
-    print("  ✓ test_persistent_flag_absent_on_root")
 
 
 # ── Persistent flag BEFORE the subcommand token ────────────────────────────
@@ -77,7 +75,6 @@ fn test_persistent_flag_before_subcommand_in_root_result() raises:
     var r = app.parse_arguments(["app", "--verbose", "search", "pattern"])
     assert_true(r.get_flag("verbose"), msg="root verbose should be True")
     assert_equal(r.subcommand, "search")
-    print("  ✓ test_persistent_flag_before_subcommand_in_root_result")
 
 
 fn test_persistent_flag_before_subcommand_pushed_to_child() raises:
@@ -101,7 +98,6 @@ fn test_persistent_flag_before_subcommand_pushed_to_child() raises:
         sub.get_flag("verbose"),
         msg="child result should also have verbose=True via push-down",
     )
-    print("  ✓ test_persistent_flag_before_subcommand_pushed_to_child")
 
 
 # ── Persistent flag AFTER the subcommand token ─────────────────────────────
@@ -127,7 +123,6 @@ fn test_persistent_flag_after_subcommand_in_child_result() raises:
     assert_true(
         sub.get_flag("verbose"), msg="child result should have verbose=True"
     )
-    print("  ✓ test_persistent_flag_after_subcommand_in_child_result")
 
 
 fn test_persistent_flag_after_subcommand_bubbles_to_root() raises:
@@ -150,7 +145,6 @@ fn test_persistent_flag_after_subcommand_bubbles_to_root() raises:
         r.get_flag("verbose"),
         msg="root result should have verbose=True via bubble-up",
     )
-    print("  ✓ test_persistent_flag_after_subcommand_bubbles_to_root")
 
 
 fn test_persistent_short_flag_after_subcommand() raises:
@@ -176,7 +170,6 @@ fn test_persistent_short_flag_after_subcommand() raises:
         r.get_subcommand_result().get_flag("verbose"),
         msg="child verbose via short form should be True",
     )
-    print("  ✓ test_persistent_short_flag_after_subcommand")
 
 
 # ── Persistent value-taking option ─────────────────────────────────────────
@@ -198,7 +191,6 @@ fn test_persistent_value_option_after_subcommand() raises:
     )
     assert_equal(r.get_string("output"), "json")
     assert_equal(r.get_subcommand_result().get_string("output"), "json")
-    print("  ✓ test_persistent_value_option_after_subcommand")
 
 
 fn test_persistent_flag_absent_defaults_false_in_both() raises:
@@ -224,7 +216,6 @@ fn test_persistent_flag_absent_defaults_false_in_both() raises:
         r.get_subcommand_result().get_flag("verbose"),
         msg="child verbose should default to False",
     )
-    print("  ✓ test_persistent_flag_absent_defaults_false_in_both")
 
 
 # ── Non-persistent flag isolation ──────────────────────────────────────────
@@ -250,14 +241,13 @@ fn test_non_persistent_root_flag_not_injected_into_child() raises:
         raised,
         msg="Non-persistent flag after subcommand should cause an error",
     )
-    print("  ✓ test_non_persistent_root_flag_not_injected_into_child")
 
 
 # ── Conflict detection ──────────────────────────────────────────────────────
 
 
 fn test_persistent_conflict_long_name_raises() raises:
-    """add_subcommand() raises when a persistent parent long_name conflicts
+    """Tests add_subcommand() raises when a persistent parent long_name conflicts
     with a child long_name."""
     var app = Command("app", "")
     app.add_argument(
@@ -277,11 +267,10 @@ fn test_persistent_conflict_long_name_raises() raises:
         raised,
         msg="Persistent long_name conflict should raise at add_subcommand time",
     )
-    print("  ✓ test_persistent_conflict_long_name_raises")
 
 
 fn test_persistent_conflict_short_name_raises() raises:
-    """add_subcommand() raises when a persistent parent short_name conflicts
+    """Tests add_subcommand() raises when a persistent parent short_name conflicts
     with a child short_name."""
     var app = Command("app", "")
     app.add_argument(
@@ -307,7 +296,6 @@ fn test_persistent_conflict_short_name_raises() raises:
             "Persistent short_name conflict should raise at add_subcommand time"
         ),
     )
-    print("  ✓ test_persistent_conflict_short_name_raises")
 
 
 fn test_no_conflict_for_non_persistent_same_name() raises:
@@ -326,7 +314,6 @@ fn test_no_conflict_for_non_persistent_same_name() raises:
     assert_true(
         True, msg="No conflict should be detected for non-persistent args"
     )
-    print("  ✓ test_no_conflict_for_non_persistent_same_name")
 
 
 # ── Main ───────────────────────────────────────────────────────────────────

--- a/tests/test_subcommands.mojo
+++ b/tests/test_subcommands.mojo
@@ -51,7 +51,6 @@ fn test_defaults_named_arg() raises:
     var args: List[String] = ["test"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("format"), "json")
-    print("  ✓ test_defaults_named_arg")
 
 
 fn test_defaults_positional_arg() raises:
@@ -69,7 +68,6 @@ fn test_defaults_positional_arg() raises:
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("pattern"), "hello")
     assert_equal(result.get_string("path"), ".")
-    print("  ✓ test_defaults_positional_arg")
 
 
 fn test_defaults_not_applied_when_provided() raises:
@@ -82,7 +80,6 @@ fn test_defaults_not_applied_when_provided() raises:
     var args: List[String] = ["test", "--format", "csv"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("format"), "csv")
-    print("  ✓ test_defaults_not_applied_when_provided")
 
 
 fn test_defaults_multiple_positional() raises:
@@ -100,7 +97,6 @@ fn test_defaults_multiple_positional() raises:
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("src"), "input.txt")
     assert_equal(result.get_string("dst"), "b.txt")
-    print("  ✓ test_defaults_multiple_positional")
 
 
 # ── Step 0: _validate() — required args ──────────────────────────────────────
@@ -126,7 +122,6 @@ fn test_validate_required_missing() raises:
         )
         assert_true("output" in msg, msg="Error should mention 'output'")
     assert_true(caught, msg="Should have raised for missing required arg")
-    print("  ✓ test_validate_required_missing")
 
 
 fn test_validate_required_provided() raises:
@@ -139,7 +134,6 @@ fn test_validate_required_provided() raises:
     var args: List[String] = ["test", "--output", "out.txt"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("output"), "out.txt")
-    print("  ✓ test_validate_required_provided")
 
 
 # ── Step 0: _validate() — positional count ───────────────────────────────────
@@ -162,7 +156,6 @@ fn test_validate_too_many_positionals() raises:
             msg="Error should mention 'Too many positional'",
         )
     assert_true(caught, msg="Should have raised for too many positionals")
-    print("  ✓ test_validate_too_many_positionals")
 
 
 # ── Step 0: _validate() — mutually exclusive ─────────────────────────────────
@@ -187,7 +180,6 @@ fn test_validate_exclusive_conflict() raises:
             msg="Error should mention 'mutually exclusive'",
         )
     assert_true(caught, msg="Should have raised for exclusive conflict")
-    print("  ✓ test_validate_exclusive_conflict")
 
 
 fn test_validate_exclusive_ok() raises:
@@ -201,7 +193,6 @@ fn test_validate_exclusive_ok() raises:
     var args: List[String] = ["test", "--json"]
     var result = command.parse_arguments(args)
     assert_true(result.get_flag("json"))
-    print("  ✓ test_validate_exclusive_ok")
 
 
 # ── Step 0: _validate() — required-together ──────────────────────────────────
@@ -227,7 +218,6 @@ fn test_validate_together_partial() raises:
             msg="Error should mention required together",
         )
     assert_true(caught, msg="Should have raised for partial together group")
-    print("  ✓ test_validate_together_partial")
 
 
 # ── Step 0: _validate() — one-required ───────────────────────────────────────
@@ -252,7 +242,6 @@ fn test_validate_one_required_none() raises:
             msg="Error should mention 'At least one'",
         )
     assert_true(caught, msg="Should have raised for one-required group")
-    print("  ✓ test_validate_one_required_none")
 
 
 # ── Step 0: _validate() — conditional requirements ───────────────────────────
@@ -276,7 +265,6 @@ fn test_validate_conditional_triggered() raises:
             msg="Error should mention 'required when'",
         )
     assert_true(caught, msg="Should have raised for conditional requirement")
-    print("  ✓ test_validate_conditional_triggered")
 
 
 fn test_validate_conditional_satisfied() raises:
@@ -290,7 +278,6 @@ fn test_validate_conditional_satisfied() raises:
     var result = command.parse_arguments(args)
     assert_true(result.get_flag("save"))
     assert_equal(result.get_string("output"), "out.txt")
-    print("  ✓ test_validate_conditional_satisfied")
 
 
 # ── Step 0: _validate() — numeric range ──────────────────────────────────────
@@ -314,7 +301,6 @@ fn test_validate_range_out_of_bounds() raises:
             msg="Error should mention 'out of range'",
         )
     assert_true(caught, msg="Should have raised for out-of-range value")
-    print("  ✓ test_validate_range_out_of_bounds")
 
 
 fn test_validate_range_in_bounds() raises:
@@ -327,7 +313,6 @@ fn test_validate_range_in_bounds() raises:
     var args: List[String] = ["test", "--port", "50"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("port"), "50")
-    print("  ✓ test_validate_range_in_bounds")
 
 
 # ── Step 0: full round-trip (defaults + validation combined) ─────────────────
@@ -351,7 +336,6 @@ fn test_defaults_then_validation_combined() raises:
     var result = command.parse_arguments(args1)
     assert_false(result.has("user"))
     assert_false(result.has("pass"))
-    print("  ✓ test_defaults_then_validation_combined")
 
 
 fn test_full_parse_with_defaults_and_range() raises:
@@ -365,7 +349,6 @@ fn test_full_parse_with_defaults_and_range() raises:
     var args: List[String] = ["test"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("port"), "50")
-    print("  ✓ test_full_parse_with_defaults_and_range")
 
 
 # ── Step 1: Data model — Command.subcommands field ───────────────────────────
@@ -375,7 +358,6 @@ fn test_command_subcommands_empty_initially() raises:
     """Tests that a fresh Command has no subcommands registered."""
     var app = Command("app", "My app")
     assert_equal(len(app.subcommands), 0)
-    print("  ✓ test_command_subcommands_empty_initially")
 
 
 fn test_add_subcommand_single() raises:
@@ -393,7 +375,6 @@ fn test_add_subcommand_single() raises:
     assert_true(idx >= 0)
     assert_equal(app.subcommands[idx].name, "search")
     assert_equal(app.subcommands[idx].description, "Search for patterns")
-    print("  ✓ test_add_subcommand_single")
 
 
 fn test_add_subcommand_multiple() raises:
@@ -415,7 +396,6 @@ fn test_add_subcommand_multiple() raises:
     assert_equal(app.subcommands[1].name, "search")
     assert_equal(app.subcommands[2].name, "init")
     assert_equal(app.subcommands[3].name, "build")
-    print("  ✓ test_add_subcommand_multiple")
 
 
 fn test_add_subcommand_preserves_child_args() raises:
@@ -437,7 +417,6 @@ fn test_add_subcommand_preserves_child_args() raises:
     assert_equal(len(app.subcommands[idx].args), 2)
     assert_equal(app.subcommands[idx].args[0].name, "pattern")
     assert_equal(app.subcommands[idx].args[1].name, "max-depth")
-    print("  ✓ test_add_subcommand_preserves_child_args")
 
 
 fn test_subcommand_has_own_version() raises:
@@ -448,7 +427,6 @@ fn test_subcommand_has_own_version() raises:
     assert_equal(app.version, "1.0.0")
     var idx = app._find_subcommand("serve")
     assert_equal(app.subcommands[idx].version, "2.0.0-beta")
-    print("  ✓ test_subcommand_has_own_version")
 
 
 # ── Step 1: Data model — ParseResult.subcommand field ────────────────────────
@@ -458,7 +436,6 @@ fn test_parseresult_subcommand_defaults_empty() raises:
     """Tests that ParseResult.subcommand defaults to empty string."""
     var result = ParseResult()
     assert_equal(result.subcommand, "")
-    print("  ✓ test_parseresult_subcommand_defaults_empty")
 
 
 fn test_parseresult_subcommand_can_be_set() raises:
@@ -466,7 +443,6 @@ fn test_parseresult_subcommand_can_be_set() raises:
     var result = ParseResult()
     result.subcommand = "search"
     assert_equal(result.subcommand, "search")
-    print("  ✓ test_parseresult_subcommand_can_be_set")
 
 
 fn test_parseresult_no_subcommand_result_initially() raises:
@@ -474,7 +450,6 @@ fn test_parseresult_no_subcommand_result_initially() raises:
     """
     var result = ParseResult()
     assert_false(result.has_subcommand_result())
-    print("  ✓ test_parseresult_no_subcommand_result_initially")
 
 
 fn test_parseresult_get_subcommand_result_raises_when_empty() raises:
@@ -490,7 +465,6 @@ fn test_parseresult_get_subcommand_result_raises_when_empty() raises:
             msg="Error should mention 'No subcommand result'",
         )
     assert_true(caught, msg="Should have raised for empty subcommand result")
-    print("  ✓ test_parseresult_get_subcommand_result_raises_when_empty")
 
 
 fn test_parseresult_subcommand_result_stored_and_retrieved() raises:
@@ -503,7 +477,6 @@ fn test_parseresult_subcommand_result_stored_and_retrieved() raises:
     assert_true(parent.has_subcommand_result())
     var retrieved = parent.get_subcommand_result()
     assert_equal(retrieved.get_string("pattern"), "hello")
-    print("  ✓ test_parseresult_subcommand_result_stored_and_retrieved")
 
 
 fn test_parseresult_str_includes_subcommand() raises:
@@ -512,7 +485,6 @@ fn test_parseresult_str_includes_subcommand() raises:
     result.subcommand = "build"
     var s = String(result)
     assert_true("build" in s, msg="__str__ should include the subcommand name")
-    print("  ✓ test_parseresult_str_includes_subcommand")
 
 
 fn test_parseresult_str_no_subcommand_section_when_empty() raises:
@@ -523,7 +495,6 @@ fn test_parseresult_str_no_subcommand_section_when_empty() raises:
         "subcommand" in s,
         msg="__str__ should not include 'subcommand' when empty",
     )
-    print("  ✓ test_parseresult_str_no_subcommand_section_when_empty")
 
 
 fn test_parseresult_copy_preserves_subcommand() raises:
@@ -539,7 +510,6 @@ fn test_parseresult_copy_preserves_subcommand() raises:
     assert_equal(copy.subcommand, "init")
     assert_true(copy.has_subcommand_result())
     assert_equal(copy.get_subcommand_result().get_string("name"), "myproject")
-    print("  ✓ test_parseresult_copy_preserves_subcommand")
 
 
 fn test_parse_without_subcommands_unaffected() raises:
@@ -554,7 +524,6 @@ fn test_parse_without_subcommands_unaffected() raises:
     assert_true(result.get_flag("verbose"))
     assert_equal(result.subcommand, "")
     assert_false(result.has_subcommand_result())
-    print("  ✓ test_parse_without_subcommands_unaffected")
 
 
 # ── Step 2: Parse routing ─────────────────────────────────────────────────────
@@ -575,7 +544,6 @@ fn test_dispatch_basic() raises:
     assert_true(result.has_subcommand_result())
     var sub = result.get_subcommand_result()
     assert_equal(sub.get_string("pattern"), "hello")
-    print("  ✓ test_dispatch_basic")
 
 
 fn test_dispatch_root_flag_before_subcommand() raises:
@@ -596,7 +564,6 @@ fn test_dispatch_root_flag_before_subcommand() raises:
     assert_equal(result.subcommand, "search")
     var sub = result.get_subcommand_result()
     assert_equal(sub.get_string("pattern"), "hello")
-    print("  ✓ test_dispatch_root_flag_before_subcommand")
 
 
 fn test_dispatch_root_short_flag_before_subcommand() raises:
@@ -617,7 +584,6 @@ fn test_dispatch_root_short_flag_before_subcommand() raises:
     assert_equal(result.subcommand, "search")
     var sub = result.get_subcommand_result()
     assert_equal(sub.get_string("pattern"), "hello")
-    print("  ✓ test_dispatch_root_short_flag_before_subcommand")
 
 
 fn test_dispatch_child_flag() raises:
@@ -638,7 +604,6 @@ fn test_dispatch_child_flag() raises:
     var sub = result.get_subcommand_result()
     assert_equal(sub.get_string("max-depth"), "3")
     assert_equal(sub.get_string("pattern"), "hello")
-    print("  ✓ test_dispatch_child_flag")
 
 
 fn test_dispatch_child_flag_short() raises:
@@ -659,7 +624,6 @@ fn test_dispatch_child_flag_short() raises:
     var sub = result.get_subcommand_result()
     assert_equal(sub.get_string("max-depth"), "5")
     assert_equal(sub.get_string("pattern"), "hello")
-    print("  ✓ test_dispatch_child_flag_short")
 
 
 fn test_dispatch_double_dash_stops_dispatch() raises:
@@ -677,7 +641,6 @@ fn test_dispatch_double_dash_stops_dispatch() raises:
     assert_equal(result.subcommand, "")
     assert_false(result.has_subcommand_result())
     assert_equal(result.get_string("arg1"), "search")
-    print("  ✓ test_dispatch_double_dash_stops_dispatch")
 
 
 fn test_dispatch_unknown_token_is_positional() raises:
@@ -693,7 +656,6 @@ fn test_dispatch_unknown_token_is_positional() raises:
     var result = app.parse_arguments(args)
     assert_equal(result.subcommand, "")
     assert_equal(result.get_string("name"), "hello")
-    print("  ✓ test_dispatch_unknown_token_is_positional")
 
 
 fn test_dispatch_two_subcommands_route_first() raises:
@@ -712,7 +674,6 @@ fn test_dispatch_two_subcommands_route_first() raises:
     var result = app.parse_arguments(args)
     assert_equal(result.subcommand, "search")
     assert_equal(result.get_subcommand_result().get_string("pattern"), "foo")
-    print("  ✓ test_dispatch_two_subcommands_route_first")
 
 
 fn test_dispatch_two_subcommands_route_second() raises:
@@ -731,7 +692,6 @@ fn test_dispatch_two_subcommands_route_second() raises:
     var result = app.parse_arguments(args)
     assert_equal(result.subcommand, "init")
     assert_equal(result.get_subcommand_result().get_string("name"), "myproject")
-    print("  ✓ test_dispatch_two_subcommands_route_second")
 
 
 fn test_dispatch_child_validation_error() raises:
@@ -754,7 +714,6 @@ fn test_dispatch_child_validation_error() raises:
             msg="Error should mention 'Required argument'",
         )
     assert_true(caught, msg="Should have raised for missing child required arg")
-    print("  ✓ test_dispatch_child_validation_error")
 
 
 fn test_dispatch_child_default_value() raises:
@@ -776,7 +735,6 @@ fn test_dispatch_child_default_value() raises:
     var sub = result.get_subcommand_result()
     assert_equal(sub.get_string("pattern"), "hello")
     assert_equal(sub.get_string("path"), ".")
-    print("  ✓ test_dispatch_child_default_value")
 
 
 fn test_dispatch_no_subcommand_when_none_match() raises:
@@ -791,7 +749,6 @@ fn test_dispatch_no_subcommand_when_none_match() raises:
     var result = app.parse_arguments(args)
     assert_equal(result.subcommand, "")
     assert_false(result.has_subcommand_result())
-    print("  ✓ test_dispatch_no_subcommand_when_none_match")
 
 
 fn test_dispatch_root_still_validates_own_required() raises:
@@ -815,7 +772,6 @@ fn test_dispatch_root_still_validates_own_required() raises:
         assert_true("Required argument" in String(e))
         assert_true("token" in String(e))
     assert_true(caught, msg="Root required arg should still be validated")
-    print("  ✓ test_dispatch_root_still_validates_own_required")
 
 
 fn test_dispatch_child_receives_no_root_tokens() raises:
@@ -837,7 +793,6 @@ fn test_dispatch_child_receives_no_root_tokens() raises:
     assert_equal(child.get_string("script"), "main.mojo")
     # --verbose is not in child result (child doesn't know about it).
     assert_false(child.has("verbose"))
-    print("  ✓ test_dispatch_child_receives_no_root_tokens")
 
 
 # ── Step 2b: auto-registered 'help' subcommand ───────────────────────────────
@@ -854,16 +809,15 @@ fn test_help_sub_auto_added() raises:
     var help_idx = app._find_subcommand("help")
     assert_true(help_idx >= 0)
     assert_true(app.subcommands[help_idx]._is_help_subcommand)
-    print("  ✓ test_help_sub_auto_added")
 
 
 fn test_help_sub_added_only_once() raises:
     """Tests that 'help' is not duplicated on multiple add_subcommand() calls.
     """
     var app = Command("app", "My app")
-    app.add_subcommand(Command("search", "Search")^)
-    app.add_subcommand(Command("init", "Init")^)
-    app.add_subcommand(Command("build", "Build")^)
+    app.add_subcommand(Command("search", "Search"))
+    app.add_subcommand(Command("init", "Init"))
+    app.add_subcommand(Command("build", "Build"))
 
     # 3 user subs + 1 help = 4 total.
     assert_equal(len(app.subcommands), 4)
@@ -872,31 +826,28 @@ fn test_help_sub_added_only_once() raises:
         if app.subcommands[i].name == "help":
             count += 1
     assert_equal(count, 1)
-    print("  ✓ test_help_sub_added_only_once")
 
 
 fn test_help_sub_appears_after_user_subs() raises:
     """Tests that 'help' is at index 0 and user subs follow in order."""
     var app = Command("app", "My app")
-    app.add_subcommand(Command("search", "Search")^)
-    app.add_subcommand(Command("init", "Init")^)
+    app.add_subcommand(Command("search", "Search"))
+    app.add_subcommand(Command("init", "Init"))
 
     # help [0], search [1], init [2].
     assert_equal(app.subcommands[0].name, "help")
     assert_equal(app.subcommands[1].name, "search")
     assert_equal(app.subcommands[2].name, "init")
-    print("  ✓ test_help_sub_appears_after_user_subs")
 
 
 fn test_help_sub_flag_on_user_subs() raises:
     """Tests that user-registered subcommands do NOT have the flag set."""
     var app = Command("app", "My app")
-    app.add_subcommand(Command("search", "Search")^)
+    app.add_subcommand(Command("search", "Search"))
 
     var search_idx = app._find_subcommand("search")
     assert_true(search_idx >= 0)
     assert_false(app.subcommands[search_idx]._is_help_subcommand)
-    print("  ✓ test_help_sub_flag_on_user_subs")
 
 
 fn test_disable_help_sub_before_add() raises:
@@ -904,19 +855,18 @@ fn test_disable_help_sub_before_add() raises:
     """
     var app = Command("app", "My app")
     app.disable_help_subcommand()
-    app.add_subcommand(Command("search", "Search")^)
+    app.add_subcommand(Command("search", "Search"))
 
     # Only 1 subcommand — no 'help'.
     assert_equal(len(app.subcommands), 1)
     assert_equal(app._find_subcommand("help"), -1)
-    print("  ✓ test_disable_help_sub_before_add")
 
 
 fn test_disable_help_sub_after_add() raises:
     """Tests that disable_help_subcommand() after add_subcommand() removes it.
     """
     var app = Command("app", "My app")
-    app.add_subcommand(Command("search", "Search")^)
+    app.add_subcommand(Command("search", "Search"))
     # 'help' is now present.
     assert_equal(len(app.subcommands), 2)
 
@@ -925,7 +875,6 @@ fn test_disable_help_sub_after_add() raises:
     assert_equal(len(app.subcommands), 1)
     assert_equal(app.subcommands[0].name, "search")
     assert_equal(app._find_subcommand("help"), -1)
-    print("  ✓ test_disable_help_sub_after_add")
 
 
 fn test_dispatch_unaffected_by_help_sub() raises:
@@ -942,7 +891,6 @@ fn test_dispatch_unaffected_by_help_sub() raises:
     assert_equal(result.subcommand, "search")
     var child = result.get_subcommand_result()
     assert_equal(child.get_string("pattern"), "TODO")
-    print("  ✓ test_dispatch_unaffected_by_help_sub")
 
 
 fn test_help_sub_disabled_unknown_word_becomes_positional() raises:
@@ -952,14 +900,13 @@ fn test_help_sub_disabled_unknown_word_becomes_positional() raises:
     app.allow_positional_with_subcommands()
     app.add_argument(Argument("query", help="Query").positional())
     app.disable_help_subcommand()
-    app.add_subcommand(Command("init", "Init")^)
+    app.add_subcommand(Command("init", "Init"))
 
     # "help" should be treated as a root positional, not dispatch.
     var args: List[String] = ["app", "help"]
     var result = app.parse_arguments(args)
     assert_equal(result.subcommand, "")
     assert_equal(result.get_string("query"), "help")
-    print("  ✓ test_help_sub_disabled_unknown_word_becomes_positional")
 
 
 # ── Error handling ───────────────────────────────────────────────────────────
@@ -969,8 +916,8 @@ fn test_unknown_subcommand_error_no_positionals() raises:
     """Tests that an unknown subcommand name gives an error when no positional args are defined.
     """
     var app = Command("app", "My app")
-    app.add_subcommand(Command("search", "Search")^)
-    app.add_subcommand(Command("init", "Init")^)
+    app.add_subcommand(Command("search", "Search"))
+    app.add_subcommand(Command("init", "Init"))
 
     var args: List[String] = ["app", "foo"]
     var caught = False
@@ -987,7 +934,6 @@ fn test_unknown_subcommand_error_no_positionals() raises:
         assert_true("search" in msg, msg="Should list available 'search'")
         assert_true("init" in msg, msg="Should list available 'init'")
     assert_true(caught, msg="Should have raised for unknown subcommand")
-    print("  ✓ test_unknown_subcommand_error_no_positionals")
 
 
 fn test_unknown_token_becomes_positional_when_positionals_defined() raises:
@@ -996,14 +942,13 @@ fn test_unknown_token_becomes_positional_when_positionals_defined() raises:
     var app = Command("app", "My app")
     app.allow_positional_with_subcommands()
     app.add_argument(Argument("query", help="Query").positional())
-    app.add_subcommand(Command("search", "Search")^)
+    app.add_subcommand(Command("search", "Search"))
 
     # "foo" doesn't match any subcommand but root has positional args → positional.
     var args: List[String] = ["app", "foo"]
     var result = app.parse_arguments(args)
     assert_equal(result.subcommand, "")
     assert_equal(result.get_string("query"), "foo")
-    print("  ✓ test_unknown_token_becomes_positional_when_positionals_defined")
 
 
 fn test_child_error_includes_command_path() raises:
@@ -1029,14 +974,13 @@ fn test_child_error_includes_command_path() raises:
         )
         assert_true("pattern" in msg, msg="Should mention 'pattern'")
     assert_true(caught, msg="Should have raised for missing required in child")
-    print("  ✓ test_child_error_includes_command_path")
 
 
 fn test_unknown_subcommand_error_excludes_help_sub() raises:
     """Tests that the error message for unknown subcommand does not list 'help'.
     """
     var app = Command("app", "My app")
-    app.add_subcommand(Command("search", "Search")^)
+    app.add_subcommand(Command("search", "Search"))
 
     var args: List[String] = ["app", "foo"]
     var caught = False
@@ -1061,7 +1005,6 @@ fn test_unknown_subcommand_error_excludes_help_sub() raises:
                 msg="'help' sub should not appear in available commands",
             )
     assert_true(caught, msg="Should have raised")
-    print("  ✓ test_unknown_subcommand_error_excludes_help_sub")
 
 
 # ── Positional + subcommand guard ────────────────────────────────────────────
@@ -1071,7 +1014,7 @@ fn test_add_positional_after_subcommand_raises() raises:
     """Tests that adding a positional after a subcommand raises without opt-in.
     """
     var app = Command("app", "My app")
-    app.add_subcommand(Command("search", "Search")^)
+    app.add_subcommand(Command("search", "Search"))
 
     var caught = False
     try:
@@ -1088,7 +1031,6 @@ fn test_add_positional_after_subcommand_raises() raises:
             msg="Should mention opt-in method",
         )
     assert_true(caught, msg="Should have raised")
-    print("  ✓ test_add_positional_after_subcommand_raises")
 
 
 fn test_add_subcommand_after_positional_raises() raises:
@@ -1099,7 +1041,7 @@ fn test_add_subcommand_after_positional_raises() raises:
 
     var caught = False
     try:
-        app.add_subcommand(Command("init", "Init")^)
+        app.add_subcommand(Command("init", "Init"))
     except e:
         caught = True
         var msg = String(e)
@@ -1112,7 +1054,6 @@ fn test_add_subcommand_after_positional_raises() raises:
             msg="Should mention opt-in method",
         )
     assert_true(caught, msg="Should have raised")
-    print("  ✓ test_add_subcommand_after_positional_raises")
 
 
 fn test_allow_positional_with_subcommands_opt_in() raises:
@@ -1121,13 +1062,13 @@ fn test_allow_positional_with_subcommands_opt_in() raises:
     var app1 = Command("app", "My app")
     app1.allow_positional_with_subcommands()
     app1.add_argument(Argument("file", help="File").positional())
-    app1.add_subcommand(Command("init", "Init")^)
+    app1.add_subcommand(Command("init", "Init"))
     assert_equal(len(app1.subcommands), 2)  # init + auto help
 
     # Direction 2: subcommand first, then positional.
     var app2 = Command("app", "My app")
     app2.allow_positional_with_subcommands()
-    app2.add_subcommand(Command("search", "Search")^)
+    app2.add_subcommand(Command("search", "Search"))
     app2.add_argument(Argument("query", help="Query").positional())
 
     # Verify parsing works: unknown token → positional.
@@ -1135,19 +1076,17 @@ fn test_allow_positional_with_subcommands_opt_in() raises:
     var result = app2.parse_arguments(args)
     assert_equal(result.subcommand, "")
     assert_equal(result.get_string("query"), "hello")
-    print("  ✓ test_allow_positional_with_subcommands_opt_in")
 
 
 fn test_non_positional_args_unaffected_by_guard() raises:
     """Tests that adding non-positional (flags/options) with subcommands
     does not trigger the guard, even without opt-in."""
     var app = Command("app", "My app")
-    app.add_subcommand(Command("search", "Search")^)
+    app.add_subcommand(Command("search", "Search"))
     # These should NOT raise:
     app.add_argument(Argument("verbose", help="Verbose").long("verbose").flag())
     app.add_argument(Argument("output", help="Output").long("output"))
     assert_true(True, msg="Non-positional args should not trigger guard")
-    print("  ✓ test_non_positional_args_unaffected_by_guard")
 
 
 # ── Step 5: Subcommand aliases ───────────────────────────────────────────────
@@ -1157,7 +1096,6 @@ fn test_command_aliases_empty_by_default() raises:
     """Tests that a fresh Command has no aliases registered."""
     var sub = Command("clone", "Clone a repo")
     assert_equal(len(sub._command_aliases), 0)
-    print("  ✓ test_command_aliases_empty_by_default")
 
 
 fn test_command_aliases_builder() raises:
@@ -1168,7 +1106,6 @@ fn test_command_aliases_builder() raises:
     assert_equal(len(sub._command_aliases), 2)
     assert_equal(sub._command_aliases[0], "cl")
     assert_equal(sub._command_aliases[1], "cln")
-    print("  ✓ test_command_aliases_builder")
 
 
 fn test_alias_dispatch_basic() raises:
@@ -1187,7 +1124,6 @@ fn test_alias_dispatch_basic() raises:
     assert_equal(result.subcommand, "clone")
     var sub_result = result.get_subcommand_result()
     assert_equal(sub_result.get_string("url"), "https://example.com/repo.git")
-    print("  ✓ test_alias_dispatch_basic")
 
 
 fn test_alias_stores_canonical_name() raises:
@@ -1202,7 +1138,6 @@ fn test_alias_stores_canonical_name() raises:
     var args: List[String] = ["app", "cm"]
     var result = app.parse_arguments(args)
     assert_equal(result.subcommand, "commit")
-    print("  ✓ test_alias_stores_canonical_name")
 
 
 fn test_alias_dispatch_with_child_flags() raises:
@@ -1223,7 +1158,6 @@ fn test_alias_dispatch_with_child_flags() raises:
     var sub = result.get_subcommand_result()
     assert_equal(sub.get_string("message"), "fix bug")
     assert_true(sub.get_flag("amend"))
-    print("  ✓ test_alias_dispatch_with_child_flags")
 
 
 fn test_alias_primary_name_still_works() raises:
@@ -1238,7 +1172,6 @@ fn test_alias_primary_name_still_works() raises:
     var args: List[String] = ["app", "clone"]
     var result = app.parse_arguments(args)
     assert_equal(result.subcommand, "clone")
-    print("  ✓ test_alias_primary_name_still_works")
 
 
 fn test_alias_find_subcommand() raises:
@@ -1258,7 +1191,6 @@ fn test_alias_find_subcommand() raises:
     assert_equal(idx_name, idx_alias1)
     assert_equal(idx_name, idx_alias2)
     assert_equal(idx_none, -1)
-    print("  ✓ test_alias_find_subcommand")
 
 
 fn test_alias_copy_init() raises:
@@ -1269,7 +1201,6 @@ fn test_alias_copy_init() raises:
     var sub2 = sub.copy()
     assert_equal(len(sub2._command_aliases), 1)
     assert_equal(sub2._command_aliases[0], "cl")
-    print("  ✓ test_alias_copy_init")
 
 
 fn test_alias_multiple_subcommands() raises:
@@ -1303,7 +1234,6 @@ fn test_alias_multiple_subcommands() raises:
     var args4: List[String] = ["app", "commit"]
     var r4 = app.parse_arguments(args4)
     assert_equal(r4.subcommand, "commit")
-    print("  ✓ test_alias_multiple_subcommands")
 
 
 # ── main ─────────────────────────────────────────────────────────────────────
@@ -1330,7 +1260,6 @@ fn test_hidden_subcommand_still_dispatchable() raises:
     assert_equal(result.subcommand, "debug")
     var sub = result.get_subcommand_result()
     assert_equal(sub.get_string("level"), "trace")
-    print("  ✓ test_hidden_subcommand_still_dispatchable")
 
 
 fn test_hidden_subcommand_alias_dispatchable() raises:
@@ -1348,7 +1277,6 @@ fn test_hidden_subcommand_alias_dispatchable() raises:
     var args: List[String] = ["app", "dbg"]
     var result = app.parse_arguments(args)
     assert_equal(result.subcommand, "debug")
-    print("  ✓ test_hidden_subcommand_alias_dispatchable")
 
 
 fn test_hidden_is_hidden_field() raises:
@@ -1357,7 +1285,6 @@ fn test_hidden_is_hidden_field() raises:
     assert_false(cmd._is_hidden, msg="_is_hidden should default to False")
     cmd.hidden()
     assert_true(cmd._is_hidden, msg="hidden() should set _is_hidden to True")
-    print("  ✓ test_hidden_is_hidden_field")
 
 
 fn test_hidden_subcommand_copy() raises:
@@ -1366,7 +1293,6 @@ fn test_hidden_subcommand_copy() raises:
     cmd.hidden()
     var copy = cmd.copy()
     assert_true(copy._is_hidden, msg="_is_hidden should survive copy")
-    print("  ✓ test_hidden_subcommand_copy")
 
 
 fn main() raises:

--- a/tests/test_typo_suggestions.mojo
+++ b/tests/test_typo_suggestions.mojo
@@ -17,7 +17,7 @@ fn test_typo_long_option_suggests() raises:
         Argument("version", help="Show version").long("version").flag()
     )
 
-    var args: List[String] = ["test", "--verbos"]
+    var _args: List[String] = ["test", "--verbos"]
     # --verbos is a prefix match for --verbose, so it should resolve.
     # Use a more distant typo to test suggestion path.
     var args2: List[String] = ["test", "--vrebose"]
@@ -36,7 +36,6 @@ fn test_typo_long_option_suggests() raises:
             msg="Error should suggest --verbose",
         )
     assert_true(caught, msg="Should have raised error for --vrebose")
-    print("  ✓ test_typo_long_option_suggests")
 
 
 fn test_typo_long_option_no_suggestion() raises:
@@ -58,7 +57,6 @@ fn test_typo_long_option_no_suggestion() raises:
             msg="Error should not suggest anything for unrelated option",
         )
     assert_true(caught, msg="Should have raised error for --zzzzzzz")
-    print("  ✓ test_typo_long_option_no_suggestion")
 
 
 fn test_typo_long_option_single_char_diff() raises:
@@ -84,7 +82,6 @@ fn test_typo_long_option_single_char_diff() raises:
             msg="Error should suggest --output",
         )
     assert_true(caught, msg="Should have raised error for --outptu")
-    print("  ✓ test_typo_long_option_single_char_diff")
 
 
 # ── Subcommand typo suggestions ──────────────────────────────────────────────
@@ -114,7 +111,6 @@ fn test_typo_subcommand_suggests() raises:
             msg="Error should suggest 'search'",
         )
     assert_true(caught, msg="Should have raised error for 'serach'")
-    print("  ✓ test_typo_subcommand_suggests")
 
 
 fn test_typo_subcommand_no_suggestion() raises:
@@ -136,7 +132,6 @@ fn test_typo_subcommand_no_suggestion() raises:
             msg="Error should not suggest anything for unrelated command",
         )
     assert_true(caught, msg="Should have raised error for 'xxxxxxx'")
-    print("  ✓ test_typo_subcommand_no_suggestion")
 
 
 # ── Alias typo suggestions ──────────────────────────────────────────────────
@@ -165,7 +160,6 @@ fn test_typo_alias_suggests() raises:
             msg="Error should suggest a correction for --colro",
         )
     assert_true(caught, msg="Should have raised error for --colro")
-    print("  ✓ test_typo_alias_suggests")
 
 
 fn test_typo_subcommand_alias_suggests() raises:
@@ -193,7 +187,6 @@ fn test_typo_subcommand_alias_suggests() raises:
             msg="Error should suggest 'clone' for 'clon'",
         )
     assert_true(caught, msg="Should have raised error for 'clon'")
-    print("  ✓ test_typo_subcommand_alias_suggests")
 
 
 fn test_typo_hidden_subcommand_not_suggested() raises:
@@ -224,7 +217,6 @@ fn test_typo_hidden_subcommand_not_suggested() raises:
         "clone" in err_msg,
         msg="Visible sub 'clone' should still be in error message",
     )
-    print("  ✓ test_typo_hidden_subcommand_not_suggested")
 
 
 fn main() raises:


### PR DESCRIPTION
This PR adds a new “mutual implication” capability to ArgMojo commands, allowing one argument’s presence to automatically set another, and documents/tests the behavior.

**Changes:**
- Introduces `Command.implies(trigger, implied)` with registration-time cycle detection and parse-time propagation.
- Applies implications during parsing (after defaults, before validation) so implied args participate in existing constraints.
- Adds a new test suite for implication behavior and updates docs/changelog to describe the feature.