### PR TITLE
[core] Add argument goups in help message

### DIFF
--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -78,6 +78,8 @@ These features appear across multiple libraries and depend only on string operat
 | Mutual implication (`implies`)     | —        | —     | —     | —    | ArgMojo unique feature       | **Done**      |
 | Stdin value (`-` convention)       | —        | —     | ✓     | —    | Unix convention              | Phase 5       |
 | Shell completion script generation | —        | ✓     | ✓     | ✓    | bash / zsh / fish            | **Done**      |
+| Argument groups in help            | ✓        | —     | ✓     | ✓    |                              | **Done**      |
+| Value-name wrapping control        | —        | —     | —     | ✓    | clap, cargo, pixi, git       | **Done**      |
 | CJK-aware help formatting          | —        | —     | —     | —    | I need it personally         | **Done**      |
 | CJK full-to-half-width correction  | —        | —     | —     | —    | I need it personally         | **Done**      |
 | CJK punctuation detection          | —        | —     | —     | —    | I need it personally         | **Done**      |
@@ -146,7 +148,7 @@ src/argmojo/
 ├── command.mojo                    # Command struct — command definition & parsing
 ├── parse_result.mojo               # ParseResult struct — parsed values
 └── utils.mojo                      # Internal utilities — ANSI colours, display helpers
-tests/                              # 424 tests across 15 files
+tests/
 ├── test_parse.mojo                 # Core parsing tests (flags, values, shorts, etc.)
 ├── test_groups.mojo                # Group constraint tests (exclusive, conditional, etc.)
 ├── test_collect.mojo               # Collection feature tests (append, delimiter, number_of_values)
@@ -161,11 +163,13 @@ tests/                              # 424 tests across 15 files
 ├── test_const_require_equals.mojo  # default_if_no_value and require_equals tests
 ├── test_response_file.mojo         # response file (@args.txt) expansion tests
 ├── test_remainder_known.mojo       # remainder, parse_known_arguments, allow_hyphen_values tests
-└── test_fullwidth.mojo             # full-width → half-width auto-correction tests
+├── test_fullwidth.mojo             # full-width → half-width auto-correction tests
+└── test_groups_help.mojo           # argument groups in help + value_name wrapping tests
 examples/
 ├── demo.mojo                       # comprehensive showcase of all ArgMojo features
 ├── mgrep.mojo                      # grep-like CLI example (no subcommands)
