### PR TITLE
[doc] Add compatibility charts in user manual showing relationship between builder methods

### DIFF
--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -157,7 +157,7 @@ myapp "hello" ./src
 #     pattern   path
 ```
 
-Positional arguments are assigned in the order they are registered with `add_argument()`. If fewer values are provided than defined arguments, the remaining ones use their default values (if any). If more are provided, an error is raised (see [Positional Argument Count Validation](#positional-arg-count-validation)).
+Positional arguments are assigned in the order they are registered with `add_argument()`. If fewer values are provided than defined arguments, the remaining ones use their default values (if any). If more are provided, an error is raised (see [Positional Argument Count Validation](#positional-argument-count-validation)).
 
 **Retrieving:**
 
@@ -1065,6 +1065,13 @@ Argument("name", help="...")
 ║   .aliases(["alt"])     alternative --names       (named only)
 ║   .deprecated("msg")    deprecation warning       (any)
 ║   .persistent()         inherit to subcommands    (named only)
+║
+╠══ Command-level constraints (called on Command, not Argument) ════════════════
+║   command.mutually_exclusive(["a","b"])  at most one from the group
+║   command.one_required(["a","b"])        at least one from the group
+║   command.required_together(["a","b"])   all or none from the group
+║   command.required_if("target","cond")   target required when cond is set
+║   command.implies("trigger","implied")   auto-set implied when trigger is set
 ╚═══════════════════════════════════════════════════════════════════════════════
 ```
 
@@ -1110,6 +1117,13 @@ flowchart LR
     DEC --> dep[".deprecated()"]
     DEC --> per[".persistent()"]
 
+    ARG -.-> CMDCON["Command-level\nConstraints"]
+    CMDCON --> mutex["command.mutually_exclusive()"]
+    CMDCON --> onereq["command.one_required()"]
+    CMDCON --> reqtog["command.required_together()"]
+    CMDCON --> reqif["command.required_if()"]
+    CMDCON --> imp["command.implies()"]
+
     style ARG fill:#e8f4fd,stroke:#333
     style NAMED fill:#d4edda,stroke:#333
     style POS fill:#d4edda,stroke:#333
@@ -1117,34 +1131,40 @@ flowchart LR
     style COUNT fill:#fff3cd,stroke:#333
     style VAL fill:#fff3cd,stroke:#333
     style DEC fill:#f0f0f0,stroke:#999,stroke-dasharray: 5 5
