### PR TITLE
[core] Rename `metavar` to `value_name` +  consume remainder args + hyphen values + partial parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ ArgMojo provides a builder-pattern API for defining and parsing command-line arg
 - **Short flag merging**: `-abc` expands to `-a -b -c`
 - **Attached short values**: `-ofile.txt` means `-o file.txt`
 - **Choices validation**: restrict values to a set (e.g., `json`, `csv`, `table`)
-- **Metavar**: custom display name for values in help text
+- **Value name**: custom display name for values in help text
 - **Hidden arguments**: exclude internal args from `--help` output
 - **Count flags**: `-vvv` → `get_count("verbose") == 3`
 - **Positional arg count validation**: reject extra positional args
@@ -145,10 +145,10 @@ For detailed explanations and more examples of every feature, see the **[User Ma
 
 ArgMojo ships with two complete example CLIs:
 
-| Example                  | File                  | Features                                                                                                                                                                                                                                                                                                                       |
-| ------------------------ | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `mgrep` — simulated grep | `examples/mgrep.mojo` | Positional args, flags, count flags, negatable flags, choices, metavar, append/collect, value delimiter, nargs, mutually exclusive groups, required-together groups, conditional requirements, numeric range, key-value map, aliases, deprecated args, hidden args, negative-number passthrough, `--` stop marker, custom tips |
-| `mgit` — simulated git   | `examples/mgit.mojo`  | Subcommands (clone/init/add/commit/push/pull/log/remote/branch/diff/tag/stash), nested subcommands (remote add/remove/rename/show), persistent (global) flags, per-command args, mutually exclusive groups, choices, aliases, deprecated args, custom tips, shell completion script generation                                 |
+| Example                  | File                  | Features                                                                                                                                                                                                                                                                                                                          |
+| ------------------------ | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mgrep` — simulated grep | `examples/mgrep.mojo` | Positional args, flags, count flags, negatable flags, choices, value_name, append/collect, value delimiter, nargs, mutually exclusive groups, required-together groups, conditional requirements, numeric range, key-value map, aliases, deprecated args, hidden args, negative-number passthrough, `--` stop marker, custom tips |
+| `mgit` — simulated git   | `examples/mgit.mojo`  | Subcommands (clone/init/add/commit/push/pull/log/remote/branch/diff/tag/stash), nested subcommands (remote add/remove/rename/show), persistent (global) flags, per-command args, mutually exclusive groups, choices, aliases, deprecated args, custom tips, shell completion script generation                                    |
 
 Build both example binaries:
 

--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -37,7 +37,7 @@ These features appear across multiple libraries and depend only on string operat
 | Auto `--help` / `-h` / `-?`        | ✓        | ✓     | ✓     | ✓    |                              | **Done**      |
 | Auto `--version` / `-V`            | ✓        | ✓     | ✓     | ✓    |                              | **Done**      |
 | Short flag merging (`-abc`)        | ✓        | —     | ✓     | ✓    |                              | **Done**      |
-| Metavar (display name for value)   | ✓        | —     | —     | ✓    |                              | **Done**      |
+| Display name for value             | ✓        | —     | —     | ✓    |                              | **Done**      |
 | Positional arg count validation    | —        | —     | ✓     | ✓    |                              | **Done**      |
 | Choices / enum validation          | ✓        | ✓     | —     | ✓    |                              | **Done**      |
 | Mutually exclusive flags           | ✓        | —     | ✓     | ✓    |                              | **Done**      |
@@ -181,7 +181,7 @@ examples/
 | Short flag merging (`-abc` → `-a -b -c`)                                                           | ✓      | ✓     |
 | Short option with attached value (`-ofile.txt`)                                                    | ✓      | ✓     |
 | Choices validation (`.choices()`)                                                                  | ✓      | ✓     |
-| Metavar (`.metavar("FILE")`)                                                                       | ✓      | ✓     |
+| Value Name (`.value_name("FILE")`)                                                                 | ✓      | ✓     |
 | Hidden arguments (`.hidden()`)                                                                     | ✓      | ✓     |
 | Count action (`-vvv` → 3) with ceiling (`.max(N)`)                                                 | ✓      | ✓     |
 | Positional arg count validation                                                                    | ✓      | ✓     |
@@ -352,7 +352,7 @@ The practical view — both dimensions checked together at parse time:
 - [x] **Short flag merging** — `-abc` expands to `-a -b -c` (argparse, cobra, clap all support this)
 - [x] **Short option with attached value** — `-ofile.txt` means `-o file.txt` (argparse, clap)
 - [x] **Choices validation** — restrict values to a set: `.choices(["debug", "info", "warn", "error"])`
-- [x] **Metavar** — display name for values in help: `.metavar("FILE")` → `--output FILE`
+- [x] **Value Name** — display name for values in help: `.value_name("FILE")` → `--output FILE`
 - [x] **Positional arg count validation** — fail if too many positional args
 - [x] **Hidden arguments** — `.hidden()` to exclude from help output (cobra, clap)
 - [x] **`count` action** — `-vvv` → `get_count("verbose") == 3` (argparse `-v` counting)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,7 +24,6 @@ Comment out unreleased changes here. This file will be edited just before each r
 
 ### 🔧 Fixes
 
-- **Rename `.metavar()` to `.value_name()`** — see above under "Fixes and API changes" (PR #13).
 - Clarify documentation and docstrings: `default_if_no_value` does not "reject" `--key value`; it simply does not consume the next token as a value (PR #12, review feedback).
 - Fix cross-library comparison: click is described as "Python CLI framework" instead of incorrectly saying "built on top of argparse" (PR #12, review feedback).
 - Reject `.require_equals()` / `.default_if_no_value()` combined with `.number_of_values[N]()` at `add_argument()` time with a clear error (PR #12, review feedback).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,9 +14,17 @@ Comment out unreleased changes here. This file will be edited just before each r
 2. Add `.require_equals()` builder method. When set, long options reject space-separated syntax (`--key value`) and require `--key=value`. Can be used standalone (the value is mandatory via `=`) or combined with `.default_if_no_value()` (the value is optional; omitting it uses default-if-no-value) (PR #12).
 3. Help output adapts to the new modifiers: `--key=<value>` for require_equals, `--key[=<value>]` for default_if_no_value (PR #12).
 4. ~~Add `response_file_prefix()` builder method on `Command` for response-file support. When enabled, tokens starting with the prefix (default `@`) are expanded by reading the referenced file — each non-empty, non-comment line becomes a separate argument. Supports comments (`#`), escape (`@@literal`), recursive nesting (configurable depth), and custom prefix characters (PR #12).~~ *(Temporarily disabled — triggers a Mojo compiler deadlock under `-D ASSERT=all`. The implementation is preserved as module-level functions and will be re-enabled when the Mojo compiler bug is fixed.)*
+5. Add `.remainder()` builder method on `Argument`. A remainder positional consumes **all** remaining tokens (including ones starting with `-`), similar to argparse `nargs=REMAINDER` or clap `trailing_var_arg`. At most one remainder positional is allowed per command and it must be the last positional (PR #13).
+6. Add `parse_known_arguments()` method on `Command`. Like `parse_arguments()`, but unrecognised options are collected into the result instead of raising an error. Access them via `result.get_unknown_args()`. Useful for forwarding unknown flags to another program (PR #13).
+7. Add `.allow_hyphen_values()` builder method on `Argument`. When set on a positional, values starting with `-` are accepted without requiring `--` (e.g., `-` for stdin). Remainder positionals have this enabled automatically (PR #13).
+
+### 🔧 Fixes and API changes
+
+- **Rename `.metavar()` to `.value_name()`** across the entire API and documentation. The internal field is now `_value_name`. This follows clap's naming convention and better describes the purpose. There is no backward-compatible alias — all call sites must use `.value_name()` (PR #13).
 
 ### 🔧 Fixes
 
+- **Rename `.metavar()` to `.value_name()`** — see above under "Fixes and API changes" (PR #13).
 - Clarify documentation and docstrings: `default_if_no_value` does not "reject" `--key value`; it simply does not consume the next token as a value (PR #12, review feedback).
 - Fix cross-library comparison: click is described as "Python CLI framework" instead of incorrectly saying "built on top of argparse" (PR #12, review feedback).
 - Reject `.require_equals()` / `.default_if_no_value()` combined with `.number_of_values[N]()` at `add_argument()` time with a clear error (PR #12, review feedback).
@@ -25,6 +33,7 @@ Comment out unreleased changes here. This file will be edited just before each r
 
 - Add `tests/test_const_require_equals.mojo` with 30 tests covering default_if_no_value, require_equals, and their interactions with choices, append, prefix matching, merged short flags, persistent flags, and help formatting (PR #12).
 - Add `tests/test_response_file.mojo` with 17 tests covering basic expansion, comments, whitespace stripping, escape, recursive nesting, depth limit, custom prefix, disabled-by-default, and error handling (PR #12).
+- Add `tests/test_remainder_known.mojo` with 18 tests covering remainder positionals, `parse_known_arguments()`, `allow_hyphen_values()`, and the `value_name` rename (PR #13).
 
 ---
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -56,7 +56,7 @@ from argmojo import Argument, Command
   - [Hidden Subcommands](#hidden-subcommands)
   - [Mixing Positional Args with Subcommands](#mixing-positional-args-with-subcommands)
 - [Help \& Display](#help--display)
-  - [Metavar](#metavar)
+  - [Value Name](#value-name)
   - [Hidden Arguments](#hidden-arguments)
   - [Deprecated Arguments](#deprecated-arguments)
   - [Default-if-no-value](#default-if-no-value)
@@ -68,6 +68,21 @@ from argmojo import Argument, Command
   - [Negative Number Passthrough](#negative-number-passthrough)
   - [Long Option Prefix Matching](#long-option-prefix-matching)
   - [The `--` Stop Marker](#the----stop-marker)
+  - [Remainder Positional (`.remainder()`)](#remainder-positional-remainder)
+  - [Allow Hyphen Values (`.allow_hyphen_values()`)](#allow-hyphen-values-allow_hyphen_values)
+  - [Partial Parsing (`parse_known_arguments()`)](#partial-parsing-parse_known_arguments)
+- [Shell Completion](#shell-completion)
+  - [Built-in `--completions` Flag](#built-in---completions-flag)
+  - [Disabling the Built-in Flag](#disabling-the-built-in-flag)
+  - [Customising the Trigger Name](#customising-the-trigger-name)
+  - [Using a Subcommand Instead of an Option](#using-a-subcommand-instead-of-an-option)
+  - [Generating a Script Programmatically](#generating-a-script-programmatically)
+  - [Installing Completions](#installing-completions)
+  - [What Gets Completed](#what-gets-completed)
+- [Cross-Library Method Name Reference](#cross-library-method-name-reference)
+  - [Argument-Level Builder Methods](#argument-level-builder-methods)
+  - [Command-Level Constraint Methods](#command-level-constraint-methods)
+  - [Notes](#notes)
 <!-- Response Files (temporarily disabled — Mojo compiler deadlock with -D ASSERT=all)
 - [Response Files](#response-files)
   - [Enabling Response Files](#enabling-response-files)
@@ -558,11 +573,11 @@ Append options show a `...` suffix to indicate they are repeatable:
   -t, --tag <tag>...            Add a tag (repeatable)
 ```
 
-If a metavar is set, it replaces the default placeholder:
+If a value name is set, it replaces the default placeholder:
 
 ```mojo
 command.add_argument(
-    Argument("include", help="Include path").long("include").short("I").metavar("DIR").append()
+    Argument("include", help="Include path").long("include").short("I").value_name("DIR").append()
 )
 ```
 
@@ -784,10 +799,10 @@ myapp --route north up      # ✗ 'up' is not a valid choice
 
 nargs options show the placeholder repeated N times:
 
-```
+```txt
 Options:
   --point <point> <point>    X Y coordinates
-  --rgb N N N                RGB colour        (with .metavar("N"))
+  --rgb N N N                RGB colour        (with .value_name("N"))
 ```
 
 Regular append options show `...` to indicate repeatability, while nargs
@@ -1074,7 +1089,7 @@ Argument("name", help="...")
 ║   └── .choices(["a","b","c"])
 ║
 ╠══ Decorators (combine with any path above) ═══════════════════════════════════
-║   .metavar("FILE")             display name in help      (value / positional)
+║   .value_name("FILE")          display name in help      (value / positional)
 ║   .hidden()                    hide from --help          (any)
 ║   .aliases(["alt"])            alternative --names       (named only)
 ║   .deprecated("msg")           deprecation warning       (any)
@@ -1127,7 +1142,7 @@ flowchart LR
     POS --> cho2[".choices()"]
 
     ARG -.-> DEC["Decorators"]
-    DEC --> meta[".metavar()"]
+    DEC --> meta[".value_name()"]
     DEC --> hid[".hidden()"]
     DEC --> ali[".aliases()"]
     DEC --> dep[".deprecated()"]
@@ -1171,7 +1186,7 @@ The table below shows which builder methods can be used with each argument mode.
 | `.map_option()`                  |      ✓      |     —     |     —      |        —        |
 | `.negatable()`                   |      —      |     ✓     |     —      |        —        |
 | `.max[N]()`                      |      —      |     —     |     ✓      |        —        |
-| `.metavar("FILE")`               |      ✓      |     —     |     —      |        ✓        |
+| `.value_name("FILE")`            |      ✓      |     —     |     —      |        ✓        |
 | `.hidden()`                      |      ✓      |     ✓     |     ✓      |        ✓        |
 | `.aliases(["alt"])`              |      ✓      |     ✓     |     ✓      |        —        |
 | `.deprecated("msg")`             |      ✓      |     ✓     |     ✓      |        ✓        |
@@ -1606,7 +1621,7 @@ app.add_argument(Argument("verbose", help="Verbose output").long("verbose").shor
 
 var search = Command("search", "Search for patterns")
 search.add_argument(Argument("pattern", help="Search pattern").positional().required())
-search.add_argument(Argument("max-depth", help="Max depth").long("max-depth").short("d").metavar("N"))
+search.add_argument(Argument("max-depth", help="Max depth").long("max-depth").short("d").value_name("N"))
 
 var init = Command("init", "Initialise a new project")
 init.add_argument(Argument("name", help="Project name").positional().required())
@@ -1966,18 +1981,20 @@ This makes it immediately clear which subcommand triggered the error, especially
 
 ## Help & Display
 
-### Metavar
+### Value Name
 
-**Metavar** overrides the placeholder text shown for a value in help output. Without it, the argument's internal name is shown in angle brackets (e.g., `<output>`).
+**Value name** overrides the placeholder text shown for a value in help output. Without it, the argument's internal name is shown in angle brackets (e.g., `<output>`).
+
+> Libraries with similar support: **argparse** (`metavar`), **clap** (`value_name`), **cobra** (`metavar`), **Click** (`metavar`).
 
 ```mojo
 command.add_argument(
     Argument("output", help="Output file path")
-    .long("output").short("o").metavar("FILE")
+    .long("output").short("o").value_name("FILE")
 )
 command.add_argument(
     Argument("max-depth", help="Maximum directory depth")
-    .long("max-depth").short("d").metavar("N")
+    .long("max-depth").short("d").value_name("N")
 )
 ```
 
@@ -1988,14 +2005,14 @@ command.add_argument(
   -d, --max-depth <max-depth> Maximum directory depth
 ```
 
-**Help output (after `.metavar()`):**
+**Help output (after `.value_name()`):**
 
 ```bash
   -o, --output FILE           Output file path
   -d, --max-depth N           Maximum directory depth
 ```
 
-Metavar is purely cosmetic — it has no effect on parsing.
+Value name is purely cosmetic — it has no effect on parsing.
 
 ### Hidden Arguments
 
@@ -2112,7 +2129,7 @@ Options:
       --compress[=<compress>]    Compression algorithm
 ```
 
-With `.metavar("ALGO")`:
+With `.value_name("ALGO")`:
 
 ```bash
 Options:
@@ -2245,13 +2262,13 @@ colour is enabled.
 
 **What controls the output:**
 
-| Builder method  | Effect on help                                        |
-| --------------- | ----------------------------------------------------- |
-| `.help("...")`  | Sets the description text for the option.             |
-| `.metavar("X")` | Replaces the default placeholder (e.g., `N`, `FILE`). |
-| `.choices()`    | Shows `{a,b,c}` in the placeholder.                   |
-| `.hidden()`     | Completely excludes the option from help.             |
-| `.required()`   | Positional args show as `<name>` instead of `[name]`. |
+| Builder method     | Effect on help                                        |
+| ------------------ | ----------------------------------------------------- |
+| `.help("...")`     | Sets the description text for the option.             |
+| `.value_name("X")` | Replaces the default placeholder (e.g., `N`, `FILE`). |
+| `.choices()`       | Shows `{a,b,c}` in the placeholder.                   |
+| `.hidden()`        | Completely excludes the option from help.             |
+| `.required()`      | Positional args show as `<name>` instead of `[name]`. |
 
 After printing help, the program exits cleanly with exit code 0.
 
@@ -2553,10 +2570,99 @@ myapp -- -10.18
 
 > **Tip:** ArgMojo's [Auto-detect](#negative-number-passthrough) can handle most negative-number cases without `--`. Use `--` only when auto-detect is insufficient (e.g., a digit short option is registered without `allow_negative_numbers()`).
 
+### Remainder Positional (`.remainder()`)
+
+A **remainder** positional consumes **all** remaining command-line tokens once it starts matching, including tokens that look like options (e.g., `--foo`, `-x`, `--some-flag`). This is useful for wrapper CLIs that forward arguments to another program.
+
+> Libraries with similar support: **argparse** (`nargs=argparse.REMAINDER`), **clap** (`trailing_var_arg`), **cobra** (`TraverseChildren` + `ArbitraryArgs`).
+
+```mojo
+var command = Command("runner", "Run a program with arguments")
+command.add_argument(
+    Argument("program", help="Program to run").positional().required()
+)
+command.add_argument(
+    Argument("args", help="Arguments to pass through").remainder()
+)
+```
+
+```bash
+runner myapp --verbose -x --output=foo.txt
+# program = "myapp"
+# args    = ["--verbose", "-x", "--output=foo.txt"]
+```
+
+The remainder positional automatically implies `.positional()` and `.append()`. In help output, it is displayed as `args...` (with trailing ellipsis).
+
+**Rules:**
+
+- `.remainder()` must not have `.long()` or `.short()` — it is positional-only.
+- At most **one** remainder positional is allowed per command.
+- The remainder positional must be the **last** positional argument.
+- When no trailing tokens are present, the remainder list is empty (not an error).
+
+### Allow Hyphen Values (`.allow_hyphen_values()`)
+
+By default, tokens starting with `-` are interpreted as options. The `.allow_hyphen_values()` builder method tells the parser that a specific positional argument may accept values starting with `-` without requiring `--` beforehand.
+
+A common use case is accepting `-` as a conventional shorthand for **stdin/stdout**:
+
+```mojo
+var command = Command("cat", "Concatenate files")
+command.add_argument(
+    Argument("file", help="Input file (use - for stdin)")
+    .positional()
+    .required()
+    .allow_hyphen_values()
+)
+```
+
+```bash
+cat -        # file = "-"  (stdin convention)
+cat input.txt  # file = "input.txt"
+```
+
+> **Note:** `.remainder()` automatically enables `.allow_hyphen_values()` — no need to set it separately on remainder positionals.
+
+### Partial Parsing (`parse_known_arguments()`)
+
+`parse_known_arguments()` works like `parse_arguments()` but **does not raise an error** for unrecognised options. Instead, unknown tokens are collected and can be retrieved from the result.
+
+> Libraries with similar support: **argparse** (`parse_known_args()`), **clap** (not built-in; use `allow_external_subcommands`), **cobra** (`FParseErrWhitelist`).
+
+```mojo
+var command = Command("wrapper", "Wrapper that forwards unknown flags")
+command.add_argument(
+    Argument("verbose", help="Verbose output").long("verbose").flag()
+)
+command.add_argument(
+    Argument("file", help="Input file").positional().required()
+)
+
+var result = command.parse_known_arguments()
+
+# Known arguments are accessed normally:
+var verbose = result.get_bool("verbose")
+var file = result.get("file")
+
+# Unknown arguments are collected separately:
+var unknown = result.get_unknown_args()
+# e.g., ["--color", "-x", "--threads=4"]
+```
+
+```bash
+wrapper input.txt --verbose --color -x --threads=4
+# verbose = True
+# file    = "input.txt"
+# unknown = ["--color", "-x", "--threads=4"]
+```
+
+All other validation (required arguments, choices, range) still applies. Only the "Unknown option" error is suppressed.
+
 <!-- Response Files section temporarily disabled — Mojo compiler deadlock with -D ASSERT=all.
      The implementation is preserved as module-level functions and will be re-enabled
      when the Mojo compiler bug is fixed.
-
+     
 ## Response Files
 
 A **response file** (also called an **args file**) lets users store arguments in a text file and reference it on the command line with a prefix character (default `@`). This is useful when the argument list is very long or when the same set of arguments is reused frequently.
@@ -2667,7 +2773,7 @@ Every `Command` automatically responds to `--completions <shell>` — just like 
 ```mojo
 var app = Command("myapp", "My application", version="1.0.0")
 app.add_argument(Argument("verbose", help="Verbose output").long("verbose").short("v").flag())
-app.add_argument(Argument("output", help="Output file").long("output").short("o").metavar("FILE"))
+app.add_argument(Argument("output", help="Output file").long("output").short("o").value_name("FILE"))
 var formats: List[String] = ["json", "csv", "table"]
 app.add_argument(Argument("format", help="Output format").long("format").choices(formats^))
 
@@ -2825,7 +2931,7 @@ The table below maps every ArgMojo builder method / command-level method to its 
 | `.takes_value()`              | (default for non-flag)            | (default for options)                    | `.action(ArgAction::Set)`       | (default for non-bool)         |
 | `.default("val")`             | `default="val"`                   |                                          | `.default_value("val")`         | flag definition arg            |
 | `.choices(["a","b"])`         | `choices=["a","b"]`               | `type=click.Choice(…)`                   | `.value_parser(["a","b"])`      | — ⁴                            |
-| `.metavar("FILE")`            | `metavar="FILE"`                  | `metavar="FILE"`                         | `.value_name("FILE")`           | —                              |
+| `.value_name("FILE")`         | `metavar="FILE"`                  | `metavar="FILE"`                         | `.value_name("FILE")`           | —                              |
 | `.hidden()`                   | `help=argparse.SUPPRESS`          |                                          | `.hide(true)`                   | `MarkHidden()` ¹               |
 | `.count()`                    | `action="count"`                  | `count=True`                             | `.action(ArgAction::Count)`     | `CountP` / `CountVarP`         |
 | `.max[N]()`                   | —                                 | —                                        | —                               | —                              |
@@ -2841,6 +2947,8 @@ The table below maps every ArgMojo builder method / command-level method to its 
 | `.persistent()`               | — ⁷                               | —                                        | `.global(true)`                 | `PersistentFlags()`            |
 | `.default_if_no_value("val")` | `const="val"` + `nargs="?"`       | — ⁸                                      | `.default_missing_value("val")` | `NoOptDefVal` field            |
 | `.require_equals()`           | —                                 | —                                        | `.require_equals(true)`         | —                              |
+| `.remainder()`                | `nargs=argparse.REMAINDER`        | —                                        | `.trailing_var_arg(true)` ¹¹    | `TraverseChildren` ¹²          |
+| `.allow_hyphen_values()`      | —                                 | —                                        | `.allow_hyphen_values(true)`    | —                              |
 
 ### Command-Level Constraint Methods
 
@@ -2851,6 +2959,7 @@ The table below maps every ArgMojo builder method / command-level method to its 
 | `required_together(…)`      | —                                | —                               | `.requires("x")` per arg       | `MarkFlagsRequiredTogether()` ¹ |
 | `required_if(target, cond)` | —                                | —                               | `.required_if_eq("x","v")`     | `MarkFlagRequired…` ¹           |
 | `implies(trigger, implied)` | —                                | —                               | `.requires_if("v","x")` ¹⁰     | —                               |
+| `parse_known_arguments()`   | `parse_known_args()`             | —                               | — ¹¹                           | `FParseErrWhitelist` ¹²         |
 | `response_file_prefix()`    | `fromfile_prefix_chars="@"`      | —                               | —                              | —                               |
 
 ### Notes
@@ -2865,3 +2974,5 @@ The table below maps every ArgMojo builder method / command-level method to its 
 8. click's closest equivalent is `is_eager` combined with a custom callback; there is no direct `const` equivalent for options.
 9. click has no built-in `MutuallyExclusiveOption`; it is typically implemented via a custom `cls` or callback.
 10. clap's `.requires_if("val", "other_arg")` means "if this arg has value `val`, then `other_arg` is also required", which is a superset of ArgMojo's `implies`.
+11. clap uses `.trailing_var_arg(true)` on the command (not the argument) for remainder-like behaviour. For `parse_known_arguments`, clap has no direct equivalent; use `allow_external_subcommands`.
+12. Cobra uses `TraverseChildren` for remainder-like behaviour. For partial parsing, Cobra's `FParseErrWhitelist{UnknownFlags: true}` ignores unknown flags.

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -1086,7 +1086,10 @@ Argument("name", help="...")
 ║   .positional()                          ← matched by position
 ║   ├── .required()
 ║   ├── .default("val")
-║   └── .choices(["a","b","c"])
+║   ├── .choices(["a","b","c"])
+║   ├── .allow_hyphen_values()               accept -x as a value, not option
+║   └── .remainder()                         consume ALL remaining tokens
+║       └── (implies .allow_hyphen_values())
 ║
 ╠══ Decorators (combine with any path above) ═══════════════════════════════════
 ║   .value_name("FILE")          display name in help      (value / positional)
@@ -1140,6 +1143,9 @@ flowchart LR
     POS --> req2[".required()"]
     POS --> def2[".default()"]
     POS --> cho2[".choices()"]
+    POS --> ahv[".allow_hyphen_values()"]
+    POS --> rem[".remainder()"]
+    rem -.-> ahv
 
     ARG -.-> DEC["Decorators"]
     DEC --> meta[".value_name()"]
@@ -1192,6 +1198,8 @@ The table below shows which builder methods can be used with each argument mode.
 | `.deprecated("msg")`             |      ✓      |     ✓     |     ✓      |        ✓        |
 | `.persistent()`                  |      ✓      |     ✓     |     ✓      |        —        |
 | `.default_if_no_value("val")`    |      ✓      |     —     |     —      |        —        |
+| `.allow_hyphen_values()`         |      ✓      |     —     |     —      |        ✓        |
+| `.remainder()`                   |      —      |     —     |     —      |        ✓        |
 | `.require_equals()`              |      ✓      |     —     |     —      |        —        |
 | `command.mutually_exclusive()` ³ |      ✓      |     ✓     |     ✓      |        —        |
 | `command.one_required()` ³       |      ✓      |     ✓     |     ✓      |        —        |
@@ -2603,7 +2611,7 @@ The remainder positional automatically implies `.positional()` and `.append()`. 
 
 ### Allow Hyphen Values (`.allow_hyphen_values()`)
 
-By default, tokens starting with `-` are interpreted as options. The `.allow_hyphen_values()` builder method tells the parser that a specific positional argument may accept values starting with `-` without requiring `--` beforehand.
+By default, tokens starting with `-` are interpreted as options. The `.allow_hyphen_values()` builder method tells the parser that a specific positional argument may accept tokens starting with `-` as regular values without requiring `--` beforehand. This covers both the bare `-` (Unix stdin/stdout convention) and any other dash-prefixed literal.
 
 A common use case is accepting `-` as a conventional shorthand for **stdin/stdout**:
 
@@ -2639,11 +2647,12 @@ command.add_argument(
     Argument("file", help="Input file").positional().required()
 )
 
-var result = command.parse_known_arguments()
+var args: List[String] = ["wrapper", "input.txt", "--verbose", "--color", "-x"]
+var result = command.parse_known_arguments(args)
 
 # Known arguments are accessed normally:
-var verbose = result.get_bool("verbose")
-var file = result.get("file")
+var verbose = result.get_flag("verbose")
+var file = result.get_string("file")
 
 # Unknown arguments are collected separately:
 var unknown = result.get_unknown_args()
@@ -2658,6 +2667,8 @@ wrapper input.txt --verbose --color -x --threads=4
 ```
 
 All other validation (required arguments, choices, range) still applies. Only the "Unknown option" error is suppressed.
+
+> **Note:** Unknown options using `=` syntax (e.g., `--color=auto`) are captured as a single token. For space-separated syntax (`--color auto`), only `--color` is recorded as unknown; `auto` flows to positional arguments because the parser cannot tell whether the unknown option takes a value. Use `=` syntax when forwarding unknown options reliably.
 
 <!-- Response Files section temporarily disabled — Mojo compiler deadlock with -D ASSERT=all.
      The implementation is preserved as module-level functions and will be re-enabled

--- a/examples/demo.mojo
+++ b/examples/demo.mojo
@@ -10,7 +10,8 @@ conditional requirements, negatable flags, color customisation
 (header_color, arg_color), numeric range validation, append with range
 clamping, value delimiter, nargs, key-value map, aliases, deprecated args,
 negative number passthrough, allow_positional_with_subcommands, custom tips,
-help_on_no_arguments, default_if_no_value, require_equals, and response files.
+help_on_no_arguments, default_if_no_value, require_equals, response files,
+remainder positionals, allow_hyphen_values, and parse_known_arguments.
 
 Note: This demo looks very strange, but useful :D
 
@@ -90,6 +91,11 @@ Try these (build first with: pixi run package && mojo build -I src -o demo examp
   ./demo analyze --help
   ./demo analyze data.csv --workers 4 --threshold 95
   ./demo analyze data.csv --workers 999       # clamped to 32
+
+  # ── Subcommand: run (remainder + allow_hyphen_values) ────────────────
+  ./demo run myapp --verbose -x --output=foo.txt
+  ./demo run -                                # stdin convention via allow_hyphen_values
+  ./demo run myapp                            # no extra args → empty remainder
 """
 
 from argmojo import Argument, Command
@@ -153,7 +159,7 @@ fn main() raises:
         Argument("host", help="Server hostname")
         .long("host")
         .short("H")
-        .metavar("ADDR")
+        .value_name("ADDR")
     )
     app.add_argument(
         Argument(
@@ -180,7 +186,7 @@ fn main() raises:
         Argument("output", help="Output file path (required with --save)")
         .long("output")
         .short("o")
-        .metavar("FILE")
+        .value_name("FILE")
     )
     app.required_if("output", "save")
 
@@ -189,7 +195,7 @@ fn main() raises:
         Argument("point", help="A 3D point (X Y Z)")
         .long("point")
         .number_of_values[3]()
-        .metavar("COORD")
+        .value_name("COORD")
     )
 
     # ── Value delimiter ──────────────────────────────────────────────────
@@ -234,7 +240,7 @@ fn main() raises:
         .long("compress")
         .short("c")
         .default_if_no_value("gzip")
-        .metavar("ALGO")
+        .value_name("ALGO")
     )
 
     # ── Require equals (standalone) ──────────────────────────────────────
@@ -243,7 +249,7 @@ fn main() raises:
         Argument("separator", help="Field separator (must use = syntax)")
         .long("separator")
         .require_equals()
-        .metavar("CHAR")
+        .value_name("CHAR")
         .default(",")
     )
 
@@ -307,7 +313,7 @@ fn main() raises:
     analyze.add_argument(
         Argument("threshold", help="Confidence threshold [0-100]")
         .long("threshold")
-        .metavar("PCT")
+        .value_name("PCT")
         .range[0, 100]()
         .clamp()
     )
@@ -315,6 +321,22 @@ fn main() raises:
     var analyze_aliases: List[String] = ["an"]
     analyze.command_aliases(analyze_aliases^)
     app.add_subcommand(analyze^)
+
+    # ── Subcommand: run (remainder + allow_hyphen_values) ────────────────
+    # Demonstrates .remainder() for forwarding args and .allow_hyphen_values()
+    # for accepting stdin convention "-".
+    var run = Command("run", "Run a program and forward extra arguments")
+    run.add_argument(
+        Argument("program", help="Program to run (use - for stdin)")
+        .positional()
+        .required()
+        .allow_hyphen_values()
+    )
+    run.add_argument(
+        Argument("args", help="Arguments forwarded to the program").remainder()
+    )
+    run.help_on_no_arguments()
+    app.add_subcommand(run^)
 
     # ── Show help when invoked with no arguments ─────────────────────────
     app.help_on_no_arguments()

--- a/examples/mgit.mojo
+++ b/examples/mgit.mojo
@@ -5,7 +5,7 @@ no actual version-control operations are implemented.
 
 Showcases: subcommands, persistent (global) flags, per-command positional
 args, boolean flags, count flags, negatable flags, choices, default values,
-required arguments, metavar, hidden arguments, append/collect, value
+required arguments, value_name, hidden arguments, append/collect, value
 delimiter, mutually exclusive groups, required-together groups, conditional
 requirements, numeric range validation, aliases, deprecated arguments,
 Commands section in help, Global Options heading, full command path in
@@ -51,13 +51,13 @@ fn main() raises:
     app.add_argument(
         Argument("git-dir", help="Set the path to the repository (.git)")
         .long("git-dir")
-        .metavar("PATH")
+        .value_name("PATH")
         .persistent()
     )
     app.add_argument(
         Argument("work-tree", help="Set the path to the working tree")
         .long("work-tree")
-        .metavar("PATH")
+        .value_name("PATH")
         .persistent()
     )
 
@@ -77,7 +77,7 @@ fn main() raises:
     clone.add_argument(
         Argument("depth", help="Create a shallow clone with N commits")
         .long("depth")
-        .metavar("N")
+        .value_name("N")
         .range[1, 999999]()
     )
     clone.add_argument(
@@ -178,7 +178,7 @@ fn main() raises:
     commit.add_argument(
         Argument("author", help="Override the commit author")
         .long("author")
-        .metavar("NAME")
+        .value_name("NAME")
     )
     # Deprecated flag
     commit.add_argument(
@@ -267,23 +267,23 @@ fn main() raises:
         Argument("number", help="Limit number of commits shown")
         .long("number")
         .short("n")
-        .metavar("N")
+        .value_name("N")
         .range[1, 999999]()
     )
     log.add_argument(
         Argument("author", help="Filter by author")
         .long("author")
-        .metavar("PATTERN")
+        .value_name("PATTERN")
     )
     log.add_argument(
         Argument("since", help="Show commits after date")
         .long("since")
-        .metavar("DATE")
+        .value_name("DATE")
     )
     log.add_argument(
         Argument("until", help="Show commits before date")
         .long("until")
-        .metavar("DATE")
+        .value_name("DATE")
     )
     # Append: multiple --grep patterns
     log.add_argument(
@@ -417,7 +417,7 @@ fn main() raises:
         Argument("unified", help="Generate diffs with N lines of context")
         .long("unified")
         .short("U")
-        .metavar("N")
+        .value_name("N")
     )
     app.add_subcommand(diff^)
 

--- a/examples/mgrep.mojo
+++ b/examples/mgrep.mojo
@@ -4,7 +4,7 @@ Simulates the interface of GNU grep.  Only argument parsing is performed;
 no actual file searching is implemented.
 
 Showcases: positional args, long/short options, boolean flags, count flags,
-negatable flags, choices, default values, required arguments, metavar,
+negatable flags, choices, default values, required arguments, value_name,
 hidden arguments, short flag merging, attached short values, append/collect,
 value delimiter, multi-value options (nargs), mutually exclusive groups,
 one-required groups, required-together groups, conditional requirements,
@@ -139,7 +139,7 @@ fn main() raises:
         Argument("max-depth", help="Maximum directory depth")
         .long("max-depth")
         .short("d")
-        .metavar("N")
+        .value_name("N")
         .range[0, 999]()
     )
 
@@ -149,7 +149,7 @@ fn main() raises:
         .long("context")
         .short("C")
         .number_of_values[2]()
-        .metavar("N")
+        .value_name("N")
     )
 
     # ── Output format (choices) ──────────────────────────────────────────
@@ -198,7 +198,7 @@ fn main() raises:
         Argument("output", help="Output file path (required with --save)")
         .long("output")
         .short("o")
-        .metavar("FILE")
+        .value_name("FILE")
     )
     app.required_if("output", "save")
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -38,10 +38,11 @@ test = """\
     && mojo run -I src -D ASSERT=all tests/test_typo_suggestions.mojo \
     && mojo run -I src -D ASSERT=all tests/test_completion.mojo \
     && mojo run -I src -D ASSERT=all tests/test_implies.mojo \
-    && mojo run -I src -D ASSERT=all tests/test_const_require_equals.mojo"""
-    # NOTE: test_response_file.mojo is excluded — response file expansion
-    # is temporarily disabled to work around a Mojo compiler deadlock
-    # with -D ASSERT=all.  Re-enable when the compiler bug is fixed.
+    && mojo run -I src -D ASSERT=all tests/test_const_require_equals.mojo \
+    && mojo run -I src -D ASSERT=all tests/test_remainder_known.mojo"""
+# NOTE: test_response_file.mojo is excluded — response file expansion
+# is temporarily disabled to work around a Mojo compiler deadlock
+# with -D ASSERT=all.  Re-enable when the compiler bug is fixed.
 
 # build example binaries
 build = """pixi run package \

--- a/src/argmojo/argument.mojo
+++ b/src/argmojo/argument.mojo
@@ -716,12 +716,13 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         return self^
 
     fn allow_hyphen_values(var self) -> Self:
-        """Allows the literal token ``-`` as a valid value.
+        """Allows tokens starting with ``-`` as valid values.
 
-        By default, a bare ``-`` is treated as a short-option prefix and
-        triggers an "unknown option" error.  Call this method to accept
-        ``-`` as a regular value, following the Unix convention where
-        ``-`` means read from stdin or write to stdout.
+        By default, tokens that start with ``-`` are interpreted as option
+        flags.  Call this method to accept such tokens as regular values
+        instead, without requiring ``--`` first.  This covers the common
+        Unix convention where a bare ``-`` means stdin/stdout, as well as
+        any other dash-prefixed literal value.
 
         Can be used on positional arguments and value-taking options.
 

--- a/src/argmojo/argument.mojo
+++ b/src/argmojo/argument.mojo
@@ -54,7 +54,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
     # Require equals syntax  (--output=file.txt OK, --output file.txt rejected)
     _ = Argument("output", help="...").long("output").require_equals()
     # Display helpers
-    _ = Argument("file", help="...").long("file").metavar("PATH")  # help: --file PATH
+    _ = Argument("file", help="...").long("file").value_name("PATH")  # help: --file PATH
     _ = Argument("internal", help="...").long("internal").hidden()  # hidden from help
     ```
     """
@@ -82,7 +82,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
     """Whether a default value has been set."""
     var _choice_values: List[String]
     """Allowed values for this argument. Empty means any value is accepted."""
-    var _metavar: String
+    var _value_name: String
     """Display name for the value in help text (e.g., 'FILE' for --output FILE)."""
     var _is_hidden: Bool
     """If True, this argument is not shown in help output."""
@@ -127,6 +127,13 @@ struct Argument(Copyable, Movable, Stringable, Writable):
     var _require_equals: Bool
     """If True, this option requires ``--key=value`` syntax;
     ``--key value`` (space-separated) is not allowed."""
+    var _is_remainder: Bool
+    """If True, this positional argument consumes all remaining tokens
+    (including those starting with ``-``).  Implies ``.positional()`` and
+    ``.append()``.  Must be the last positional argument."""
+    var _allow_hyphen_values: Bool
+    """If True, the literal token ``-`` is accepted as a valid value for
+    this argument (conventionally meaning stdin/stdout)."""
 
     # ===------------------------------------------------------------------=== #
     # Life cycle methods
@@ -149,7 +156,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         self._default_value = ""
         self._has_default = False
         self._choice_values = List[String]()
-        self._metavar = ""
+        self._value_name = ""
         self._is_hidden = False
         self._is_count = False
         self._is_negatable = False
@@ -169,6 +176,8 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         self._default_if_no_value = ""
         self._has_default_if_no_value = False
         self._require_equals = False
+        self._is_remainder = False
+        self._allow_hyphen_values = False
 
     fn __copyinit__(out self, copy: Self):
         """Creates a copy of this argument.
@@ -188,7 +197,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         self._choice_values = List[String]()
         for i in range(len(copy._choice_values)):
             self._choice_values.append(copy._choice_values[i])
-        self._metavar = copy._metavar
+        self._value_name = copy._value_name
         self._is_hidden = copy._is_hidden
         self._is_count = copy._is_count
         self._is_negatable = copy._is_negatable
@@ -210,6 +219,8 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         self._default_if_no_value = copy._default_if_no_value
         self._has_default_if_no_value = copy._has_default_if_no_value
         self._require_equals = copy._require_equals
+        self._is_remainder = copy._is_remainder
+        self._allow_hyphen_values = copy._allow_hyphen_values
 
     fn __moveinit__(out self, deinit move: Self):
         """Moves the value from another Argument.
@@ -227,7 +238,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         self._default_value = move._default_value^
         self._has_default = move._has_default
         self._choice_values = move._choice_values^
-        self._metavar = move._metavar^
+        self._value_name = move._value_name^
         self._is_hidden = move._is_hidden
         self._is_count = move._is_count
         self._is_negatable = move._is_negatable
@@ -247,6 +258,8 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         self._default_if_no_value = move._default_if_no_value^
         self._has_default_if_no_value = move._has_default_if_no_value
         self._require_equals = move._require_equals
+        self._is_remainder = move._is_remainder
+        self._allow_hyphen_values = move._allow_hyphen_values
 
     # ===------------------------------------------------------------------=== #
     # Builder methods for configuring the argument
@@ -348,19 +361,19 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         self._choice_values = values^
         return self^
 
-    fn metavar(var self, name: String) -> Self:
+    fn value_name(var self, name: String) -> Self:
         """Sets the display name for the value in help text.
 
-        For example, ``.metavar("FILE")`` causes help to show ``--output FILE``
+        For example, ``.value_name("FILE")`` causes help to show ``--output FILE``
         instead of ``--output OUTPUT``.
 
         Args:
             name: The display name.
 
         Returns:
-            Self with the metavar set.
+            Self with the value_name set.
         """
-        self._metavar = name
+        self._value_name = name
         return self^
 
     fn hidden(var self) -> Self:
@@ -667,6 +680,63 @@ struct Argument(Copyable, Movable, Stringable, Writable):
             Self with require-equals enabled.
         """
         self._require_equals = True
+        return self^
+
+    fn remainder(var self) -> Self:
+        """Marks this positional argument as a remainder collector.
+
+        A remainder argument consumes **all** remaining tokens on the
+        command line — including those starting with ``-``.  It is
+        equivalent to Python's ``nargs=argparse.REMAINDER``.
+
+        Implies ``.positional()`` and ``.append()`` — values are retrieved
+        via ``ParseResult.get_list()``.
+
+        A ``Command`` may have at most one remainder argument, and it
+        must be the last positional argument.  Tokens collected by a
+        remainder argument are **not** parsed as options; they are stored
+        verbatim.
+
+        Examples::
+
+            # myapp build -- -Wall -O2 src/main.c
+            # With .remainder(), everything after 'build' goes into rest:
+            _ = Argument("rest", help="...").remainder()
+
+            # Or without '--':
+            # myapp run script.py --script-flag
+            # rest = ["script.py", "--script-flag"]
+
+        Returns:
+            Self marked as a remainder positional.
+        """
+        self._is_remainder = True
+        self._is_positional = True
+        self._is_append = True
+        return self^
+
+    fn allow_hyphen_values(var self) -> Self:
+        """Allows the literal token ``-`` as a valid value.
+
+        By default, a bare ``-`` is treated as a short-option prefix and
+        triggers an "unknown option" error.  Call this method to accept
+        ``-`` as a regular value, following the Unix convention where
+        ``-`` means read from stdin or write to stdout.
+
+        Can be used on positional arguments and value-taking options.
+
+        Examples::
+
+            # Positional: myapp -  → positional value is "-"
+            _ = Argument("input", help="...").positional().allow_hyphen_values()
+
+            # Option: myapp --file -  → file value is "-"
+            _ = Argument("file", help="...").long("file").allow_hyphen_values()
+
+        Returns:
+            Self with hyphen-value support enabled.
+        """
+        self._allow_hyphen_values = True
         return self^
 
     # ===------------------------------------------------------------------=== #

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -408,6 +408,28 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 + "': .require_equals() / .default_if_no_value() cannot be"
                 " combined with .number_of_values[N]() (multi-value options)"
             )
+        # Guard: remainder must not be combined with long/short (it is positional-only).
+        if argument._is_remainder and (
+            argument._long_name or argument._short_name
+        ):
+            self._error(
+                "Argument '"
+                + argument.name
+                + "': .remainder() is for positional arguments only; remove"
+                " .long() / .short()"
+            )
+        # Guard: at most one remainder positional is allowed.
+        if argument._is_remainder:
+            for _ri in range(len(self.args)):
+                if self.args[_ri]._is_remainder:
+                    self._error(
+                        "Argument '"
+                        + argument.name
+                        + "': only one .remainder() positional is allowed"
+                        " (already set on '"
+                        + self.args[_ri].name
+                        + "')"
+                    )
         self.args.append(argument^)
 
     fn add_subcommand(mut self, var sub: Command) raises:
@@ -1166,10 +1188,13 @@ struct Command(Copyable, Movable, Stringable, Writable):
         var s = String("Usage: ") + self.name
         for i in range(len(self.args)):
             if self.args[i]._is_positional and not self.args[i]._is_hidden:
+                var display = self.args[i].name
+                if self.args[i]._is_remainder:
+                    display += "..."
                 if self.args[i]._is_required:
-                    s += " <" + self.args[i].name + ">"
+                    s += " <" + display + ">"
                 else:
-                    s += " [" + self.args[i].name + "]"
+                    s += " [" + display + "]"
         var has_subcommands = False
         for i in range(len(self.subcommands)):
             if (
@@ -1303,6 +1328,20 @@ struct Command(Copyable, Movable, Stringable, Writable):
 
         # === PARSING PHASE === #
 
+        # Check if there is a remainder positional and which slot it is.
+        var remainder_pos_idx: Int = -1
+        for _ri in range(len(self.args)):
+            if self.args[_ri]._is_remainder:
+                # Find its positional slot index.
+                var slot: Int = 0
+                for _rj in range(len(self.args)):
+                    if self.args[_rj]._is_positional:
+                        if self.args[_rj].name == self.args[_ri].name:
+                            remainder_pos_idx = slot
+                            break
+                        slot += 1
+                break
+
         while i < len(args_to_parse):
             var arg = args_to_parse[i]
 
@@ -1313,6 +1352,17 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 continue
 
             if stop_parsing_options:
+                result._positionals.append(arg)
+                i += 1
+                continue
+
+            # ── Remainder mode: if the current positional slot is a
+            # remainder argument, consume ALL remaining tokens verbatim. ──
+            if (
+                remainder_pos_idx >= 0
+                and len(result._positionals) >= remainder_pos_idx
+            ):
+                # We've reached or passed the remainder slot — consume everything.
                 result._positionals.append(arg)
                 i += 1
                 continue
@@ -1415,6 +1465,191 @@ struct Command(Copyable, Movable, Stringable, Writable):
             i += 1
 
         # Apply defaults, propagate implications, then validate constraints.
+        self._apply_defaults(result)
+        self._apply_implications(result)
+        self._validate(result)
+
+        return result^
+
+    fn parse_known_arguments(
+        self, raw_args: List[String]
+    ) raises -> ParseResult:
+        """Parses known arguments, collecting unrecognised ones.
+
+        Behaves like ``parse_arguments()`` but does **not** error on
+        unknown options.  Instead, unrecognised tokens are stored in the
+        result and can be retrieved via ``result.get_unknown_args()``.
+
+        This is useful for wrapper CLIs that forward unknown flags to
+        another tool, or for incremental/phased parsing.
+
+        Args:
+            raw_args: The raw argument strings (including program name at
+                index 0).
+
+        Returns:
+            A ParseResult whose ``get_unknown_args()`` contains any
+            tokens that did not match a registered argument.
+
+        Raises:
+            Error on validation failures (required args, groups, etc.)
+            — only *unknown-option* errors are suppressed.
+        """
+        var result = ParseResult()
+
+        var args_to_parse = raw_args.copy()
+
+        # Register positional argument names in order.
+        for i in range(len(self.args)):
+            if self.args[i]._is_positional:
+                result._positional_names.append(self.args[i].name)
+
+        var i: Int = 1
+        var stop_parsing_options = False
+
+        if self._help_on_no_arguments and len(args_to_parse) <= 1:
+            print(self._generate_help())
+            exit(0)
+
+        # Remainder positional detection (same as parse_arguments).
+        var remainder_pos_idx: Int = -1
+        for _ri in range(len(self.args)):
+            if self.args[_ri]._is_remainder:
+                var slot: Int = 0
+                for _rj in range(len(self.args)):
+                    if self.args[_rj]._is_positional:
+                        if self.args[_rj].name == self.args[_ri].name:
+                            remainder_pos_idx = slot
+                            break
+                        slot += 1
+                break
+
+        while i < len(args_to_parse):
+            var arg = args_to_parse[i]
+
+            if arg == "--" and not stop_parsing_options:
+                stop_parsing_options = True
+                i += 1
+                continue
+
+            if stop_parsing_options:
+                result._positionals.append(arg)
+                i += 1
+                continue
+
+            # Remainder mode.
+            if (
+                remainder_pos_idx >= 0
+                and len(result._positionals) >= remainder_pos_idx
+            ):
+                result._positionals.append(arg)
+                i += 1
+                continue
+
+            # --help / -h / -?
+            if arg == "--help" or arg == "-h" or arg == "-?":
+                print(self._generate_help())
+                exit(0)
+
+            # --version / -V
+            if arg == "--version" or arg == "-V":
+                print(self.name + " " + self.version)
+                exit(0)
+
+            # Completions (long-option form).
+            if (
+                self._completions_enabled
+                and not self._completions_is_subcommand
+                and arg == "--" + self._completions_name
+            ):
+                if i + 1 < len(args_to_parse):
+                    i += 1
+                    var shell_arg = args_to_parse[i]
+                    try:
+                        print(self.generate_completion(shell_arg))
+                    except e:
+                        self._error(String(e))
+                        exit(2)
+                    exit(0)
+                else:
+                    self._error(
+                        "--"
+                        + self._completions_name
+                        + " requires a shell name: bash, zsh, or fish"
+                    )
+                    exit(2)
+
+            # Long option — try to parse; collect as unknown if it fails.
+            if arg.startswith("--"):
+                try:
+                    i = self._parse_long_option(args_to_parse, i, result)
+                except:
+                    result._unknown_args.append(arg)
+                    i += 1
+                continue
+
+            # Short option — try to parse; collect as unknown if it fails.
+            if arg.startswith("-") and len(arg) > 1:
+                if _looks_like_number(arg):
+                    var has_digit_short = False
+                    for _ni in range(len(self.args)):
+                        var sn = self.args[_ni]._short_name
+                        if sn >= "0" and sn <= "9":
+                            has_digit_short = True
+                            break
+                    if self._allow_negative_numbers or not has_digit_short:
+                        result._positionals.append(arg)
+                        i += 1
+                        continue
+                try:
+                    var key = String(arg[1:])
+                    if len(key) == 1:
+                        i = self._parse_short_single(
+                            key, args_to_parse, i, result
+                        )
+                    else:
+                        i = self._parse_short_merged(
+                            key, args_to_parse, i, result
+                        )
+                except:
+                    result._unknown_args.append(arg)
+                    i += 1
+                continue
+
+            # Completions subcommand.
+            if (
+                self._completions_enabled
+                and self._completions_is_subcommand
+                and arg == self._completions_name
+            ):
+                if i + 1 < len(args_to_parse):
+                    i += 1
+                    var shell_arg = args_to_parse[i]
+                    try:
+                        print(self.generate_completion(shell_arg))
+                    except e:
+                        self._error(String(e))
+                        exit(2)
+                    exit(0)
+                else:
+                    self._error(
+                        self._completions_name
+                        + " requires a shell name: bash, zsh, or fish"
+                    )
+                    exit(2)
+
+            # Subcommand dispatch.
+            if len(self.subcommands) > 0:
+                var new_i = self._dispatch_subcommand(
+                    arg, args_to_parse, i, result
+                )
+                if new_i >= 0:
+                    i = new_i
+                    continue
+
+            result._positionals.append(arg)
+            i += 1
+
         self._apply_defaults(result)
         self._apply_implications(result)
         self._validate(result)
@@ -1949,6 +2184,21 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 else:
                     result._values[a.name] = a._default_value
 
+        # Populate remainder-positional lists from collected positionals.
+        # A remainder arg at positional slot N collects positionals[N:].
+        var pos_slot: Int = 0
+        for j in range(len(self.args)):
+            if self.args[j]._is_positional:
+                if self.args[j]._is_remainder:
+                    # Collect all positionals from this slot onward into _lists.
+                    var lst = List[String]()
+                    for k in range(pos_slot, len(result._positionals)):
+                        lst.append(result._positionals[k])
+                    if len(lst) > 0:
+                        result._lists[self.args[j].name] = lst^
+                    break
+                pos_slot += 1
+
     fn _apply_implications(self, mut result: ParseResult):
         """Propagates implication rules on the parse result.
 
@@ -2009,8 +2259,19 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 )
 
         # Validate positional argument count — too many args is an error.
+        # Skip this check when a remainder positional is registered (it
+        # deliberately collects an unbounded number of tokens).
+        var has_remainder = False
+        for _ri in range(len(self.args)):
+            if self.args[_ri]._is_remainder:
+                has_remainder = True
+                break
         var expected_count: Int = len(result._positional_names)
-        if expected_count > 0 and len(result._positionals) > expected_count:
+        if (
+            expected_count > 0
+            and len(result._positionals) > expected_count
+            and not has_remainder
+        ):
             self._error_with_usage(
                 "Too many positional arguments: expected "
                 + String(expected_count)
@@ -2551,24 +2812,13 @@ struct Command(Copyable, Movable, Stringable, Writable):
         # Show positional args in usage line.
         for i in range(len(self.args)):
             if self.args[i]._is_positional and not self.args[i]._is_hidden:
+                var display = self.args[i].name
+                if self.args[i]._is_remainder:
+                    display += "..."
                 if self.args[i]._is_required:
-                    s += (
-                        " "
-                        + arg_color
-                        + "<"
-                        + self.args[i].name
-                        + ">"
-                        + reset_code
-                    )
+                    s += " " + arg_color + "<" + display + ">" + reset_code
                 else:
-                    s += (
-                        " "
-                        + arg_color
-                        + "["
-                        + self.args[i].name
-                        + "]"
-                        + reset_code
-                    )
+                    s += " " + arg_color + "[" + display + "]" + reset_code
 
         # Show <COMMAND> placeholder when subcommands are registered.
         var has_subcommands = False
@@ -2619,9 +2869,12 @@ struct Command(Copyable, Movable, Stringable, Writable):
         var pos_helps = List[String]()
         for i in range(len(self.args)):
             if self.args[i]._is_positional and not self.args[i]._is_hidden:
-                var plain = String("  ") + self.args[i].name
+                var name_display = self.args[i].name
+                if self.args[i]._is_remainder:
+                    name_display += "..."
+                var plain = String("  ") + name_display
                 var colored = (
-                    String("  ") + arg_color + self.args[i].name + reset_code
+                    String("  ") + arg_color + name_display + reset_code
                 )
                 pos_plains.append(plain)
                 pos_colors.append(colored)
@@ -2716,7 +2969,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                             + reset_code
                         )
 
-                # Show metavar or choices for value-taking options.
+                # Show value_name or choices for value-taking options.
                 if not self.args[i]._is_flag and not self.args[i]._is_count:
                     var ncount = self.args[i]._number_of_values
                     var repeat = ncount if ncount > 0 else 1
@@ -2731,8 +2984,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
                     var close_bracket = String("]") if self.args[
                         i
                     ]._has_default_if_no_value else String("")
-                    if self.args[i]._metavar:
-                        var mv = self.args[i]._metavar
+                    if self.args[i]._value_name:
+                        var mv = self.args[i]._value_name
                         var mv_plain = String("")
                         var mv_colored = String("")
                         for _r in range(repeat - 1):
@@ -3590,7 +3843,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                         choices += arg._choice_values[k]
                     spec += ":value:(" + choices + ")"
                 else:
-                    var mv = arg._metavar if arg._metavar else arg.name
+                    var mv = arg._value_name if arg._value_name else arg.name
                     spec += ":" + mv + ":"
             spec += "'"
         else:
@@ -3603,7 +3856,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                         choices += arg._choice_values[k]
                     spec += "[" + desc + "]:value:(" + choices + ")'"
                 else:
-                    var mv = arg._metavar if arg._metavar else arg.name
+                    var mv = arg._value_name if arg._value_name else arg.name
                     spec += "[" + desc + "]:" + mv + ":'"
             else:
                 spec += "[" + desc + "]'"

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -430,6 +430,18 @@ struct Command(Copyable, Movable, Stringable, Writable):
                         + self.args[_ri].name
                         + "')"
                     )
+        # Guard: no positional may be added after a remainder.
+        if argument._is_positional and not argument._is_remainder:
+            for _ri in range(len(self.args)):
+                if self.args[_ri]._is_remainder:
+                    self._error(
+                        "Argument '"
+                        + argument.name
+                        + "': cannot add a positional argument after"
+                        " a .remainder() positional ('"
+                        + self.args[_ri].name
+                        + "')"
+                    )
         self.args.append(argument^)
 
     fn add_subcommand(mut self, var sub: Command) raises:
@@ -1400,6 +1412,28 @@ struct Command(Copyable, Movable, Stringable, Writable):
                     )
                     exit(2)
 
+            # ── allow_hyphen_values ──────────────────────────────────
+            # If the next positional slot accepts dash-prefixed tokens
+            # and this token is NOT a known option, consume as positional.
+            if arg.startswith("-") and len(arg) > 1:
+                var _ahv_consumed = False
+                var _ahv_slot = len(result._positionals)
+                if _ahv_slot < len(result._positional_names):
+                    var _ahv_name = result._positional_names[_ahv_slot]
+                    for _ai in range(len(self.args)):
+                        if (
+                            self.args[_ai].name == _ahv_name
+                            and self.args[_ai]._allow_hyphen_values
+                        ):
+                            if not self._is_known_option(arg):
+                                result._positionals.append(arg)
+                                i += 1
+                                _ahv_consumed = True
+                            break
+                if _ahv_consumed:
+                    continue
+            # ────────────────────────────────────────────────────────
+
             # Long option: --key, --key=value, --key value
             if arg.startswith("--"):
                 i = self._parse_long_option(args_to_parse, i, result)
@@ -1494,6 +1528,17 @@ struct Command(Copyable, Movable, Stringable, Writable):
         Raises:
             Error on validation failures (required args, groups, etc.)
             — only *unknown-option* errors are suppressed.
+
+
+        Notes:
+
+        Unknown options using ``=`` syntax (e.g. ``--color=auto``) are
+        captured as a single token in the unknown list.  For space-
+        separated syntax (``--color auto``), only ``--color`` is
+        recorded as unknown; ``auto`` flows to positional arguments
+        because the parser cannot determine whether the unknown option
+        takes a value.  Prefer ``=`` syntax when forwarding unknown
+        options reliably.
         """
         var result = ParseResult()
 
@@ -1578,6 +1623,26 @@ struct Command(Copyable, Movable, Stringable, Writable):
                         + " requires a shell name: bash, zsh, or fish"
                     )
                     exit(2)
+
+            # ── allow_hyphen_values (same logic as parse_arguments) ──
+            if arg.startswith("-") and len(arg) > 1:
+                var _ahv_consumed = False
+                var _ahv_slot = len(result._positionals)
+                if _ahv_slot < len(result._positional_names):
+                    var _ahv_name = result._positional_names[_ahv_slot]
+                    for _ai in range(len(self.args)):
+                        if (
+                            self.args[_ai].name == _ahv_name
+                            and self.args[_ai]._allow_hyphen_values
+                        ):
+                            if not self._is_known_option(arg):
+                                result._positionals.append(arg)
+                                i += 1
+                                _ahv_consumed = True
+                            break
+                if _ahv_consumed:
+                    continue
+            # ────────────────────────────────────────────────────────
 
             # Long option — try to parse; collect as unknown if it fails.
             if arg.startswith("--"):
@@ -2190,12 +2255,12 @@ struct Command(Copyable, Movable, Stringable, Writable):
         for j in range(len(self.args)):
             if self.args[j]._is_positional:
                 if self.args[j]._is_remainder:
-                    # Collect all positionals from this slot onward into _lists.
+                    # Always set the remainder list so callers can reliably
+                    # get an empty list when no remainder tokens were present.
                     var lst = List[String]()
                     for k in range(pos_slot, len(result._positionals)):
                         lst.append(result._positionals[k])
-                    if len(lst) > 0:
-                        result._lists[self.args[j].name] = lst^
+                    result._lists[self.args[j].name] = lst^
                     break
                 pos_slot += 1
 
@@ -2492,6 +2557,45 @@ struct Command(Copyable, Movable, Stringable, Writable):
     # ===------------------------------------------------------------------=== #
     # Argument lookup helpers
     # ===------------------------------------------------------------------=== #
+
+    fn _is_known_option(self, token: String) -> Bool:
+        """Check if a dash-prefixed token matches a defined option.
+
+        Used by the ``allow_hyphen_values`` logic to decide whether a
+        token should be dispatched to option parsing or consumed as a
+        positional value.
+
+        Args:
+            token: The raw CLI token (e.g. ``--verbose``, ``-v``).
+
+        Returns:
+            True if the token matches a known long/short option.
+        """
+        if token.startswith("--"):
+            var key = String(token[2:])
+            var eq = key.find("=")
+            if eq >= 0:
+                key = String(key[:eq])
+            for idx in range(len(self.args)):
+                if self.args[idx]._long_name == key:
+                    return True
+                if self.args[idx]._long_name and self.args[
+                    idx
+                ]._long_name.startswith(key):
+                    return True
+                for j in range(len(self.args[idx]._alias_names)):
+                    if self.args[idx]._alias_names[j] == key or self.args[
+                        idx
+                    ]._alias_names[j].startswith(key):
+                        return True
+            return False
+        elif token.startswith("-") and len(token) > 1:
+            var ch = String(token[1:2])
+            for idx in range(len(self.args)):
+                if self.args[idx]._short_name == ch:
+                    return True
+            return False
+        return False
 
     fn _find_by_long(self, name: String) raises -> Argument:
         """Finds an argument definition by its long name, alias, or unambiguous prefix.

--- a/src/argmojo/parse_result.mojo
+++ b/src/argmojo/parse_result.mojo
@@ -31,6 +31,9 @@ struct ParseResult(Copyable, Movable, Stringable, Writable):
     Use ``has_subcommand_result()`` to check presence and
     ``get_subcommand_result()`` to retrieve the value.
     """
+    var _unknown_args: List[String]
+    """Unrecognised arguments collected by ``parse_known_arguments()``.
+    Empty when using the standard ``parse_arguments()`` method."""
 
     fn __init__(out self):
         """Creates an empty ParseResult."""
@@ -43,6 +46,7 @@ struct ParseResult(Copyable, Movable, Stringable, Writable):
         self._positional_names = List[String]()
         self.subcommand = ""
         self._subcommand_results = List[ParseResult]()
+        self._unknown_args = List[String]()
 
     fn __copyinit__(out self, copy: Self):
         """Creates a deep copy of a ParseResult.
@@ -63,6 +67,7 @@ struct ParseResult(Copyable, Movable, Stringable, Writable):
         self._positional_names = copy._positional_names.copy()
         self.subcommand = copy.subcommand
         self._subcommand_results = copy._subcommand_results.copy()
+        self._unknown_args = copy._unknown_args.copy()
 
     fn __moveinit__(out self, deinit move: Self):
         """Moves a ParseResult, transferring all field ownership.
@@ -79,6 +84,7 @@ struct ParseResult(Copyable, Movable, Stringable, Writable):
         self._positional_names = move._positional_names^
         self.subcommand = move.subcommand^
         self._subcommand_results = move._subcommand_results^
+        self._unknown_args = move._unknown_args^
 
     fn get_flag(self, name: String) -> Bool:
         """Gets a boolean flag value. Returns False if not set.
@@ -245,6 +251,18 @@ struct ParseResult(Copyable, Movable, Stringable, Writable):
             )
         var r: ParseResult = self._subcommand_results[0].copy()
         return r^
+
+    fn get_unknown_args(self) -> List[String]:
+        """Returns the list of unrecognised arguments.
+
+        Only populated when the result comes from
+        ``Command.parse_known_arguments()``.  Returns an empty list
+        when using the standard ``parse_arguments()`` method.
+
+        Returns:
+            A copy of the unknown-arguments list.
+        """
+        return self._unknown_args.copy()
 
     fn __str__(self) -> String:
         """Return a string representation of the parse result."""

--- a/tests/test_const_require_equals.mojo
+++ b/tests/test_const_require_equals.mojo
@@ -468,15 +468,15 @@ fn test_help_const_format() raises:
     )
 
 
-fn test_help_const_with_metavar() raises:
-    """Help shows --compress[=ALGO] when default_if_no_value and metavar are both set.
+fn test_help_const_with_value_name() raises:
+    """Help shows --compress[=ALGO] when default_if_no_value and value_name are both set.
     """
     var command = Command("test", "Test app")
     command.add_argument(
         Argument("compress", help="Compression algorithm")
         .long("compress")
         .default_if_no_value("gzip")
-        .metavar("ALGO")
+        .value_name("ALGO")
     )
 
     var help = command._generate_help(color=False)
@@ -486,14 +486,14 @@ fn test_help_const_with_metavar() raises:
     )
 
 
-fn test_help_require_equals_with_metavar() raises:
-    """Help shows --output=FILE when require_equals and metavar are set."""
+fn test_help_require_equals_with_value_name() raises:
+    """Help shows --output=FILE when require_equals and value_name are set."""
     var command = Command("test", "Test app")
     command.add_argument(
         Argument("output", help="Output file")
         .long("output")
         .require_equals()
-        .metavar("FILE")
+        .value_name("FILE")
     )
 
     var help = command._generate_help(color=False)

--- a/tests/test_help.mojo
+++ b/tests/test_help.mojo
@@ -48,27 +48,27 @@ fn test_hidden_still_works() raises:
 # ── Metavar ──────────────────────────────────────────────────────────────────────
 
 
-fn test_metavar_in_help() raises:
-    """Tests that metavar appears in help output."""
+fn test_value_name_in_help() raises:
+    """Tests that value_name appears in help output."""
     var command = Command("test", "Test app")
     command.add_argument(
         Argument("output", help="Output file")
         .long("output")
         .short("o")
-        .metavar("FILE")
+        .value_name("FILE")
     )
 
     var help = command._generate_help()
-    assert_true("FILE" in help, msg="metavar 'FILE' should appear in help")
+    assert_true("FILE" in help, msg="value_name 'FILE' should appear in help")
     # Should NOT show the default "<output>" form.
     assert_false(
         "<output>" in help,
-        msg="default placeholder should not appear when metavar is set",
+        msg="default placeholder should not appear when value_name is set",
     )
 
 
 fn test_choices_in_help() raises:
-    """Tests that choices are displayed in help when no metavar."""
+    """Tests that choices are displayed in help when no value_name."""
     var command = Command("test", "Test app")
     var fmts: List[String] = ["json", "csv", "table"]
     command.add_argument(
@@ -114,17 +114,20 @@ fn test_append_in_help() raises:
         Argument("tag", help="Add a tag").long("tag").short("t").append()
     )
     command.add_argument(
-        Argument("env", help="Target env").long("env").metavar("ENV").append()
+        Argument("env", help="Target env")
+        .long("env")
+        .value_name("ENV")
+        .append()
     )
 
     var help = command._generate_help()
     assert_true(
         "<tag>..." in help,
-        msg="append arg without metavar should show <tag>... in help",
+        msg="append arg without value_name should show <tag>... in help",
     )
     assert_true(
         "ENV..." in help,
-        msg="append arg with metavar should show ENV... in help",
+        msg="append arg with value_name should show ENV... in help",
     )
 
 
@@ -484,7 +487,7 @@ fn test_nargs_in_help() raises:
         Argument("rgb", help="RGB colour")
         .long("rgb")
         .number_of_values[3]()
-        .metavar("N")
+        .value_name("N")
     )
 
     var help = command._generate_help(color=False)
@@ -496,7 +499,7 @@ fn test_nargs_in_help() raises:
     # --rgb should show N N N
     assert_true(
         "N N N" in help,
-        msg="number_of_values(3) with metavar should show 'N N N'",
+        msg="number_of_values(3) with value_name should show 'N N N'",
     )
     # Neither should have "..." since they are nargs, not plain append.
     assert_false(
@@ -505,20 +508,20 @@ fn test_nargs_in_help() raises:
     )
 
 
-fn test_nargs_with_metavar() raises:
-    """Tests nargs with a custom metavar in help."""
+fn test_nargs_with_value_name() raises:
+    """Tests nargs with a custom value_name in help."""
     var command = Command("test", "Test app")
     command.add_argument(
         Argument("size", help="Width and height")
         .long("size")
         .number_of_values[2]()
-        .metavar("PX")
+        .value_name("PX")
     )
 
     var help = command._generate_help(color=False)
     assert_true(
         "PX PX" in help,
-        msg="number_of_values(2) with metavar PX should show 'PX PX'",
+        msg="number_of_values(2) with value_name PX should show 'PX PX'",
     )
 
 

--- a/tests/test_remainder_known.mojo
+++ b/tests/test_remainder_known.mojo
@@ -299,6 +299,76 @@ fn test_hyphen_value_positional() raises:
     assert_equal(result.get_string("input"), "-")
 
 
+fn test_hyphen_value_multi_char_short() raises:
+    """Tests that '-x' is consumed as a positional when allow_hyphen_values
+    is set and '-x' is NOT a known option.  Without the flag, '-x' would
+    be treated as an unknown short option and error."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("pattern", help="Regex pattern")
+        .positional()
+        .required()
+        .allow_hyphen_values()
+    )
+
+    var args: List[String] = ["test", "-foo"]
+    var result = command.parse_arguments(args)
+    assert_equal(result.get_string("pattern"), "-foo")
+
+
+fn test_hyphen_value_long_token() raises:
+    """Tests that '--unknown-thing' is consumed as a positional when
+    allow_hyphen_values is set and it is not a known long option."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("expr", help="Expression")
+        .positional()
+        .required()
+        .allow_hyphen_values()
+    )
+
+    var args: List[String] = ["test", "--not-an-option"]
+    var result = command.parse_arguments(args)
+    assert_equal(result.get_string("expr"), "--not-an-option")
+
+
+fn test_hyphen_value_known_option_still_parsed() raises:
+    """Tests that a known option is still parsed normally even when the
+    current positional has allow_hyphen_values."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("verbose", help="Verbose").long("verbose").short("v").flag()
+    )
+    command.add_argument(
+        Argument("pattern", help="Pattern")
+        .positional()
+        .required()
+        .allow_hyphen_values()
+    )
+
+    # -v is a known short option → parsed as flag, not as positional.
+    var args: List[String] = ["test", "-v", "-foo"]
+    var result = command.parse_arguments(args)
+    assert_true(result.get_flag("verbose"))
+    assert_equal(result.get_string("pattern"), "-foo")
+
+
+fn test_hyphen_value_without_flag_errors() raises:
+    """Tests that without allow_hyphen_values, '-x' raises an error."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("input", help="Input").positional().required()
+    )
+
+    var args: List[String] = ["test", "-x"]
+    var failed = False
+    try:
+        _ = command.parse_arguments(args)
+    except:
+        failed = True
+    assert_true(failed, msg="'-x' without allow_hyphen_values should error")
+
+
 fn test_hyphen_value_with_other_positional() raises:
     """Tests '-' alongside a regular positional."""
     var command = Command("test", "Test app")
@@ -332,6 +402,39 @@ fn test_hyphen_value_with_option() raises:
     var args: List[String] = ["test", "--file", "-"]
     var result = command.parse_arguments(args)
     assert_equal(result.get_string("file"), "-")
+
+
+fn test_hyphen_value_in_parse_known() raises:
+    """Tests allow_hyphen_values with parse_known_arguments: unknown
+    dash tokens go to positional instead of unknown_args."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("verbose", help="Verbose").long("verbose").flag()
+    )
+    command.add_argument(
+        Argument("expr", help="Expression")
+        .positional()
+        .required()
+        .allow_hyphen_values()
+    )
+
+    var args: List[String] = ["test", "--verbose", "-pattern"]
+    var result = command.parse_known_arguments(args)
+    assert_true(result.get_flag("verbose"))
+    assert_equal(result.get_string("expr"), "-pattern")
+    assert_equal(len(result.get_unknown_args()), 0)
+
+
+fn test_remainder_guard_positional_after() raises:
+    """Tests that adding a positional after a remainder is rejected."""
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("rest", help="Rest").remainder())
+    var failed = False
+    try:
+        command.add_argument(Argument("extra", help="Extra").positional())
+    except:
+        failed = True
+    assert_true(failed, msg="positional after remainder should be rejected")
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/tests/test_remainder_known.mojo
+++ b/tests/test_remainder_known.mojo
@@ -1,0 +1,343 @@
+"""Tests for argmojo — remainder nargs, parse_known_arguments, 
+value_name rename, allow_hyphen_values."""
+
+from testing import assert_true, assert_false, assert_equal, TestSuite
+import argmojo
+from argmojo import Argument, Command, ParseResult
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# value_name (renamed from metavar)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+fn test_value_name_basic() raises:
+    """Tests that .value_name() sets the display name for help."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("output", help="Output file")
+        .long("output")
+        .short("o")
+        .value_name("FILE")
+    )
+    # Parse succeeds normally — value_name is purely cosmetic.
+    var args: List[String] = ["test", "--output", "data.csv"]
+    var result = command.parse_arguments(args)
+    assert_equal(result.get_string("output"), "data.csv")
+
+
+fn test_value_name_in_help() raises:
+    """Tests that value_name appears in help output."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("output", help="Output file")
+        .long("output")
+        .short("o")
+        .value_name("FILE")
+    )
+    # The help text should contain "FILE" instead of "<output>".
+    # We don't assert exact help format, just that it works without errors.
+    var args: List[String] = ["test", "--output", "out.txt"]
+    var result = command.parse_arguments(args)
+    assert_equal(result.get_string("output"), "out.txt")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# remainder()
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+fn test_remainder_basic() raises:
+    """Tests that remainder consumes all remaining tokens."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("cmd", help="Command to run").positional().required()
+    )
+    command.add_argument(
+        Argument("rest", help="Arguments for the command").remainder()
+    )
+
+    var args: List[String] = ["test", "gcc", "-Wall", "-O2", "main.c"]
+    var result = command.parse_arguments(args)
+    assert_equal(result.get_string("cmd"), "gcc")
+    var rest = result.get_list("rest")
+    assert_equal(len(rest), 3)
+    assert_equal(rest[0], "-Wall")
+    assert_equal(rest[1], "-O2")
+    assert_equal(rest[2], "main.c")
+
+
+fn test_remainder_empty() raises:
+    """Tests remainder with no trailing arguments."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("cmd", help="Command to run").positional().required()
+    )
+    command.add_argument(
+        Argument("rest", help="Arguments for the command").remainder()
+    )
+
+    var args: List[String] = ["test", "gcc"]
+    var result = command.parse_arguments(args)
+    assert_equal(result.get_string("cmd"), "gcc")
+    var rest = result.get_list("rest")
+    assert_equal(len(rest), 0)
+
+
+fn test_remainder_only() raises:
+    """Tests remainder as the only positional."""
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("rest", help="All arguments").remainder())
+
+    var args: List[String] = ["test", "--flag", "-v", "file.txt"]
+    var result = command.parse_arguments(args)
+    var rest = result.get_list("rest")
+    assert_equal(len(rest), 3)
+    assert_equal(rest[0], "--flag")
+    assert_equal(rest[1], "-v")
+    assert_equal(rest[2], "file.txt")
+
+
+fn test_remainder_with_options_before() raises:
+    """Tests that options before the remainder positional slot are parsed normally.
+    """
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("verbose", help="Verbose").long("verbose").short("v").flag()
+    )
+    command.add_argument(
+        Argument("cmd", help="Command").positional().required()
+    )
+    command.add_argument(Argument("rest", help="Rest").remainder())
+
+    var args: List[String] = ["test", "--verbose", "gcc", "-O2", "main.c"]
+    var result = command.parse_arguments(args)
+    assert_true(result.get_flag("verbose"))
+    assert_equal(result.get_string("cmd"), "gcc")
+    var rest = result.get_list("rest")
+    assert_equal(len(rest), 2)
+    assert_equal(rest[0], "-O2")
+    assert_equal(rest[1], "main.c")
+
+
+fn test_remainder_captures_double_dash_tokens() raises:
+    """Tests that remainder captures -- and tokens after it."""
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("rest", help="All args").remainder())
+
+    var args: List[String] = ["test", "--", "-v", "--help"]
+    var result = command.parse_arguments(args)
+    # The "--" is consumed as the stop marker and remaining go to positionals.
+    # Remainder collects them all.
+    var rest = result.get_list("rest")
+    assert_equal(len(rest), 2)
+    assert_equal(rest[0], "-v")
+    assert_equal(rest[1], "--help")
+
+
+fn test_remainder_guard_no_long_short() raises:
+    """Tests that remainder rejects .long() or .short()."""
+    var command = Command("test", "Test app")
+    var failed = False
+    try:
+        command.add_argument(
+            Argument("rest", help="Rest").long("rest").remainder()
+        )
+    except:
+        failed = True
+    assert_true(failed, msg="remainder with .long() should be rejected")
+
+
+fn test_remainder_guard_only_one() raises:
+    """Tests that only one remainder positional is allowed."""
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("rest1", help="Rest 1").remainder())
+    var failed = False
+    try:
+        command.add_argument(Argument("rest2", help="Rest 2").remainder())
+    except:
+        failed = True
+    assert_true(failed, msg="second remainder should be rejected")
+
+
+fn test_remainder_with_dashes_in_values() raises:
+    """Tests that remainder captures tokens like --unknown and -x."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("cmd", help="Command").positional().required()
+    )
+    command.add_argument(Argument("args", help="Forwarded args").remainder())
+
+    var args: List[String] = [
+        "test",
+        "cmake",
+        "-DCMAKE_BUILD_TYPE=Release",
+        "--preset",
+        "default",
+    ]
+    var result = command.parse_arguments(args)
+    assert_equal(result.get_string("cmd"), "cmake")
+    var rest = result.get_list("args")
+    assert_equal(len(rest), 3)
+    assert_equal(rest[0], "-DCMAKE_BUILD_TYPE=Release")
+    assert_equal(rest[1], "--preset")
+    assert_equal(rest[2], "default")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# parse_known_arguments()
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+fn test_parse_known_basic() raises:
+    """Tests that unknown options are collected instead of erroring."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("verbose", help="Verbose").long("verbose").short("v").flag()
+    )
+
+    var args: List[String] = ["test", "--verbose", "--unknown", "-x"]
+    var result = command.parse_known_arguments(args)
+    assert_true(result.get_flag("verbose"))
+    var unknown = result.get_unknown_args()
+    assert_equal(len(unknown), 2)
+    assert_equal(unknown[0], "--unknown")
+    assert_equal(unknown[1], "-x")
+
+
+fn test_parse_known_no_unknowns() raises:
+    """Tests parse_known_arguments with all args recognized."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("verbose", help="Verbose").long("verbose").flag()
+    )
+    command.add_argument(
+        Argument("output", help="Output").long("output").short("o")
+    )
+
+    var args: List[String] = ["test", "--verbose", "--output", "file.txt"]
+    var result = command.parse_known_arguments(args)
+    assert_true(result.get_flag("verbose"))
+    assert_equal(result.get_string("output"), "file.txt")
+    var unknown = result.get_unknown_args()
+    assert_equal(len(unknown), 0)
+
+
+fn test_parse_known_mixed_with_positionals() raises:
+    """Tests parse_known_arguments with positionals and unknown options."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("file", help="Input file").positional().required()
+    )
+    command.add_argument(
+        Argument("verbose", help="Verbose").long("verbose").flag()
+    )
+
+    var args: List[String] = [
+        "test",
+        "--verbose",
+        "input.txt",
+        "--unknown-flag",
+    ]
+    var result = command.parse_known_arguments(args)
+    assert_true(result.get_flag("verbose"))
+    assert_equal(result.get_string("file"), "input.txt")
+    var unknown = result.get_unknown_args()
+    assert_equal(len(unknown), 1)
+    assert_equal(unknown[0], "--unknown-flag")
+
+
+fn test_parse_known_unknown_with_value() raises:
+    """Tests that unknown long options with = syntax are collected."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("verbose", help="Verbose").long("verbose").flag()
+    )
+
+    var args: List[String] = ["test", "--verbose", "--color=auto"]
+    var result = command.parse_known_arguments(args)
+    assert_true(result.get_flag("verbose"))
+    var unknown = result.get_unknown_args()
+    assert_equal(len(unknown), 1)
+    assert_equal(unknown[0], "--color=auto")
+
+
+fn test_parse_known_preserves_validation() raises:
+    """Tests that parse_known_arguments still validates required args."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("output", help="Output").long("output").required()
+    )
+
+    var args: List[String] = ["test", "--unknown"]
+    var failed = False
+    try:
+        _ = command.parse_known_arguments(args)
+    except:
+        failed = True
+    assert_true(failed, msg="required arg validation should still apply")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# allow_hyphen_values() / stdin convention
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+fn test_hyphen_value_positional() raises:
+    """Tests that '-' is accepted as a positional value."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("input", help="Input (- for stdin)")
+        .positional()
+        .required()
+        .allow_hyphen_values()
+    )
+
+    # A bare "-" already works as a positional because len("-") == 1,
+    # so the short-option check (len > 1) skips it.
+    var args: List[String] = ["test", "-"]
+    var result = command.parse_arguments(args)
+    assert_equal(result.get_string("input"), "-")
+
+
+fn test_hyphen_value_with_other_positional() raises:
+    """Tests '-' alongside a regular positional."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("input", help="Input")
+        .positional()
+        .required()
+        .allow_hyphen_values()
+    )
+    command.add_argument(
+        Argument("output", help="Output").positional().default("out.txt")
+    )
+
+    var args: List[String] = ["test", "-", "result.csv"]
+    var result = command.parse_arguments(args)
+    assert_equal(result.get_string("input"), "-")
+    assert_equal(result.get_string("output"), "result.csv")
+
+
+fn test_hyphen_value_with_option() raises:
+    """Tests that '-' works as a value for a named option."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("file", help="File (- for stdin)")
+        .long("file")
+        .short("f")
+        .allow_hyphen_values()
+    )
+
+    # --file - should take "-" as the value.
+    var args: List[String] = ["test", "--file", "-"]
+    var result = command.parse_arguments(args)
+    assert_equal(result.get_string("file"), "-")
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Test runner
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+fn main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
This PR renames the `metavar` API to `value_name` and adds new parsing capabilities for remainder positionals, hyphen-as-value handling, and partial/known-arg parsing.

**Changes:**
- Renamed `.metavar()` to `.value_name()` across core code, docs, examples, and tests.
- Added remainder positional support (`.remainder()`) and updated usage/help formatting to show `...`.
- Added `Command.parse_known_arguments()` and `ParseResult.get_unknown_args()` plus new tests and documentation.