-└── mgit.mojo                       # git-like CLI example (with subcommands)
+├── mgit.mojo                       # git-like CLI example (with subcommands)
+└── yu.mojo                         # Chinese-language CLI example (CJK-aware help)
 ```
 
 ### 4.2 What's Already Done ✓
@@ -566,7 +570,7 @@ Before adding Phase 5 features, further decompose `parse_arguments()` for readab
 - [x] **Range clamping** — `.range[min, max]().clamp()` adjusts out-of-range values to the nearest boundary with a warning instead of erroring (Click has `IntRange(clamp=True)`)
 - [x] **Colored error output** — ANSI styled error messages (help output already colored)
 - [x] **Shell completion script generation** — `generate_completion("bash"|"zsh"|"fish")` returns a complete completion script; static approach (no runtime hook), covers options/flags/choices/subcommands (clap `generate`, cobra `completion`, click `shell_complete`)
-- [ ] **Argument groups in help** — group related options under headings (argparse add_argument_group)
+- [x] **Argument groups in help** — `.group("name")` groups related options under headings; independent per-section padding; persistent args stay in "Global Options:" (argparse `add_argument_group`) (PR #17)
 - [ ] **Usage line customisation** — two approaches: (1) manual override via `.usage("...")` for git-style hand-written usage strings (e.g. `[-v | --version] [-h | --help] [-C <path>] ...`); (2) auto-expanded mode that enumerates every flag inline like argparse (good for small CLIs, noisy for large ones). Current default `[OPTIONS]` / `<COMMAND>` is the cobra/clap/click convention and is the right default.
 - [x] **Partial parsing** — `parse_known_arguments()` collects unrecognised options instead of erroring; access via `result.get_unknown_args()` (argparse `parse_known_args`) (PR #13)
 - [x] **Require equals syntax** — `.require_equals()` forces `--key=value`, disallows `--key value` (clap `require_equals`) (PR #12)
@@ -585,6 +589,7 @@ Before adding Phase 5 features, further decompose `parse_arguments()` for readab
 - [x] **Subcommand aliases** — `sub.command_aliases(["co"])` registers shorthand names; typo suggestions and completions search aliases too (cobra `Command.Aliases`, clap `Command::alias`)
 - [x] **Hidden subcommands** — `sub.hidden()` — exclude from the "Commands:" section in help, completions, and error messages; dispatchable by exact name or alias (clap `Command::hide`, cobra `Hidden`) (PR #9)
 - [x] **`NO_COLOR` env variable** — honour the [no-color.org](https://no-color.org/) standard: if env `NO_COLOR` is set (any value, including empty), suppress all ANSI colour output; lower priority than explicit `.color(False)` API call (PR #9)
+- [x] **Value-name wrapping control** — `.value_name[wrapped: Bool = True]("NAME")` displays custom value names in `<NAME>` by default (matching clap/cargo/pixi/git convention); pass `False` for bare display (PR #17)
 
 #### Explicitly Out of Scope in This Phase
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,12 @@ Comment out unreleased changes here. This file will be edited just before each r
 8. **CJK-aware help alignment.** Help output now computes column padding using terminal display width instead of byte length. CJK ideographs and fullwidth characters are correctly treated as 2-column-wide, so help descriptions stay aligned when option names, positional names, or subcommand names contain Chinese, Japanese, or Korean characters. ANSI escape sequences are skipped during width calculation. No API changes — this is automatic (PR #14).
 9. **Full-width → half-width auto-correction.** When CJK users forget to switch input methods and type fullwidth ASCII (e.g., `－－ｖｅｒｂｏｓｅ` instead of `--verbose`, or `＝` instead of `=`), ArgMojo auto-detects and corrects these characters with a coloured warning. Fullwidth spaces (`U+3000`) embedded in a token cause it to be split into multiple arguments. All tokens containing fullwidth ASCII are normalized; only option tokens (starting with `-` after correction) trigger a warning. Disabled via `disable_fullwidth_correction()` (PR #15).
 10. **CJK punctuation auto-correction.** Common CJK punctuation outside the fullwidth ASCII range is also corrected — for example, em-dash (`——verbose`) is converted to `--verbose`. This runs as a separate pass after fullwidth correction. Disabled via `disable_punctuation_correction()` (PR #16).
+11. **Argument groups in help.** Add `.group("name")` builder method on `Argument`. Arguments assigned to the same group are displayed under a dedicated heading in `--help` output, in first-appearance order. Ungrouped arguments remain under the default "Options:" heading. Persistent arguments are collected under "Global Options:" as before (PR #17).
+12. **Value-name wrapping control.** Change `.value_name()` to accept a compile-time `wrapped` parameter: `.value_name[wrapped: Bool = True]("NAME")`. When `wrapped` is `True` (the default), the custom value name is displayed in angle brackets (`<NAME>`) in help output — matching the convention used by clap, cargo, pixi, and git. When `wrapped` is `False`, the value name is displayed bare (`NAME`). The auto-generated default placeholder (`<arg_name>`) is not affected (PR #17).
+
+### ⚠️ Breaking changes
+
+- **Value-name display now uses angle brackets by default.** Custom value names set via `.value_name("FOO")` are now rendered as `<FOO>` in help output. To preserve the old behaviour (bare `FOO`), use `.value_name[False]("FOO")`. This only affects custom value names — the auto-generated placeholder was already wrapped in `<>` (PR #17).
 
 ### 🔧 Fixes and API changes
 
@@ -37,6 +43,7 @@ Comment out unreleased changes here. This file will be edited just before each r
 - Add `tests/test_response_file.mojo` with 17 tests covering basic expansion, comments, whitespace stripping, escape, recursive nesting, depth limit, custom prefix, disabled-by-default, and error handling (PR #12).
 - Add `tests/test_remainder_known.mojo` with 18 tests covering remainder positionals, `parse_known_arguments()`, `allow_hyphen_values()`, and the `value_name` rename (PR #13).
 - Add `tests/test_fullwidth.mojo` with 30 tests covering full-width → half-width auto-correction and CJK punctuation correction, including utility functions, fullwidth flags, equals syntax, embedded fullwidth spaces, opt-out, choices validation, merged short flags, subcommand dispatch, parse_known_arguments, and CJK punctuation em-dash correction (PR #15, #16).
+- Add `tests/test_groups_help.mojo` with 25 tests covering argument groups in help output and value-name wrapping control, including basic grouping, multiple groups, independent padding, hidden arguments in groups, groups with subcommands, wrapped/unwrapped value names with append/nargs/require_equals/default_if_no_value, and coloured output (PR #17).
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,9 +6,9 @@ This document tracks all notable changes to ArgMojo, including new features, API
 Comment out unreleased changes here. This file will be edited just before each release to reflect the final changelog for that version.
 -->
 
-## Unreleased
+## Unreleased (v0.4.0)
 
-### ⭐️ New features
+### ⭐️ New features in v0.4.0
 
 1. Add `.default_if_no_value("value")` builder method for default-if-no-value semantics. When an option has a default-if-no-value, it may appear without an explicit value: `--compress` uses the default-if-no-value, while `--compress=bzip2` uses the explicit value. For long options, `.default_if_no_value()` implies `.require_equals()`. For short options, `-c` uses the default-if-no-value while `-cbzip2` uses the attached value (PR #12).
 2. Add `.require_equals()` builder method. When set, long options reject space-separated syntax (`--key value`) and require `--key=value`. Can be used standalone (the value is mandatory via `=`) or combined with `.default_if_no_value()` (the value is optional; omitting it uses default-if-no-value) (PR #12).
@@ -23,21 +23,18 @@ Comment out unreleased changes here. This file will be edited just before each r
 11. **Argument groups in help.** Add `.group("name")` builder method on `Argument`. Arguments assigned to the same group are displayed under a dedicated heading in `--help` output, in first-appearance order. Ungrouped arguments remain under the default "Options:" heading. Persistent arguments are collected under "Global Options:" as before (PR #17).
 12. **Value-name wrapping control.** Change `.value_name()` to accept a compile-time `wrapped` parameter: `.value_name[wrapped: Bool = True]("NAME")`. When `wrapped` is `True` (the default), the custom value name is displayed in angle brackets (`<NAME>`) in help output — matching the convention used by clap, cargo, pixi, and git. When `wrapped` is `False`, the value name is displayed bare (`NAME`). The auto-generated default placeholder (`<arg_name>`) is not affected (PR #17).
 
-### ⚠️ Breaking changes
-
-- **Value-name display now uses angle brackets by default.** Custom value names set via `.value_name("FOO")` are now rendered as `<FOO>` in help output. To preserve the old behaviour (bare `FOO`), use `.value_name[False]("FOO")`. This only affects custom value names — the auto-generated placeholder was already wrapped in `<>` (PR #17).
-
-### 🔧 Fixes and API changes
+### 🦋 Changed in v0.4.0
 
 - **Rename `.metavar()` to `.value_name()`** across the entire API and documentation. The internal field is now `_value_name`. This follows clap's naming convention and better describes the purpose. There is no backward-compatible alias — all call sites must use `.value_name()` (PR #13).
+- **Value-name display now uses angle brackets by default.** Custom value names set via `.value_name("FOO")` are now rendered as `<FOO>` in help output. To preserve the old behaviour (bare `FOO`), use `.value_name[False]("FOO")`. This only affects custom value names — the auto-generated placeholder was already wrapped in `<>` (PR #17).
 
-### 🔧 Fixes
+### 🔧 Fixes in v0.4.0
 
 - Clarify documentation and docstrings: `default_if_no_value` does not "reject" `--key value`; it simply does not consume the next token as a value (PR #12, review feedback).
 - Fix cross-library comparison: click is described as "Python CLI framework" instead of incorrectly saying "built on top of argparse" (PR #12, review feedback).
 - Reject `.require_equals()` / `.default_if_no_value()` combined with `.number_of_values[N]()` at `add_argument()` time with a clear error (PR #12, review feedback).
 
-### 📚 Documentation and testing
+### 📚 Documentation and testing in v0.4.0
 
 - Add `tests/test_const_require_equals.mojo` with 30 tests covering default_if_no_value, require_equals, and their interactions with choices, append, prefix matching, merged short flags, persistent flags, and help formatting (PR #12).
 - Add `tests/test_response_file.mojo` with 17 tests covering basic expansion, comments, whitespace stripping, escape, recursive nesting, depth limit, custom prefix, disabled-by-default, and error handling (PR #12).

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -338,7 +338,7 @@ command.add_argument(
 
 ## Builder Method Compatibility
 
-The `Argument` builder has ~20 chainable methods, but not all combinations make sense. The diagrams below show **which methods can be used together** at a glance.
+The `Argument` builder has 27 chainable methods, and the `Command` struct has additional configuration methods and constraint methods. Not all combinations make sense. The diagrams below show **which methods can be used together** at a glance.
 
 ### ASCII Tree
 
@@ -356,7 +356,8 @@ Argument("name", help="...")
 ║   │   ├── .append()
 ║   │   │   ├── .delimiter(",")
 ║   │   │   └── .number_of_values[2]()
-║   │   └── .map_option()
+║   │   ├── .map_option()
+║   │   └── .allow_hyphen_values()               accept -x as a value, not option
 ║   │
 ║   ├── .flag()                            ← boolean, no value
 ║   │   └── .negatable()                     adds --no-X form
@@ -375,6 +376,8 @@ Argument("name", help="...")
 ║
 ╠══ Decorators (combine with any path above) ═══════════════════════════════════
 ║   .value_name("FILE")          display name in help      (value / positional)
+║   └── [wrapped=True]           wrap in <> (default); [False] = bare
+║   .group("Network")            section heading in help   (any)
 ║   .hidden()                    hide from --help          (any)
 ║   .aliases(["alt"])            alternative --names       (named only)
 ║   .deprecated("msg")           deprecation warning       (any)
@@ -388,13 +391,38 @@ Argument("name", help="...")
 ║   command.required_together(["a","b"])   all or none from the group
 ║   command.required_if("target","cond")   target required when cond is set
 ║   command.implies("trigger","implied")   auto-set implied when trigger is set
+║
+╠══ Command-level configuration (called on Command) ════════════════════════════
+║   command.help_on_no_arguments()              show help when invoked with no args
+║   command.allow_negative_numbers()            negative tokens treated as positionals
+║   command.allow_positional_with_subcommands() allow positionals + subcommands
+║   command.add_tip("...")                      custom tip shown in help footer
+║   command.command_aliases(["co"])             alternate names for this subcommand
+║   command.hidden()                            hide subcommand from help/completions
+║   command.disable_help_subcommand()           opt out of auto-added help subcommand
+║   ├── Colour customisation
+║   │   command.header_color("CYAN")            section header colour
+║   │   command.arg_color("GREEN")              argument name colour
+║   │   command.warn_color("YELLOW")            deprecation warning colour
+║   │   command.error_color("RED")              error message colour
+║   ├── Shell completion
+║   │   command.disable_default_completions()   disable built-in --completions
+║   │   command.completions_name("name")        custom trigger name
+║   │   command.completions_as_subcommand()     expose as subcommand instead
+║   ├── Response files
+║   │   command.response_file_prefix("@")       enable @args.txt expansion ⁵
+║   │   command.response_file_max_depth(10)     max recursive nesting depth ⁵
+║   └── CJK / i18n
+║       command.disable_fullwidth_correction()  disable fullwidth→halfwidth auto-fix
+║       command.disable_punctuation_correction()  disable CJK punctuation correction
 ╚═══════════════════════════════════════════════════════════════════════════════
 ```
 
 > **Reading guide:** Indentation shows "goes after" — e.g. `.clamp()` is
 > indented under `.range[min,max]()` because it requires range.  The three main
 > paths (value / flag / count) under *Named option* are **mutually
-> exclusive** — pick exactly one mode per argument.
+> exclusive** — pick exactly one mode per argument.  Command-level methods
+> are called on `Command`, not chained on `Argument`.
 
 ### Compatibility Table
 
@@ -415,7 +443,8 @@ The table below shows which builder methods can be used with each argument mode.
 | `.map_option()`                  |      ✓      |     —     |     —      |        —        |
 | `.negatable()`                   |      —      |     ✓     |     —      |        —        |
 | `.max[N]()`                      |      —      |     —     |     ✓      |        —        |
-| `.value_name("FILE")`            |      ✓      |     —     |     —      |        ✓        |
+| `.value_name("FILE")` ⁴          |      ✓      |     —     |     —      |        ✓        |
+| `.group("name")`                 |      ✓      |     ✓     |     ✓      |        ✓        |
 | `.hidden()`                      |      ✓      |     ✓     |     ✓      |        ✓        |
 | `.aliases(["alt"])`              |      ✓      |     ✓     |     ✓      |        —        |
 | `.deprecated("msg")`             |      ✓      |     ✓     |     ✓      |        ✓        |