+    style CMDCON fill:#fce4ec,stroke:#999,stroke-dasharray: 5 5
 ```
 
 ### Compatibility Table
 
 The table below shows which builder methods can be used with each argument mode. **✓** = compatible, **—** = not applicable.
 
-| Method                   | Named value | `.flag()` | `.count()` | `.positional()` |
-| ------------------------ | :---------: | :-------: | :--------: | :-------------: |
-| `.long("x")`             |      ✓      |     ✓     |     ✓      |        —        |
-| `.short("x")`            |      ✓      |     ✓     |     ✓      |        —        |
-| `.required()`            |      ✓      |     —     |     —      |        ✓        |
-| `.default("val")`        |      ✓      |     —     |     —      |        ✓        |
-| `.choices(["a","b"])`    |      ✓      |     —     |     —      |        ✓        |
-| `.range[min,max]()`      |      ✓      |     —     |     —      |        —        |
-| `.clamp()`               |     ✓ ¹     |     —     |     —      |        —        |
-| `.append()`              |      ✓      |     —     |     —      |        —        |
-| `.delimiter(",")`        |     ✓ ²     |     —     |     —      |        —        |
-| `.number_of_values[N]()` |     ✓ ²     |     —     |     —      |        —        |
-| `.map_option()`          |      ✓      |     —     |     —      |        —        |
-| `.negatable()`           |      —      |     ✓     |     —      |        —        |
-| `.max[N]()`              |      —      |     —     |     ✓      |        —        |
-| `.metavar("FILE")`       |      ✓      |     —     |     —      |        ✓        |
-| `.hidden()`              |      ✓      |     ✓     |     ✓      |        ✓        |
-| `.aliases(["alt"])`      |      ✓      |     ✓     |     ✓      |        —        |
-| `.deprecated("msg")`     |      ✓      |     ✓     |     ✓      |        ✓        |
-| `.persistent()`          |      ✓      |     ✓     |     ✓      |        —        |
+| Method                           | Named value | `.flag()` | `.count()` | `.positional()` |
+| -------------------------------- | :---------: | :-------: | :--------: | :-------------: |
+| `.long("x")`                     |      ✓      |     ✓     |     ✓      |        —        |
+| `.short("x")`                    |      ✓      |     ✓     |     ✓      |        —        |
+| `.required()`                    |      ✓      |     —     |     —      |        ✓        |
+| `.default("val")`                |      ✓      |     —     |     —      |        ✓        |
+| `.choices(["a","b"])`            |      ✓      |     —     |     —      |        ✓        |
+| `.range[min,max]()`              |      ✓      |     —     |     —      |        —        |
+| `.clamp()`                       |     ✓ ¹     |     —     |     —      |        —        |
+| `.append()`                      |      ✓      |     —     |     —      |        —        |
+| `.delimiter(",")`                |     ✓ ²     |     —     |     —      |        —        |
+| `.number_of_values[N]()`         |     ✓ ²     |     —     |     —      |        —        |
+| `.map_option()`                  |      ✓      |     —     |     —      |        —        |
+| `.negatable()`                   |      —      |     ✓     |     —      |        —        |
+| `.max[N]()`                      |      —      |     —     |     ✓      |        —        |
+| `.metavar("FILE")`               |      ✓      |     —     |     —      |        ✓        |
+| `.hidden()`                      |      ✓      |     ✓     |     ✓      |        ✓        |
+| `.aliases(["alt"])`              |      ✓      |     ✓     |     ✓      |        —        |
+| `.deprecated("msg")`             |      ✓      |     ✓     |     ✓      |        ✓        |
+| `.persistent()`                  |      ✓      |     ✓     |     ✓      |        —        |
+| `command.mutually_exclusive()` ³ |      ✓      |     ✓     |     ✓      |        —        |
+| `command.one_required()` ³       |      ✓      |     ✓     |     ✓      |        —        |
+| `command.required_together()` ³  |      ✓      |     ✓     |     ✓      |        —        |
+| `command.required_if()` ³        |      ✓      |     ✓     |     ✓      |        —        |
+| `command.implies()` ³            |      ✓      |     ✓     |     ✓      |        —        |
 
-> ¹ Requires `.range[]()` first.  ² Implies `.append()` automatically.
+> ¹ Requires `.range[]()` first.  ² Implies `.append()` automatically.  ³ Command-level method — takes argument names as strings, not chained on `Argument`.
 
 ## Group Constraints
 
@@ -1433,7 +1453,7 @@ Each rule is checked independently after parsing.
 
 Error messages use `--long` display names when available:
 
-```
+```bash
 Error: Argument '--output' is required when '--save' is provided
 ```
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -36,6 +36,10 @@ from argmojo import Argument, Command
   - [Positional Argument Count Validation](#positional-argument-count-validation)
   - [Numeric Range Validation](#numeric-range-validation)
   - [Range Clamping (`.clamp()`)](#range-clamping-clamp)
+- [Builder Method Compatibility](#builder-method-compatibility)
+  - [ASCII Tree](#ascii-tree)
+  - [Mermaid Diagram](#mermaid-diagram)
+  - [Compatibility Table](#compatibility-table)
 - [Group Constraints](#group-constraints)
   - [Mutually Exclusive Groups](#mutually-exclusive-groups)
   - [One-Required Groups](#one-required-groups)
@@ -1020,6 +1024,127 @@ myapp --port 50 --port 200 --port 0
 myapp --port 200
 # Error: Value 200 for '--port' is out of range [1, 100]
 ```
+
+## Builder Method Compatibility
+
+The `Argument` builder has ~20 chainable methods, but not all combinations make sense. The diagrams below show **which methods can be used together** at a glance.
+
+### ASCII Tree
+
+```txt
+Argument("name", help="...")
+║
+╠══ Named option ═══════════════════════════════════════════════════════════════
+║   .long("x") ─── .short("x")             ← pick one or both
+║   │
+║   ├── [value mode] (default)             ← takes a string value
+║   │   ├── .required()
+║   │   ├── .default("val")
+║   │   ├── .choices(["a","b","c"])
+║   │   ├── .range[1,100]() ─── .clamp()
+║   │   ├── .append()
+║   │   │   ├── .delimiter(",")
+║   │   │   └── .number_of_values[2]()
+║   │   └── .map_option()
+║   │
+║   ├── .flag()                            ← boolean, no value
+║   │   └── .negatable()                     adds --no-X form
+║   │
+║   └── .count()                           ← counter: -vvv → 3
+║       └── .max[3]()                        cap the counter
+║
+╠══ Positional ═════════════════════════════════════════════════════════════════
+║   .positional()                          ← matched by position
+║   ├── .required()
+║   ├── .default("val")
+║   └── .choices(["a","b","c"])
+║
+╠══ Decorators (combine with any path above) ═══════════════════════════════════
+║   .metavar("FILE")      display name in help      (value / positional)
+║   .hidden()             hide from --help          (any)
+║   .aliases(["alt"])     alternative --names       (named only)
+║   .deprecated("msg")    deprecation warning       (any)
+║   .persistent()         inherit to subcommands    (named only)
+╚═══════════════════════════════════════════════════════════════════════════════
+```
+
+> **Reading guide:** Indentation shows "goes after" — e.g. `.clamp()` is
+> indented under `.range[]()` because it requires range.  The three main
+> paths (value / flag / count) under *Named option* are **mutually
+> exclusive** — pick exactly one mode per argument.
+
+### Mermaid Diagram
+
+```mermaid
+flowchart LR
+    ARG["Argument(name, help)"]
+
+    ARG --> NAMED[".long() / .short()"]
+    ARG --> POS[".positional()"]
+
+    NAMED --> VAL["Value mode\n(default)"]
+    NAMED --> FLAG[".flag()"]
+    NAMED --> COUNT[".count()"]
+
+    VAL --> req1[".required()"]
+    VAL --> def1[".default()"]
+    VAL --> cho1[".choices()"]
+    VAL --> rng[".range[]()"]
+    rng --> clp[".clamp()"]
+    VAL --> app[".append()"]
+    app --> delim[".delimiter()"]
+    app --> nvals[".number_of_values[]()"]
+    VAL --> mapopt[".map_option()"]
+
+    FLAG --> neg[".negatable()"]
+    COUNT --> maxn[".max[]()"]
+
+    POS --> req2[".required()"]
+    POS --> def2[".default()"]
+    POS --> cho2[".choices()"]
+
+    ARG -.-> DEC["Decorators"]
+    DEC --> meta[".metavar()"]
+    DEC --> hid[".hidden()"]
+    DEC --> ali[".aliases()"]
+    DEC --> dep[".deprecated()"]
+    DEC --> per[".persistent()"]
+
+    style ARG fill:#e8f4fd,stroke:#333
+    style NAMED fill:#d4edda,stroke:#333
+    style POS fill:#d4edda,stroke:#333
+    style FLAG fill:#fff3cd,stroke:#333
+    style COUNT fill:#fff3cd,stroke:#333
+    style VAL fill:#fff3cd,stroke:#333
+    style DEC fill:#f0f0f0,stroke:#999,stroke-dasharray: 5 5
+```
+
+### Compatibility Table
+
+The table below shows which builder methods can be used with each argument mode. **✓** = compatible, **—** = not applicable.
+
+| Method                   | Named value | `.flag()` | `.count()` | `.positional()` |
+| ------------------------ | :---------: | :-------: | :--------: | :-------------: |
+| `.long("x")`             |      ✓      |     ✓     |     ✓      |        —        |
+| `.short("x")`            |      ✓      |     ✓     |     ✓      |        —        |
+| `.required()`            |      ✓      |     —     |     —      |        ✓        |
+| `.default("val")`        |      ✓      |     —     |     —      |        ✓        |
+| `.choices(["a","b"])`    |      ✓      |     —     |     —      |        ✓        |
+| `.range[min,max]()`      |      ✓      |     —     |     —      |        —        |
+| `.clamp()`               |     ✓ ¹     |     —     |     —      |        —        |
+| `.append()`              |      ✓      |     —     |     —      |        —        |
+| `.delimiter(",")`        |     ✓ ²     |     —     |     —      |        —        |
+| `.number_of_values[N]()` |     ✓ ²     |     —     |     —      |        —        |
+| `.map_option()`          |      ✓      |     —     |     —      |        —        |
+| `.negatable()`           |      —      |     ✓     |     —      |        —        |
+| `.max[N]()`              |      —      |     —     |     ✓      |        —        |
+| `.metavar("FILE")`       |      ✓      |     —     |     —      |        ✓        |
+| `.hidden()`              |      ✓      |     ✓     |     ✓      |        ✓        |
+| `.aliases(["alt"])`      |      ✓      |     ✓     |     ✓      |        —        |
+| `.deprecated("msg")`     |      ✓      |     ✓     |     ✓      |        ✓        |
+| `.persistent()`          |      ✓      |     ✓     |     ✓      |        —        |
+
+> ¹ Requires `.range[]()` first.  ² Implies `.append()` automatically.
 
 ## Group Constraints
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -1041,7 +1041,7 @@ Argument("name", help="...")
 ║   │   ├── .required()
 ║   │   ├── .default("val")
 ║   │   ├── .choices(["a","b","c"])
-║   │   ├── .range[1,100]() ─── .clamp()
+║   │   ├── .range[1, 100]() ─── .clamp()
 ║   │   ├── .append()
 ║   │   │   ├── .delimiter(",")
 ║   │   │   └── .number_of_values[2]()
@@ -1076,7 +1076,7 @@ Argument("name", help="...")
 ```
 
 > **Reading guide:** Indentation shows "goes after" — e.g. `.clamp()` is
-> indented under `.range[]()` because it requires range.  The three main
+> indented under `.range[min,max]()` because it requires range.  The three main
 > paths (value / flag / count) under *Named option* are **mutually
 > exclusive** — pick exactly one mode per argument.
 
@@ -1096,15 +1096,15 @@ flowchart LR
     VAL --> req1[".required()"]
     VAL --> def1[".default()"]
     VAL --> cho1[".choices()"]
-    VAL --> rng[".range[]()"]
+    VAL --> rng[".range[min,max]()"]
     rng --> clp[".clamp()"]
     VAL --> app[".append()"]
     app --> delim[".delimiter()"]
-    app --> nvals[".number_of_values[]()"]
+    app --> nvals[".number_of_values[N]()"]
     VAL --> mapopt[".map_option()"]
 
     FLAG --> neg[".negatable()"]
-    COUNT --> maxn[".max[]()"]
+    COUNT --> maxn[".max[N]()"]
 
     POS --> req2[".required()"]
     POS --> def2[".default()"]
@@ -1142,7 +1142,7 @@ The table below shows which builder methods can be used with each argument mode.
 | -------------------------------- | :---------: | :-------: | :--------: | :-------------: |
 | `.long("x")`                     |      ✓      |     ✓     |     ✓      |        —        |
 | `.short("x")`                    |      ✓      |     ✓     |     ✓      |        —        |
-| `.required()`                    |      ✓      |     —     |     —      |        ✓        |
+| `.required()`                    |      ✓      |     ✓     |     ✓      |        ✓        |
 | `.default("val")`                |      ✓      |     —     |     —      |        ✓        |
 | `.choices(["a","b"])`            |      ✓      |     —     |     —      |        ✓        |
 | `.range[min,max]()`              |      ✓      |     —     |     —      |        —        |
@@ -1164,7 +1164,7 @@ The table below shows which builder methods can be used with each argument mode.
 | `command.required_if()` ³        |      ✓      |     ✓     |     ✓      |        —        |
 | `command.implies()` ³            |      ✓      |     ✓     |     ✓      |        —        |
 
-> ¹ Requires `.range[]()` first.  ² Implies `.append()` automatically.  ³ Command-level method — takes argument names as strings, not chained on `Argument`.
+> ¹ Requires `.range[min,max]()` first.  ² Implies `.append()` automatically.  ³ Command-level method — takes argument names as strings, not chained on `Argument`.
 
 ## Group Constraints
 


### PR DESCRIPTION
Adds a new “Builder Method Compatibility” section, with an ASCII compatibility tree, a Mermaid flowchart, and a per-mode compatibility table, to the ArgMojo user manual to help users understand which `Argument` builder methods can be meaningfully combined across named-value, flag, count, and positional argument modes.