@@ -430,7 +459,7 @@ The table below shows which builder methods can be used with each argument mode.
 | `command.required_if()` ³        |      ✓      |     ✓     |     ✓      |        —        |
 | `command.implies()` ³            |      ✓      |     ✓     |     ✓      |        —        |
 
-> ¹ Requires `.range[min,max]()` first.  ² Implies `.append()` automatically.  ³ Command-level method — takes argument names as strings, not chained on `Argument`.
+> ¹ Requires `.range[min,max]()` first.  ² Implies `.append()` automatically.  ³ Command-level method — takes argument names as strings, not chained on `Argument`.  ⁴ Accepts compile-time parameter: `.value_name[wrapped: Bool = True]("NAME")` — `True` wraps in `<NAME>`, `False` displays bare `NAME`.  ⁵ Response files temporarily disabled due to Mojo compiler bug.
 
 ## Short Option Details
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -19,6 +19,9 @@ from argmojo import Argument, Command
   - [Default Values](#default-values)
   - [Required Arguments](#required-arguments)
   - [Aliases](#aliases)
+- [Builder Method Compatibility](#builder-method-compatibility)
+  - [ASCII Tree](#ascii-tree)
+  - [Compatibility Table](#compatibility-table)
 - [Short Option Details](#short-option-details)
   - [Short Flag Merging](#short-flag-merging)
   - [Attached Short Values](#attached-short-values)
@@ -36,10 +39,6 @@ from argmojo import Argument, Command
   - [Positional Argument Count Validation](#positional-argument-count-validation)
   - [Numeric Range Validation](#numeric-range-validation)
   - [Range Clamping (`.clamp()`)](#range-clamping-clamp)
-- [Builder Method Compatibility](#builder-method-compatibility)
-  - [ASCII Tree](#ascii-tree)
-  - [Mermaid Diagram](#mermaid-diagram)
-  - [Compatibility Table](#compatibility-table)
 - [Group Constraints](#group-constraints)
   - [Mutually Exclusive Groups](#mutually-exclusive-groups)
   - [One-Required Groups](#one-required-groups)
@@ -61,6 +60,7 @@ from argmojo import Argument, Command
   - [Deprecated Arguments](#deprecated-arguments)
   - [Default-if-no-value](#default-if-no-value)
   - [Require Equals Syntax](#require-equals-syntax)
+  - [Argument Groups](#argument-groups)
   - [Auto-generated Help](#auto-generated-help)
   - [Custom Tips](#custom-tips)
   - [Version Display](#version-display)
@@ -335,6 +335,102 @@ command.add_argument(
         .aliases(alias_list^)
 )
 ```
+
+## Builder Method Compatibility
+
+The `Argument` builder has ~20 chainable methods, but not all combinations make sense. The diagrams below show **which methods can be used together** at a glance.
+
+### ASCII Tree
+
+```txt
+Argument("name", help="...")
+║
+╠══ Named option ═══════════════════════════════════════════════════════════════
+║   .long("x") ─── .short("x")             ← pick one or both
+║   │
+║   ├── [value mode] (default)             ← takes a string value
+║   │   ├── .required()
+║   │   ├── .default("val")
+║   │   ├── .choices(["a","b","c"])
+║   │   ├── .range[1, 100]() ─── .clamp()
+║   │   ├── .append()
+║   │   │   ├── .delimiter(",")
+║   │   │   └── .number_of_values[2]()
+║   │   └── .map_option()
+║   │
+║   ├── .flag()                            ← boolean, no value
+║   │   └── .negatable()                     adds --no-X form
+║   │
+║   └── .count()                           ← counter: -vvv → 3
+║       └── .max[3]()                        cap the counter
+║
+╠══ Positional ═════════════════════════════════════════════════════════════════
+║   .positional()                          ← matched by position
+║   ├── .required()
+║   ├── .default("val")
+║   ├── .choices(["a","b","c"])
+║   ├── .allow_hyphen_values()               accept -x as a value, not option
+║   └── .remainder()                         consume ALL remaining tokens
+║       └── (implies .allow_hyphen_values())
+║
+╠══ Decorators (combine with any path above) ═══════════════════════════════════
+║   .value_name("FILE")          display name in help      (value / positional)
+║   .hidden()                    hide from --help          (any)
+║   .aliases(["alt"])            alternative --names       (named only)
+║   .deprecated("msg")           deprecation warning       (any)
+║   .persistent()                inherit to subcommands    (named only)
+║   .default_if_no_value("val")  default-if-no-value       (value only)
+║   .require_equals()            force --key=value syntax  (named value only)
+║
+╠══ Command-level constraints (called on Command, not Argument) ════════════════
+║   command.mutually_exclusive(["a","b"])  at most one from the group
+║   command.one_required(["a","b"])        at least one from the group
+║   command.required_together(["a","b"])   all or none from the group
+║   command.required_if("target","cond")   target required when cond is set
+║   command.implies("trigger","implied")   auto-set implied when trigger is set
+╚═══════════════════════════════════════════════════════════════════════════════
+```
+
+> **Reading guide:** Indentation shows "goes after" — e.g. `.clamp()` is
+> indented under `.range[min,max]()` because it requires range.  The three main
+> paths (value / flag / count) under *Named option* are **mutually
+> exclusive** — pick exactly one mode per argument.
+
+### Compatibility Table
+
+The table below shows which builder methods can be used with each argument mode. **✓** = compatible, **—** = not applicable.
+
+| Method                           | Named value | `.flag()` | `.count()` | `.positional()` |
+| -------------------------------- | :---------: | :-------: | :--------: | :-------------: |
+| `.long("x")`                     |      ✓      |     ✓     |     ✓      |        —        |
+| `.short("x")`                    |      ✓      |     ✓     |     ✓      |        —        |
+| `.required()`                    |      ✓      |     ✓     |     ✓      |        ✓        |
+| `.default("val")`                |      ✓      |     —     |     —      |        ✓        |
+| `.choices(["a","b"])`            |      ✓      |     —     |     —      |        ✓        |
+| `.range[min,max]()`              |      ✓      |     —     |     —      |        —        |
+| `.clamp()`                       |     ✓ ¹     |     —     |     —      |        —        |
+| `.append()`                      |      ✓      |     —     |     —      |        —        |
+| `.delimiter(",")`                |     ✓ ²     |     —     |     —      |        —        |
+| `.number_of_values[N]()`         |     ✓ ²     |     —     |     —      |        —        |
+| `.map_option()`                  |      ✓      |     —     |     —      |        —        |
+| `.negatable()`                   |      —      |     ✓     |     —      |        —        |
+| `.max[N]()`                      |      —      |     —     |     ✓      |        —        |
+| `.value_name("FILE")`            |      ✓      |     —     |     —      |        ✓        |
+| `.hidden()`                      |      ✓      |     ✓     |     ✓      |        ✓        |
+| `.aliases(["alt"])`              |      ✓      |     ✓     |     ✓      |        —        |
+| `.deprecated("msg")`             |      ✓      |     ✓     |     ✓      |        ✓        |
+| `.persistent()`                  |      ✓      |     ✓     |     ✓      |        —        |
+| `.default_if_no_value("val")`    |      ✓      |     —     |     —      |        —        |
+| `.allow_hyphen_values()`         |      ✓      |     —     |     —      |        ✓        |
+| `.remainder()`                   |      —      |     —     |     —      |        ✓        |
+| `.require_equals()`              |      ✓      |     —     |     —      |        —        |
+| `command.mutually_exclusive()` ³ |      ✓      |     ✓     |     ✓      |        —        |
+| `command.one_required()` ³       |      ✓      |     ✓     |     ✓      |        —        |
+| `command.required_together()` ³  |      ✓      |     ✓     |     ✓      |        —        |
+| `command.required_if()` ³        |      ✓      |     ✓     |     ✓      |        —        |
+| `command.implies()` ³            |      ✓      |     ✓     |     ✓      |        —        |
+
+> ¹ Requires `.range[min,max]()` first.  ² Implies `.append()` automatically.  ³ Command-level method — takes argument names as strings, not chained on `Argument`.
 
 ## Short Option Details
 
@@ -1055,161 +1151,6 @@ myapp --port 50 --port 200 --port 0
 myapp --port 200
 # Error: Value 200 for '--port' is out of range [1, 100]
 ```
-
-## Builder Method Compatibility
-
-The `Argument` builder has ~20 chainable methods, but not all combinations make sense. The diagrams below show **which methods can be used together** at a glance.
-
-### ASCII Tree
-
-```txt
-Argument("name", help="...")
-║
-╠══ Named option ═══════════════════════════════════════════════════════════════
-║   .long("x") ─── .short("x")             ← pick one or both
-║   │
-║   ├── [value mode] (default)             ← takes a string value
-║   │   ├── .required()
-║   │   ├── .default("val")
-║   │   ├── .choices(["a","b","c"])
-║   │   ├── .range[1, 100]() ─── .clamp()
-║   │   ├── .append()
-║   │   │   ├── .delimiter(",")
-║   │   │   └── .number_of_values[2]()
-║   │   └── .map_option()
-║   │
-║   ├── .flag()                            ← boolean, no value
-║   │   └── .negatable()                     adds --no-X form
-║   │
-║   └── .count()                           ← counter: -vvv → 3
-║       └── .max[3]()                        cap the counter
-║
-╠══ Positional ═════════════════════════════════════════════════════════════════
-║   .positional()                          ← matched by position
-║   ├── .required()
-║   ├── .default("val")
-║   ├── .choices(["a","b","c"])
-║   ├── .allow_hyphen_values()               accept -x as a value, not option
-║   └── .remainder()                         consume ALL remaining tokens
-║       └── (implies .allow_hyphen_values())
-║
-╠══ Decorators (combine with any path above) ═══════════════════════════════════
-║   .value_name("FILE")          display name in help      (value / positional)
-║   .hidden()                    hide from --help          (any)
-║   .aliases(["alt"])            alternative --names       (named only)
-║   .deprecated("msg")           deprecation warning       (any)
-║   .persistent()                inherit to subcommands    (named only)
-║   .default_if_no_value("val")  default-if-no-value       (value only)
-║   .require_equals()            force --key=value syntax  (named value only)
-║
-╠══ Command-level constraints (called on Command, not Argument) ════════════════
-║   command.mutually_exclusive(["a","b"])  at most one from the group
-║   command.one_required(["a","b"])        at least one from the group
-║   command.required_together(["a","b"])   all or none from the group
-║   command.required_if("target","cond")   target required when cond is set
-║   command.implies("trigger","implied")   auto-set implied when trigger is set
-╚═══════════════════════════════════════════════════════════════════════════════
-```
-
-> **Reading guide:** Indentation shows "goes after" — e.g. `.clamp()` is
-> indented under `.range[min,max]()` because it requires range.  The three main
-> paths (value / flag / count) under *Named option* are **mutually
-> exclusive** — pick exactly one mode per argument.
-
-### Mermaid Diagram
-
-```mermaid
-flowchart LR
-    ARG["Argument(name, help)"]
-
-    ARG --> NAMED[".long() / .short()"]
-    ARG --> POS[".positional()"]
-
-    NAMED --> VAL["Value mode\n(default)"]
-    NAMED --> FLAG[".flag()"]
-    NAMED --> COUNT[".count()"]
-
-    VAL --> req1[".required()"]
-    VAL --> def1[".default()"]
-    VAL --> cho1[".choices()"]
-    VAL --> rng[".range[min,max]()"]
-    rng --> clp[".clamp()"]
-    VAL --> app[".append()"]
-    app --> delim[".delimiter()"]
-    app --> nvals[".number_of_values[N]()"]
-    VAL --> mapopt[".map_option()"]
-
-    FLAG --> neg[".negatable()"]
-    COUNT --> maxn[".max[N]()"]
-
-    POS --> req2[".required()"]
-    POS --> def2[".default()"]
-    POS --> cho2[".choices()"]
-    POS --> ahv[".allow_hyphen_values()"]
-    POS --> rem[".remainder()"]
-    rem -.-> ahv
-
-    ARG -.-> DEC["Decorators"]
-    DEC --> meta[".value_name()"]
-    DEC --> hid[".hidden()"]
-    DEC --> ali[".aliases()"]
-    DEC --> dep[".deprecated()"]
-    DEC --> per[".persistent()"]
-    DEC --> dinv[".default_if_no_value()"]
-    DEC --> reqeq[".require_equals()"]
-
-    ARG -.-> CMDCON["Command-level\nConstraints"]
-    CMDCON --> mutex["command.mutually_exclusive()"]
-    CMDCON --> onereq["command.one_required()"]
-    CMDCON --> reqtog["command.required_together()"]
-    CMDCON --> reqif["command.required_if()"]
-    CMDCON --> imp["command.implies()"]
-
-    style ARG fill:#e8f4fd,stroke:#333
-    style NAMED fill:#d4edda,stroke:#333
-    style POS fill:#d4edda,stroke:#333
-    style FLAG fill:#fff3cd,stroke:#333
-    style COUNT fill:#fff3cd,stroke:#333
-    style VAL fill:#fff3cd,stroke:#333
-    style DEC fill:#f0f0f0,stroke:#999,stroke-dasharray: 5 5
-    style CMDCON fill:#fce4ec,stroke:#999,stroke-dasharray: 5 5
-```
-
-### Compatibility Table
-
-The table below shows which builder methods can be used with each argument mode. **✓** = compatible, **—** = not applicable.
-
-| Method                           | Named value | `.flag()` | `.count()` | `.positional()` |
-| -------------------------------- | :---------: | :-------: | :--------: | :-------------: |
-| `.long("x")`                     |      ✓      |     ✓     |     ✓      |        —        |
-| `.short("x")`                    |      ✓      |     ✓     |     ✓      |        —        |
-| `.required()`                    |      ✓      |     ✓     |     ✓      |        ✓        |
-| `.default("val")`                |      ✓      |     —     |     —      |        ✓        |
-| `.choices(["a","b"])`            |      ✓      |     —     |     —      |        ✓        |
-| `.range[min,max]()`              |      ✓      |     —     |     —      |        —        |
-| `.clamp()`                       |     ✓ ¹     |     —     |     —      |        —        |
-| `.append()`                      |      ✓      |     —     |     —      |        —        |
-| `.delimiter(",")`                |     ✓ ²     |     —     |     —      |        —        |
-| `.number_of_values[N]()`         |     ✓ ²     |     —     |     —      |        —        |
-| `.map_option()`                  |      ✓      |     —     |     —      |        —        |
-| `.negatable()`                   |      —      |     ✓     |     —      |        —        |
-| `.max[N]()`                      |      —      |     —     |     ✓      |        —        |
-| `.value_name("FILE")`            |      ✓      |     —     |     —      |        ✓        |
-| `.hidden()`                      |      ✓      |     ✓     |     ✓      |        ✓        |
-| `.aliases(["alt"])`              |      ✓      |     ✓     |     ✓      |        —        |
-| `.deprecated("msg")`             |      ✓      |     ✓     |     ✓      |        ✓        |
-| `.persistent()`                  |      ✓      |     ✓     |     ✓      |        —        |
-| `.default_if_no_value("val")`    |      ✓      |     —     |     —      |        —        |
-| `.allow_hyphen_values()`         |      ✓      |     —     |     —      |        ✓        |
-| `.remainder()`                   |      —      |     —     |     —      |        ✓        |
-| `.require_equals()`              |      ✓      |     —     |     —      |        —        |
-| `command.mutually_exclusive()` ³ |      ✓      |     ✓     |     ✓      |        —        |
-| `command.one_required()` ³       |      ✓      |     ✓     |     ✓      |        —        |
-| `command.required_together()` ³  |      ✓      |     ✓     |     ✓      |        —        |
-| `command.required_if()` ³        |      ✓      |     ✓     |     ✓      |        —        |
-| `command.implies()` ³            |      ✓      |     ✓     |     ✓      |        —        |
-
-> ¹ Requires `.range[min,max]()` first.  ² Implies `.append()` automatically.  ³ Command-level method — takes argument names as strings, not chained on `Argument`.
 
 ## Group Constraints
 
@@ -1995,6 +1936,8 @@ This makes it immediately clear which subcommand triggered the error, especially
 
 **Value name** overrides the placeholder text shown for a value in help output. Without it, the argument's internal name is shown in angle brackets (e.g., `<output>`).
 
+By default, custom value names are also wrapped in angle brackets, matching the convention used by clap, cargo, pixi, and git. To display a bare value name without brackets, pass `wrapped=False` as a compile-time parameter.
+
 > Libraries with similar support: **argparse** (`metavar`), **clap** (`value_name`), **cobra** (`metavar`), **Click** (`metavar`).
 
 ```mojo
@@ -2015,11 +1958,24 @@ command.add_argument(
   -d, --max-depth <max-depth> Maximum directory depth
 ```
 
-**Help output (after `.value_name()`):**
+**Help output (after `.value_name()` — wrapped by default):**
 
 ```bash
-  -o, --output FILE           Output file path
-  -d, --max-depth N           Maximum directory depth
+  -o, --output <FILE>         Output file path
+  -d, --max-depth <N>         Maximum directory depth
+```
+
+**Unwrapped value name** — pass `False` to suppress the angle brackets:
+
+```mojo
+command.add_argument(
+    Argument("point", help="A 3D coordinate")
+    .long("point").number_of_values[3]().value_name[False]("COORD")
+)
+```
+
+```bash
+      --point COORD COORD COORD    A 3D coordinate
 ```
 
 Value name is purely cosmetic — it has no effect on parsing.
@@ -2176,6 +2132,53 @@ Options:
 ```
 
 **Combined with `.default_if_no_value()`** — see [Default-if-no-value](#default-if-no-value) above. When both are set, `--key` uses the default-if-no-value while `--key=val` uses the explicit value.
+
+### Argument Groups
+
+By default, all options appear under a single "Options:" heading in `--help`. Use `.group("name")` to organise related arguments under their own section heading.
+
+```mojo
+command.add_argument(
+    Argument("host", help="Server hostname")
+    .long("host").value_name("ADDR").group("Network")
+)
+command.add_argument(
+    Argument("port", help="Server port")
+    .long("port").short("P").group("Network")
+)
+command.add_argument(
+    Argument("output", help="Output file path")
+    .long("output").short("o").value_name("FILE").group("Output")
+)
+command.add_argument(
+    Argument("verbose", help="Increase verbosity")
+    .long("verbose").short("v").count()
+)
+```
+
+**Help output:**
+
+```bash
+Options:
+  -v, --verbose <verbose>    Increase verbosity
+  -h, --help                 Show this help message
+
+Network:
+      --host <ADDR>    Server hostname
+  -P, --port <port>    Server port
+
+Output:
+  -o, --output <FILE>    Output file path
+```
+
+**Key behaviours:**
+
+- **Ungrouped arguments** remain under "Options:".
+- **Group headings** appear in first-appearance order after "Options:".
+- **Persistent arguments** are collected under "Global Options:" regardless of their group.
+- **Hidden arguments** are excluded from all sections.
+- **Column padding** is computed independently per section, so each group aligns neatly.
+- Groups are purely cosmetic — they do not affect parsing or validation.
 
 ### Auto-generated Help
 

--- a/examples/demo.mojo
+++ b/examples/demo.mojo
@@ -11,7 +11,9 @@ conditional requirements, negatable flags, color customisation
 clamping, value delimiter, nargs, key-value map, aliases, deprecated args,
 negative number passthrough, allow_positional_with_subcommands, custom tips,
 help_on_no_arguments, default_if_no_value, require_equals, response files,
-remainder positionals, allow_hyphen_values, and parse_known_arguments.
+remainder positionals, allow_hyphen_values, parse_known_arguments,
+argument groups in help (.group()), and value_name wrapping control
+(.value_name[wrapped: Bool]()).
 
 Note: This demo looks very strange, but useful :D
 
@@ -160,6 +162,7 @@ fn main() raises:
         .long("host")
         .short("H")
         .value_name("ADDR")
+        .group("Network")
     )
     app.add_argument(
         Argument(
@@ -170,6 +173,7 @@ fn main() raises:
         .append()
         .range[1, 65535]()
         .clamp()
+        .group("Network")
     )
     var net_group: List[String] = ["host", "port"]
     app.required_together(net_group^)
@@ -181,12 +185,14 @@ fn main() raises:
         .long("save")
         .short("S")
         .flag()
+        .group("Output")
     )
     app.add_argument(
         Argument("output", help="Output file path (required with --save)")
         .long("output")
         .short("o")
         .value_name("FILE")
+        .group("Output")
     )
     app.required_if("output", "save")
 
@@ -195,7 +201,8 @@ fn main() raises:
         Argument("point", help="A 3D point (X Y Z)")
         .long("point")
         .number_of_values[3]()
-        .value_name("COORD")
+        .value_name[False]("COORD")
+        .group("Data")
     )
 
     # ── Value delimiter ──────────────────────────────────────────────────
@@ -204,6 +211,7 @@ fn main() raises:
         .long("tags")
         .short("t")
         .delimiter(",")
+        .group("Data")
     )
 
     # ── Key-value map ────────────────────────────────────────────────────
@@ -212,6 +220,7 @@ fn main() raises:
         .long("define")
         .short("D")
         .map_option()
+        .group("Data")
     )
 
     # ── Aliases ──────────────────────────────────────────────────────────
@@ -241,6 +250,7 @@ fn main() raises:
         .short("c")
         .default_if_no_value("gzip")
         .value_name("ALGO")
+        .group("Output")
     )
 
     # ── Require equals (standalone) ──────────────────────────────────────
@@ -251,6 +261,7 @@ fn main() raises:
         .require_equals()
         .value_name("CHAR")
         .default(",")
+        .group("Output")
     )
 
     # ── Hidden argument ──────────────────────────────────────────────────

--- a/pixi.toml
+++ b/pixi.toml
@@ -40,7 +40,8 @@ test = """\
     && mojo run -I src -D ASSERT=all tests/test_implies.mojo \
     && mojo run -I src -D ASSERT=all tests/test_const_require_equals.mojo \
     && mojo run -I src -D ASSERT=all tests/test_remainder_known.mojo \
-    && mojo run -I src -D ASSERT=all tests/test_fullwidth.mojo"""
+    && mojo run -I src -D ASSERT=all tests/test_fullwidth.mojo \
+    && mojo run -I src -D ASSERT=all tests/test_groups_help.mojo"""
 # NOTE: test_response_file.mojo is excluded — response file expansion
 # is temporarily disabled to work around a Mojo compiler deadlock
 # with -D ASSERT=all.  Re-enable when the compiler bug is fixed.

--- a/src/argmojo/argument.mojo
+++ b/src/argmojo/argument.mojo
@@ -134,6 +134,13 @@ struct Argument(Copyable, Movable, Stringable, Writable):
     var _allow_hyphen_values: Bool
     """If True, the literal token ``-`` is accepted as a valid value for
     this argument (conventionally meaning stdin/stdout)."""
+    var _value_name_wrapped: Bool
+    """If True, the value_name is displayed wrapped in angle brackets
+    (e.g. ``<FILE>`` instead of ``FILE``).  Defaults to True."""
+    var _group: String
+    """Help-output group name for this argument.  Arguments with the same
+    group name are displayed together under a shared heading.  Empty
+    string means ungrouped (shown under the default 'Options:' heading)."""
 
     # ===------------------------------------------------------------------=== #
     # Life cycle methods
@@ -178,6 +185,8 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         self._require_equals = False
         self._is_remainder = False
         self._allow_hyphen_values = False
+        self._value_name_wrapped = True
+        self._group = ""
 
     fn __copyinit__(out self, copy: Self):
         """Creates a copy of this argument.
@@ -221,6 +230,8 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         self._require_equals = copy._require_equals
         self._is_remainder = copy._is_remainder
         self._allow_hyphen_values = copy._allow_hyphen_values
+        self._value_name_wrapped = copy._value_name_wrapped
+        self._group = copy._group
 
     fn __moveinit__(out self, deinit move: Self):
         """Moves the value from another Argument.
@@ -260,6 +271,8 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         self._require_equals = move._require_equals
         self._is_remainder = move._is_remainder
         self._allow_hyphen_values = move._allow_hyphen_values
+        self._value_name_wrapped = move._value_name_wrapped
+        self._group = move._group^
 
     # ===------------------------------------------------------------------=== #
     # Builder methods for configuring the argument
@@ -361,11 +374,15 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         self._choice_values = values^
         return self^
 
-    fn value_name(var self, name: String) -> Self:
+    fn value_name[wrapped: Bool = True](var self, name: String) -> Self:
         """Sets the display name for the value in help text.
 
-        For example, ``.value_name("FILE")`` causes help to show ``--output FILE``
-        instead of ``--output OUTPUT``.
+        When *wrapped* is True (default), the name is displayed inside angle
+        brackets: ``--output <FILE>``.  When False, it is displayed bare:
+        ``--output FILE``.
+
+        Parameters:
+            wrapped: Wrap the display name in ``<>`` (default True).
 
         Args:
             name: The display name.
@@ -374,6 +391,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
             Self with the value_name set.
         """
         self._value_name = name
+        self._value_name_wrapped = wrapped
         return self^
 
     fn hidden(var self) -> Self:
@@ -738,6 +756,23 @@ struct Argument(Copyable, Movable, Stringable, Writable):
             Self with hyphen-value support enabled.
         """
         self._allow_hyphen_values = True
+        return self^
+
+    fn group(var self, name: String) -> Self:
+        """Assigns this argument to a named help-output group.
+
+        Arguments sharing the same group name are displayed together
+        under a dedicated heading in ``--help`` output (e.g.,
+        ``Network:`` or ``Authentication:``).  Ungrouped arguments
+        remain under the default ``Options:`` heading.
+
+        Args:
+            name: The group name (used as the section heading).
+
+        Returns:
+            Self with the group set.
+        """
+        self._group = name
         return self^
 
     # ===------------------------------------------------------------------=== #

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -3166,11 +3166,12 @@ struct Command(Copyable, Movable, Stringable, Writable):
         header_color: String,
         reset_code: String,
     ) -> String:
-        """Generates the 'Options:' and 'Global Options:' sections.
+        """Generates the 'Options:', group, and 'Global Options:' sections.
 
         Separates local options from persistent (global) options and
-        displays them under distinct headings.  Built-in ``--help`` and
-        ``--version`` are always appended to the local section.
+        displays them under distinct headings.  Options with a ``.group()``
+        are shown under their group heading.  Built-in ``--help`` and
+        ``--version`` are always appended to the ungrouped local section.
 
         Args:
             arg_color: ANSI colour code for argument names.
@@ -3184,6 +3185,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         var opt_colors = List[String]()
         var opt_helps = List[String]()
         var opt_persistent = List[Bool]()
+        var opt_groups = List[String]()
 
         for i in range(len(self.args)):
             if not self.args[i]._is_positional and not self.args[i]._is_hidden:
@@ -3246,7 +3248,12 @@ struct Command(Copyable, Movable, Stringable, Writable):
                         i
                     ]._has_default_if_no_value else String("")
                     if self.args[i]._value_name:
-                        var mv = self.args[i]._value_name
+                        var raw_mv = self.args[i]._value_name
+                        var mv: String
+                        if self.args[i]._value_name_wrapped:
+                            mv = "<" + raw_mv + ">"
+                        else:
+                            mv = raw_mv
                         var mv_plain = String("")
                         var mv_colored = String("")
                         for _r in range(repeat - 1):
@@ -3313,6 +3320,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 opt_plains.append(plain)
                 opt_colors.append(colored)
                 opt_persistent.append(self.args[i]._is_persistent)
+                opt_groups.append(self.args[i]._group)
                 # Append deprecation notice to help text if applicable.
                 var help = self.args[i].help_text
                 if self.args[i]._deprecated_msg:
@@ -3321,7 +3329,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                     help += "[deprecated: " + self.args[i]._deprecated_msg + "]"
                 opt_helps.append(help)
 
-        # Built-in options (always shown under local "Options:" section).
+        # Built-in options (always shown under local ungrouped "Options:" section).
         var help_plain = String("  -h, --help")
         var help_colored = (
             "  "
@@ -3347,10 +3355,12 @@ struct Command(Copyable, Movable, Stringable, Writable):
         opt_plains.append(help_plain)
         opt_colors.append(help_colored)
         opt_persistent.append(False)
+        opt_groups.append(String(""))
         opt_helps.append(String("Show this help message"))
         opt_plains.append(version_plain)
         opt_colors.append(version_colored)
         opt_persistent.append(False)
+        opt_groups.append(String(""))
         opt_helps.append(String("Show version"))
         if self._completions_enabled and not self._completions_is_subcommand:
             var comp_plain = String(
@@ -3370,6 +3380,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
             opt_plains.append(comp_plain)
             opt_colors.append(comp_colored)
             opt_persistent.append(False)
+            opt_groups.append(String(""))
             opt_helps.append(String("Generate shell completion script"))
 
         # Check if there are any persistent (global) options.
@@ -3379,35 +3390,78 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 has_global = True
                 break
 
-        # Compute padding width for local and global options separately.
-        var local_max: Int = 0
-        var global_max: Int = 0
-        for k in range(len(opt_plains)):
-            var w = _display_width(opt_plains[k])
-            if opt_persistent[k]:
-                if w > global_max:
-                    global_max = w
-            else:
-                if w > local_max:
-                    local_max = w
-        var local_pad = local_max + 4
-        var global_pad = global_max + 4
+        # Collect distinct group names in order of first appearance.
+        var group_names = List[String]()
+        for k in range(len(opt_groups)):
+            if opt_groups[k] and not opt_persistent[k]:
+                var found = False
+                for g in range(len(group_names)):
+                    if group_names[g] == opt_groups[k]:
+                        found = True
+                        break
+                if not found:
+                    group_names.append(opt_groups[k])
 
-        # Pass 2: assemble padded lines using coloured text.
-        # Local options.
+        # --- Helper: compute max display width for a subset of options ---
+        fn _section_pad(
+            plains: List[String],
+            persistent: List[Bool],
+            groups: List[String],
+            want_persistent: Bool,
+            want_group: String,
+        ) -> Int:
+            var mx: Int = 0
+            for idx in range(len(plains)):
+                if persistent[idx] != want_persistent:
+                    continue
+                if groups[idx] != want_group:
+                    continue
+                var w = _display_width(plains[idx])
+                if w > mx:
+                    mx = w
+            return mx + 4
+
+        # --- Ungrouped local options (Options:) ---
+        var ungrouped_pad = _section_pad(
+            opt_plains, opt_persistent, opt_groups, False, String("")
+        )
         var s = header_color + "Options:" + reset_code + "\n"
         for k in range(len(opt_plains)):
-            if not opt_persistent[k]:
+            if not opt_persistent[k] and not opt_groups[k]:
                 var line = opt_colors[k]
                 if opt_helps[k]:
-                    var padding = local_pad - _display_width(opt_plains[k])
+                    var padding = ungrouped_pad - _display_width(opt_plains[k])
                     for _p in range(padding):
                         line += " "
                     line += opt_helps[k]
                 s += line + "\n"
 
+        # --- Grouped local options (one section per group) ---
+        for g in range(len(group_names)):
+            var gname = group_names[g]
+            var gpad = _section_pad(
+                opt_plains, opt_persistent, opt_groups, False, gname
+            )
+            s += "\n" + header_color + gname + ":" + reset_code + "\n"
+            for k in range(len(opt_plains)):
+                if not opt_persistent[k] and opt_groups[k] == gname:
+                    var line = opt_colors[k]
+                    if opt_helps[k]:
+                        var padding = gpad - _display_width(opt_plains[k])
+                        for _p in range(padding):
+                            line += " "
+                        line += opt_helps[k]
+                    s += line + "\n"
+
         # Global (persistent) options — shown under a separate heading.
         if has_global:
+            var global_max: Int = 0
+            for k in range(len(opt_plains)):
+                if opt_persistent[k]:
+                    var w = _display_width(opt_plains[k])
+                    if w > global_max:
+                        global_max = w
+            var global_pad = global_max + 4
             s += "\n" + header_color + "Global Options:" + reset_code + "\n"
             for k in range(len(opt_plains)):
                 if opt_persistent[k]:

--- a/tests/test_const_require_equals.mojo
+++ b/tests/test_const_require_equals.mojo
@@ -481,8 +481,8 @@ fn test_help_const_with_value_name() raises:
 
     var help = command._generate_help(color=False)
     assert_true(
-        "--compress[=ALGO]" in help,
-        msg="help should show '--compress[=ALGO]': " + help,
+        "--compress[=<ALGO>]" in help,
+        msg="help should show '--compress[=<ALGO>]': " + help,
     )
 
 
@@ -498,8 +498,8 @@ fn test_help_require_equals_with_value_name() raises:
 
     var help = command._generate_help(color=False)
     assert_true(
-        "--output=FILE" in help,
-        msg="help should show '--output=FILE': " + help,
+        "--output=<FILE>" in help,
+        msg="help should show '--output=<FILE>': " + help,
     )
 
 

--- a/tests/test_groups_help.mojo
+++ b/tests/test_groups_help.mojo
@@ -1,0 +1,574 @@
+"""Tests for argmojo — argument groups in help output and value_name wrapping."""
+
+from testing import assert_true, assert_false, assert_equal, TestSuite
+import argmojo
+from argmojo import Argument, Command, ParseResult
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Argument groups in help
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+fn test_group_basic() raises:
+    """Options with .group() appear under a group heading in help."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("verbose", help="Verbose output")
+        .long("verbose")
+        .short("v")
+        .flag()
+    )
+    command.add_argument(
+        Argument("host", help="Server host")
+        .long("host")
+        .short("H")
+        .group("Network")
+    )
+    command.add_argument(
+        Argument("port", help="Server port")
+        .long("port")
+        .short("p")
+        .group("Network")
+    )
+
+    var help = command._generate_help(color=False)
+    assert_true(
+        "Network:" in help,
+        msg="help should contain 'Network:' group heading: " + help,
+    )
+    assert_true(
+        "Options:" in help,
+        msg="help should contain 'Options:' for ungrouped args: " + help,
+    )
+
+
+fn test_group_ungrouped_separate_from_grouped() raises:
+    """Ungrouped options appear under 'Options:' and grouped under their
+    own heading — they don't mix."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("verbose", help="Verbose output")
+        .long("verbose")
+        .short("v")
+        .flag()
+    )
+    command.add_argument(
+        Argument("host", help="Server host").long("host").group("Network")
+    )
+
+    var help = command._generate_help(color=False)
+    # --verbose should appear before "Network:" heading.
+    var opts_pos = help.find("Options:")
+    var net_pos = help.find("Network:")
+    var verbose_pos = help.find("--verbose")
+    var host_pos = help.find("--host")
+    assert_true(opts_pos >= 0, msg="Options: heading missing")
+    assert_true(net_pos >= 0, msg="Network: heading missing")
+    assert_true(
+        verbose_pos < net_pos,
+        msg="--verbose should appear before Network: heading",
+    )
+    assert_true(
+        host_pos > net_pos,
+        msg="--host should appear after Network: heading",
+    )
+
+
+fn test_group_multiple_groups() raises:
+    """Multiple groups each get their own heading, in first-appearance order."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("user", help="Username").long("user").group("Authentication")
+    )
+    command.add_argument(
+        Argument("host", help="Server host").long("host").group("Network")
+    )
+    command.add_argument(
+        Argument("pass", help="Password").long("pass").group("Authentication")
+    )
+    command.add_argument(
+        Argument("port", help="Server port").long("port").group("Network")
+    )
+
+    var help = command._generate_help(color=False)
+    var auth_pos = help.find("Authentication:")
+    var net_pos = help.find("Network:")
+    assert_true(auth_pos >= 0, msg="Authentication: heading missing")
+    assert_true(net_pos >= 0, msg="Network: heading missing")
+    # Authentication was registered first, so it should appear first.
+    assert_true(
+        auth_pos < net_pos,
+        msg="Authentication: should appear before Network:",
+    )
+    # Both --user and --pass should be under Authentication.
+    var user_pos = help.find("--user")
+    var pass_pos = help.find("--pass")
+    assert_true(
+        user_pos > auth_pos, msg="--user should be under Authentication:"
+    )
+    assert_true(
+        pass_pos > auth_pos, msg="--pass should be under Authentication:"
+    )
+    assert_true(
+        user_pos < net_pos,
+        msg="--user should be before Network:",
+    )
+    assert_true(
+        pass_pos < net_pos,
+        msg="--pass should be before Network:",
+    )
+
+
+fn test_group_no_groups_unchanged() raises:
+    """When no groups are used, help output is the same as before (only Options:).
+    """
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("verbose", help="Verbose output")
+        .long("verbose")
+        .short("v")
+        .flag()
+    )
+    command.add_argument(
+        Argument("output", help="Output file").long("output").short("o")
+    )
+
+    var help = command._generate_help(color=False)
+    assert_true("Options:" in help, msg="Options: heading should exist")
+    # Should have --verbose and --output under the same section.
+    var verbose_pos = help.find("--verbose")
+    var output_pos = help.find("--output")
+    var options_pos = help.find("Options:")
+    assert_true(verbose_pos > options_pos, msg="--verbose under Options:")
+    assert_true(output_pos > options_pos, msg="--output under Options:")
+
+
+fn test_group_builtin_options_ungrouped() raises:
+    """Built-in --help and --version always appear under Options:, not in groups.
+    """
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("host", help="Server host").long("host").group("Network")
+    )
+
+    var help = command._generate_help(color=False)
+    var options_pos = help.find("Options:")
+    var network_pos = help.find("Network:")
+    var help_pos = help.find("--help")
+    var version_pos = help.find("--version")
+    # --help and --version should be under Options:, before Network:.
+    assert_true(
+        help_pos > options_pos and help_pos < network_pos,
+        msg="--help should be under Options: before Network:",
+    )
+    assert_true(
+        version_pos > options_pos and version_pos < network_pos,
+        msg="--version should be under Options: before Network:",
+    )
+
+
+fn test_group_with_persistent() raises:
+    """Persistent (global) args go under Global Options:, not under groups."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("verbose", help="Verbose output")
+        .long("verbose")
+        .short("v")
+        .flag()
+        .persistent()
+    )
+    command.add_argument(
+        Argument("host", help="Server host").long("host").group("Network")
+    )
+
+    var sub = Command("sub", "A subcommand")
+    command.add_subcommand(sub^)
+
+    var help = command._generate_help(color=False)
+    assert_true("Options:" in help, msg="Options: heading missing")
+    assert_true("Network:" in help, msg="Network: heading missing")
+    assert_true(
+        "Global Options:" in help, msg="Global Options: heading missing"
+    )
+    # --verbose should be under Global Options:, after Network:.
+    var global_pos = help.find("Global Options:")
+    var verbose_pos = help.find("--verbose")
+    assert_true(
+        verbose_pos > global_pos,
+        msg="--verbose (persistent) should be under Global Options:",
+    )
+
+
+fn test_group_independent_padding() raises:
+    """Each group computes its own padding independently."""
+    var command = Command("test", "Test app")
+    # Group A: short names → small padding.
+    command.add_argument(
+        Argument("a", help="Alpha").long("a").flag().group("Short")
+    )
+    # Group B: long name → wider padding.
+    command.add_argument(
+        Argument("very-long-option-name", help="Beta")
+        .long("very-long-option-name")
+        .flag()
+        .group("Long")
+    )
+
+    var help = command._generate_help(color=False)
+    assert_true("Short:" in help, msg="Short: heading missing")
+    assert_true("Long:" in help, msg="Long: heading missing")
+    # Both option helptexts should be present and aligned within their sections.
+    assert_true("Alpha" in help, msg="Alpha help text missing")
+    assert_true("Beta" in help, msg="Beta help text missing")
+
+
+fn test_group_with_colored_output() raises:
+    """Group headings use the same header_color styling as Options:/Arguments:.
+    """
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("host", help="Server host").long("host").group("Network")
+    )
+
+    var help = command._generate_help(color=True)
+    # The group heading should be present (with ANSI codes, so just check the name).
+    assert_true(
+        "Network:" in help,
+        msg="Network: heading should be in coloured output: " + help,
+    )
+
+
+fn test_group_hidden_arg_not_shown() raises:
+    """Hidden args with a group are still excluded from help."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("secret", help="Secret option")
+        .long("secret")
+        .group("Internal")
+        .hidden()
+    )
+    command.add_argument(
+        Argument("public", help="Public option")
+        .long("public")
+        .group("Internal")
+    )
+
+    var help = command._generate_help(color=False)
+    assert_false("--secret" in help, msg="hidden arg should not appear in help")
+    # If the only non-hidden arg in a group exists, the heading should show.
+    assert_true("Internal:" in help, msg="Internal: heading should show")
+
+
+fn test_group_all_hidden_no_heading() raises:
+    """If all args in a group are hidden, the group heading should not appear.
+    """
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("debug1", help="Debug 1")
+        .long("debug1")
+        .group("Debug")
+        .hidden()
+    )
+    command.add_argument(
+        Argument("debug2", help="Debug 2")
+        .long("debug2")
+        .group("Debug")
+        .hidden()
+    )
+    command.add_argument(
+        Argument("verbose", help="Verbose output").long("verbose").flag()
+    )
+
+    var help = command._generate_help(color=False)
+    assert_false(
+        "Debug:" in help,
+        msg="group heading should not appear when all its args are hidden",
+    )
+
+
+fn test_group_does_not_affect_parsing() raises:
+    """Groups are purely cosmetic — they don't change parsing behavior."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("host", help="Host").long("host").group("Network")
+    )
+    command.add_argument(
+        Argument("port", help="Port").long("port").group("Network")
+    )
+
+    var args: List[String] = ["test", "--host", "localhost", "--port", "8080"]
+    var result = command.parse_arguments(args)
+    assert_equal(result.get_string("host"), "localhost")
+    assert_equal(result.get_string("port"), "8080")
+
+
+fn test_group_with_subcommand_help() raises:
+    """Group headings work correctly on subcommands too."""
+    var app = Command("app", "App")
+    var sub = Command("serve", "Start server")
+    sub.add_argument(
+        Argument("host", help="Server host").long("host").group("Network")
+    )
+    sub.add_argument(
+        Argument("port", help="Server port").long("port").group("Network")
+    )
+    sub.add_argument(Argument("workers", help="Worker count").long("workers"))
+    app.add_subcommand(sub^)
+
+    # Get the subcommand help directly (index 1; index 0 is auto-added 'help').
+    var sub_help = app.subcommands[1].copy()._generate_help(color=False)
+    assert_true(
+        "Network:" in sub_help, msg="Network: heading in subcommand help"
+    )
+    assert_true(
+        "Options:" in sub_help, msg="Options: heading in subcommand help"
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# value_name wrapping (angle brackets)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+fn test_value_name_wrapped_by_default() raises:
+    """The value_name is wrapped in <> by default."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("output", help="Output file")
+        .long("output")
+        .short("o")
+        .value_name("FILE")
+    )
+
+    var help = command._generate_help(color=False)
+    assert_true(
+        "<FILE>" in help,
+        msg="value_name should be wrapped in <> by default: " + help,
+    )
+
+
+fn test_value_name_unwrapped() raises:
+    """The value_name[False] displays without angle brackets."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("output", help="Output file")
+        .long("output")
+        .short("o")
+        .value_name[False]("FILE")
+    )
+
+    var help = command._generate_help(color=False)
+    assert_true(
+        " FILE" in help,
+        msg="value_name[False] should show bare FILE: " + help,
+    )
+    assert_false(
+        "<FILE>" in help,
+        msg="value_name[False] should NOT wrap in <>: " + help,
+    )
+
+
+fn test_value_name_wrapped_explicit() raises:
+    """The value_name[True] explicitly wraps in angle brackets."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("path", help="Path").long("path").value_name[True]("DIR")
+    )
+
+    var help = command._generate_help(color=False)
+    assert_true(
+        "<DIR>" in help, msg="value_name[True] should show <DIR>: " + help
+    )
+
+
+fn test_value_name_wrapped_with_append() raises:
+    """Wrapped value_name shows <ENV>... for append args."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("env", help="Target env")
+        .long("env")
+        .value_name("ENV")
+        .append()
+    )
+
+    var help = command._generate_help(color=False)
+    assert_true(
+        "<ENV>..." in help,
+        msg="append arg with wrapped value_name should show <ENV>...: " + help,
+    )
+
+
+fn test_value_name_unwrapped_with_append() raises:
+    """Unwrapped value_name shows ENV... for append args."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("env", help="Target env")
+        .long("env")
+        .value_name[False]("ENV")
+        .append()
+    )
+
+    var help = command._generate_help(color=False)
+    assert_true(
+        "ENV..." in help,
+        msg="append arg with unwrapped value_name should show ENV...: " + help,
+    )
+    assert_false(
+        "<ENV>..." in help,
+        msg="should not wrap when wrapped=False: " + help,
+    )
+
+
+fn test_value_name_wrapped_with_nargs() raises:
+    """Wrapped value_name with nargs repeats <N> <N>."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("point", help="X Y")
+        .long("point")
+        .number_of_values[2]()
+        .value_name("N")
+    )
+
+    var help = command._generate_help(color=False)
+    assert_true(
+        "<N> <N>" in help,
+        msg="wrapped nargs should show '<N> <N>': " + help,
+    )
+
+
+fn test_value_name_unwrapped_with_nargs() raises:
+    """Unwrapped value_name with nargs repeats N N."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("point", help="X Y")
+        .long("point")
+        .number_of_values[2]()
+        .value_name[False]("N")
+    )
+
+    var help = command._generate_help(color=False)
+    assert_true(
+        "N N" in help,
+        msg="unwrapped nargs should show 'N N': " + help,
+    )
+    assert_false(
+        "<N>" in help,
+        msg="should not wrap when wrapped=False: " + help,
+    )
+
+
+fn test_value_name_wrapped_require_equals() raises:
+    """Wrapped value_name with require_equals shows --output=<FILE>."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("output", help="Output file")
+        .long("output")
+        .require_equals()
+        .value_name("FILE")
+    )
+
+    var help = command._generate_help(color=False)
+    assert_true(
+        "--output=<FILE>" in help,
+        msg="require_equals + wrapped should show --output=<FILE>: " + help,
+    )
+
+
+fn test_value_name_wrapped_default_if_no_value() raises:
+    """Wrapped value_name with default_if_no_value shows --compress[=<ALGO>]."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("compress", help="Compression")
+        .long("compress")
+        .default_if_no_value("gzip")
+        .value_name("ALGO")
+    )
+
+    var help = command._generate_help(color=False)
+    assert_true(
+        "--compress[=<ALGO>]" in help,
+        msg="default_if_no_value + wrapped should show --compress[=<ALGO>]: "
+        + help,
+    )
+
+
+fn test_value_name_no_wrapping_does_not_affect_default_placeholder() raises:
+    """When no value_name is set, the default placeholder <name> is always used.
+    """
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("output", help="Output file").long("output"))
+
+    var help = command._generate_help(color=False)
+    assert_true(
+        "<output>" in help,
+        msg="default placeholder should always use <name>: " + help,
+    )
+
+
+fn test_value_name_colored_output_wrapped() raises:
+    """Wrapped value_name works correctly in coloured output."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("output", help="Output file").long("output").value_name("PATH")
+    )
+
+    var help = command._generate_help(color=True)
+    assert_true(
+        "<PATH>" in help,
+        msg="wrapped value_name should appear in coloured output: " + help,
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Combined — groups + value_name wrapping
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+fn test_group_with_value_name_wrapped() raises:
+    """Grouped option with wrapped value_name shows correctly."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("host", help="Server host")
+        .long("host")
+        .value_name("ADDR")
+        .group("Network")
+    )
+
+    var help = command._generate_help(color=False)
+    assert_true("Network:" in help, msg="Network: heading missing")
+    assert_true(
+        "<ADDR>" in help,
+        msg="wrapped value_name should appear in grouped option: " + help,
+    )
+
+
+fn test_group_with_value_name_unwrapped() raises:
+    """Grouped option with unwrapped value_name shows bare text."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("host", help="Server host")
+        .long("host")
+        .value_name[False]("ADDR")
+        .group("Network")
+    )
+
+    var help = command._generate_help(color=False)
+    assert_true("Network:" in help, msg="Network: heading missing")
+    assert_true(
+        " ADDR" in help,
+        msg="unwrapped value_name in group: " + help,
+    )
+    assert_false(
+        "<ADDR>" in help,
+        msg="should not wrap when wrapped=False: " + help,
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# Test runner
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+fn main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_help.mojo
+++ b/tests/test_help.mojo
@@ -127,8 +127,8 @@ fn test_append_in_help() raises:
         msg="append arg without value_name should show <tag>... in help",
     )
     assert_true(
-        "ENV..." in help,
-        msg="append arg with value_name should show ENV... in help",
+        "<ENV>..." in help,
+        msg="append arg with value_name should show <ENV>... in help",
     )
 
 
@@ -497,10 +497,10 @@ fn test_nargs_in_help() raises:
         "<point> <point>" in help,
         msg="number_of_values(2) should show '<point> <point>' in help",
     )
-    # --rgb should show N N N
+    # --rgb should show <N> <N> <N>
     assert_true(
-        "N N N" in help,
-        msg="number_of_values(3) with value_name should show 'N N N'",
+        "<N> <N> <N>" in help,
+        msg="number_of_values(3) with value_name should show '<N> <N> <N>'",
     )
     # Neither should have "..." since they are nargs, not plain append.
     assert_false(
@@ -521,8 +521,8 @@ fn test_nargs_with_value_name() raises:
 
     var help = command._generate_help(color=False)
     assert_true(
-        "PX PX" in help,
-        msg="number_of_values(2) with value_name PX should show 'PX PX'",
+        "<PX> <PX>" in help,
+        msg="number_of_values(2) with value_name PX should show '<PX> <PX>'",
     )
 
 


### PR DESCRIPTION
This PR adds help-output organization features to ArgMojo by introducing named argument groups in the generated `--help` text and by standardizing custom value-name placeholders to render with angle brackets by default.

**Changes:**
- Add `Argument.group("name")` and render grouped options under dedicated section headings in help output.
- Extend `Argument.value_name` to support a compile-time `wrapped` parameter, defaulting to wrapped `<NAME>` display in help.
- Update/expand tests, docs, examples, and the test runner to cover and document the new help formatting behavior.