### PR TITLE
[core] Convert color customization to a compile-time parameter of `StringLiteral` type

### DIFF
--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -407,7 +407,7 @@ The practical view — both dimensions checked together at parse time:
 - [x] **`-?` help alias** — `-?` accepted as an alias for `-h` / `--help` (common in Windows CLI tools, Java, MySQL, curl)
 - [x] **Help on no args** — `command.help_on_no_arguments()` shows help when invoked with no arguments (like git/docker/cargo)
 - [x] **Dynamic help padding** — help column alignment is computed from the longest option line instead of a fixed width
-- [x] **colored help output** — ANSI colors (bold+underline headers, colored arg names), with `color=False` opt-out and customisable colors via `header_color()` / `arg_color()`
+- [x] **colored help output** — ANSI colors (bold+underline headers, colored arg names), with `color=False` opt-out and customisable colors via `header_color["NAME"]()` / `arg_color["NAME"]()` (compile-time validated)
 - [x] **number of values (multi-value)** — `--point 1 2 3` consumes N values for one option (argparse `nargs`, clap `num_args`)
 - [x] **Conditional requirement** — `--output` required only when `--save` is present (cobra `MarkFlagRequiredWith`, clap `required_if_eq`)
 - [x] **Numeric range validation** — `.range[1, 65535]()` validates `--port` value is within range (no major library has this built-in)

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -401,10 +401,10 @@ Argument("name", help="...")
 ║   command.hidden()                            hide subcommand from help/completions
 ║   command.disable_help_subcommand()           opt out of auto-added help subcommand
 ║   ├── Colour customisation
-║   │   command.header_color("CYAN")            section header colour
-║   │   command.arg_color("GREEN")              argument name colour
-║   │   command.warn_color("YELLOW")            deprecation warning colour
-║   │   command.error_color("RED")              error message colour
+║   │   command.header_color["CYAN"]()          section header colour
+║   │   command.arg_color["GREEN"]()            argument name colour
+║   │   command.warn_color["YELLOW"]()          deprecation warning colour
+║   │   command.error_color["RED"]()            error message colour
 ║   ├── Shell completion
 ║   │   command.disable_default_completions()   disable built-in --completions
 ║   │   command.completions_name("name")        custom trigger name
@@ -2272,13 +2272,13 @@ The **header colour**, **argument-name colour**, **deprecation warning colour**,
 
 ```mojo
 var command = Command("myapp", "My app")
-command.header_color("BLUE")     # section headers in bright blue
-command.arg_color("GREEN")       # option/argument names in bright green
-command.warn_color("YELLOW")     # deprecation warnings (default: orange)
-command.error_color("MAGENTA")   # parse errors (default: red)
+command.header_color["BLUE"]()     # section headers in bright blue
+command.arg_color["GREEN"]()       # option/argument names in bright green
+command.warn_color["YELLOW"]()     # deprecation warnings (default: orange)
+command.error_color["MAGENTA"]()   # parse errors (default: red)
 ```
 
-Available colour names (case-insensitive):
+Available colour names (uppercase only):
 
 | Name      | ANSI code | Preview            |
 | --------- | --------- | ------------------ |
@@ -2292,7 +2292,7 @@ Available colour names (case-insensitive):
 | `WHITE`   | 97        | bright white       |
 | `ORANGE`  | 33        | orange/dark yellow |
 
-An unrecognised colour name raises an `Error` at runtime.
+An unrecognised colour name is caught at **compile time** — the program will not compile if you pass an invalid name.
 
 Padding calculation is always based on the **plain-text width** (without escape codes), so columns remain correctly aligned regardless of whether colour is enabled.
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -377,7 +377,7 @@ Argument("name", help="...")
 ╠══ Decorators (combine with any path above) ═══════════════════════════════════
 ║   .value_name("FILE")          display name in help      (value / positional)
 ║   └── [wrapped=True]           wrap in <> (default); [False] = bare
-║   .group("Network")            section heading in help   (any)
+║   .group("Network")            section heading in help   (named only)
 ║   .hidden()                    hide from --help          (any)
 ║   .aliases(["alt"])            alternative --names       (named only)
 ║   .deprecated("msg")           deprecation warning       (any)
@@ -444,7 +444,7 @@ The table below shows which builder methods can be used with each argument mode.
 | `.negatable()`                   |      —      |     ✓     |     —      |        —        |
 | `.max[N]()`                      |      —      |     —     |     ✓      |        —        |
 | `.value_name("FILE")` ⁴          |      ✓      |     —     |     —      |        ✓        |
-| `.group("name")`                 |      ✓      |     ✓     |     ✓      |        ✓        |
+| `.group("name")`                 |      ✓      |     ✓     |     ✓      |        —        |
 | `.hidden()`                      |      ✓      |     ✓     |     ✓      |        ✓        |
 | `.aliases(["alt"])`              |      ✓      |     ✓     |     ✓      |        —        |
 | `.deprecated("msg")`             |      ✓      |     ✓     |     ✓      |        ✓        |
@@ -2189,7 +2189,7 @@ command.add_argument(
 
 ```bash
 Options:
-  -v, --verbose <verbose>    Increase verbosity
+  -v, --verbose              Increase verbosity
   -h, --help                 Show this help message
 
 Network:

--- a/examples/demo.mojo
+++ b/examples/demo.mojo
@@ -114,8 +114,8 @@ fn main() raises:
     )
 
     # ── Color customisation ──────────────────────────────────────────────
-    app.header_color("CYAN")
-    app.arg_color("GREEN")
+    app.header_color["CYAN"]()
+    app.arg_color["GREEN"]()
 
     # ── Response file support ────────────────────────────────────────────
     app.response_file_prefix()  # enables @args.txt expansion

--- a/examples/demo.mojo
+++ b/examples/demo.mojo
@@ -13,7 +13,7 @@ negative number passthrough, allow_positional_with_subcommands, custom tips,
 help_on_no_arguments, default_if_no_value, require_equals, response files,
 remainder positionals, allow_hyphen_values, parse_known_arguments,
 argument groups in help (.group()), and value_name wrapping control
-(.value_name[wrapped: Bool]()).
+(.value_name("NAME") or .value_name[False]("NAME")).
 
 Note: This demo looks very strange, but useful :D
 

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -1089,100 +1089,95 @@ struct Command(Copyable, Movable, Stringable, Writable):
         """
         self._help_on_no_arguments = True
 
-    fn header_color(mut self, name: String) raises:
+    # [Mojo Miji]
+    # We set `name` as a parameter, instead of an argument, because we
+    # want to check at compile time that it is a valid colour name.
+    # If we made it an argument, the check would be deferred to runtime,
+    # which means that the users, rather than developers, may encounter
+    # errors about a wrong colour name in the terminal when they use
+    # the programme, no matter what colour name they type in.
+    fn header_color[name: StringLiteral](mut self):
         """Sets the colour for section headers (Usage, Arguments, Options).
 
         Headers are always rendered in **bold + underline**; this method
         controls only the foreground colour.
 
-        Accepted colour names (case-insensitive): ``RED``, ``GREEN``,
-        ``YELLOW``, ``BLUE``, ``MAGENTA``, ``PINK``, ``CYAN``, ``WHITE``,
-        ``ORANGE``.
+        Accepted colour names: ``RED``, ``GREEN``, ``YELLOW``, ``BLUE``,
+        ``MAGENTA``, ``PINK``, ``CYAN``, ``WHITE``, ``ORANGE``.
+        Invalid names are caught at compile time.
 
-        Args:
+        Parameters:
             name: The colour name.
-
-        Raises:
-            Error if the name is not recognised.
 
         Example:
 
         ```mojo
         from argmojo import Command
         var command = Command("myapp", "A sample application")
-        command.header_color("YELLOW")
+        command.header_color["YELLOW"]()
         ```
         """
-        self._header_color = _resolve_color(name)
+        self._header_color = _resolve_color[name]()
 
-    fn arg_color(mut self, name: String) raises:
+    fn arg_color[name: StringLiteral](mut self):
         """Sets the colour for option and argument names in help output.
 
-        Accepted colour names (case-insensitive): ``RED``, ``GREEN``,
-        ``YELLOW``, ``BLUE``, ``MAGENTA``, ``PINK``, ``CYAN``, ``WHITE``,
-        ``ORANGE``.
+        Accepted colour names: ``RED``, ``GREEN``, ``YELLOW``, ``BLUE``,
+        ``MAGENTA``, ``PINK``, ``CYAN``, ``WHITE``, ``ORANGE``.
+        Invalid names are caught at compile time.
 
-        Args:
+        Parameters:
             name: The colour name.
-
-        Raises:
-            Error if the name is not recognised.
 
         Example:
 
         ```mojo
         from argmojo import Command
         var command = Command("myapp", "A sample application")
-        command.arg_color("GREEN")
+        command.arg_color["GREEN"]()
         ```
         """
-        self._arg_color = _resolve_color(name)
+        self._arg_color = _resolve_color[name]()
 
-    fn warn_color(mut self, name: String) raises:
+    fn warn_color[name: StringLiteral](mut self):
         """Sets the colour for deprecation warning messages.
 
-        Accepted colour names (case-insensitive): ``RED``, ``GREEN``,
-        ``YELLOW``, ``BLUE``, ``MAGENTA``, ``PINK``, ``CYAN``, ``WHITE``,
-        ``ORANGE``.
+        Accepted colour names: ``RED``, ``GREEN``, ``YELLOW``, ``BLUE``,
+        ``MAGENTA``, ``PINK``, ``CYAN``, ``WHITE``, ``ORANGE``.
+        Invalid names are caught at compile time.
 
-        Args:
+        Parameters:
             name: The colour name.
-
-        Raises:
-            Error if the name is not recognised.
 
         Example:
 
         ```mojo
         from argmojo import Command
         var command = Command("myapp", "A sample application")
-        command.warn_color("YELLOW")  # change from default orange
+        command.warn_color["YELLOW"]()
         ```
         """
-        self._warn_color = _resolve_color(name)
+        self._warn_color = _resolve_color[name]()
 
-    fn error_color(mut self, name: String) raises:
+    fn error_color[name: StringLiteral](mut self):
         """Sets the colour for parse error messages.
 
-        Accepted colour names (case-insensitive): ``RED``, ``GREEN``,
-        ``YELLOW``, ``BLUE``, ``MAGENTA``, ``PINK``, ``CYAN``, ``WHITE``,
-        ``ORANGE``.
+        Accepted colour names: ``RED``, ``GREEN``, ``YELLOW``, ``BLUE``,
+        ``MAGENTA``, ``PINK``, ``CYAN``, ``WHITE``, ``ORANGE``.
+        Invalid names are caught at compile time.
 
-        Args:
+        Parameters:
             name: The colour name.
-
-        Raises:
-            Error if the name is not recognised.
 
         Example:
 
         ```mojo
         from argmojo import Command
         var command = Command("myapp", "A sample application")
-        command.error_color("MAGENTA")  # change from default red
+        command.error_color["MAGENTA"]()
         ```
         """
-        self._error_color = _resolve_color(name)
+        self._error_color = _resolve_color[name]()
 
     # ===------------------------------------------------------------------=== #
     # Private output helpers

--- a/src/argmojo/utils.mojo
+++ b/src/argmojo/utils.mojo
@@ -242,41 +242,51 @@ fn _is_ascii_digit(ch: String) -> Bool:
     return ch >= "0" and ch <= "9"
 
 
-fn _resolve_color(name: String) raises -> String:
-    """Maps a user-facing colour name to its ANSI code.
+fn _resolve_color[name: StringLiteral]() -> String:
+    """Maps a user-facing colour name to its ANSI code at compile time.
 
-    Accepted names (case-insensitive): RED, GREEN, YELLOW, BLUE,
+    Accepted names (uppercase only): RED, GREEN, YELLOW, BLUE,
     MAGENTA, PINK (alias for MAGENTA), CYAN, WHITE, ORANGE.
+
+    Parameters:
+        name: The colour name (must be one of the accepted names).
 
     Returns:
         The ANSI escape code for the colour.
-
-    Raises:
-        Error if the name is not recognised.
     """
-    var upper = name.upper()
-    if upper == "RED":
-        return _RED
-    if upper == "GREEN":
-        return _GREEN
-    if upper == "YELLOW":
-        return _YELLOW
-    if upper == "BLUE":
-        return _BLUE
-    if upper == "MAGENTA" or upper == "PINK":
-        return _MAGENTA
-    if upper == "CYAN":
-        return _CYAN
-    if upper == "WHITE":
-        return _WHITE
-    if upper == "ORANGE":
-        return _ORANGE
-    raise Error(
+    constrained[
+        name == "RED"
+        or name == "GREEN"
+        or name == "YELLOW"
+        or name == "BLUE"
+        or name == "MAGENTA"
+        or name == "PINK"
+        or name == "CYAN"
+        or name == "WHITE"
+        or name == "ORANGE",
         "Unknown colour '"
         + name
-        + "'. Choose from: RED, GREEN, YELLOW, BLUE, MAGENTA, PINK, CYAN,"
-        " WHITE, ORANGE"
-    )
+        + "'. Choose from: RED, GREEN, YELLOW, BLUE, MAGENTA, PINK,"
+        " CYAN, WHITE, ORANGE",
+    ]()
+
+    @parameter
+    if name == "RED":
+        return _RED
+    elif name == "GREEN":
+        return _GREEN
+    elif name == "YELLOW":
+        return _YELLOW
+    elif name == "BLUE":
+        return _BLUE
+    elif name == "MAGENTA" or name == "PINK":
+        return _MAGENTA
+    elif name == "CYAN":
+        return _CYAN
+    elif name == "WHITE":
+        return _WHITE
+    else:  # ORANGE
+        return _ORANGE
 
 
 fn _levenshtein(a: String, b: String) -> Int:

--- a/tests/test_help.mojo
+++ b/tests/test_help.mojo
@@ -338,7 +338,7 @@ fn test_custom_header_color() raises:
     """Setting header_color changes the header ANSI code in help output."""
     var command = Command("app", "My app")
     command.add_argument(Argument("file", help="Input file").long("file"))
-    command.header_color("RED")
+    command.header_color["RED"]()
 
     var help = command._generate_help(color=True)
     # RED = \x1b[91m ; bold+underline = \x1b[1;4m
@@ -359,7 +359,7 @@ fn test_custom_arg_color() raises:
     command.add_argument(
         Argument("verbose", help="Be verbose").long("verbose").flag()
     )
-    command.arg_color("GREEN")
+    command.arg_color["GREEN"]()
 
     var help = command._generate_help(color=True)
     # GREEN = \x1b[92m
@@ -378,8 +378,8 @@ fn test_custom_both_colors() raises:
     """Setting both header_color and arg_color at the same time."""
     var command = Command("app", "My app")
     command.add_argument(Argument("file", help="Input").long("file"))
-    command.header_color("BLUE")
-    command.arg_color("GREEN")
+    command.header_color["BLUE"]()
+    command.arg_color["GREEN"]()
 
     var help = command._generate_help(color=True)
     assert_true("\x1b[94m" in help, msg="Header should be blue (94)")
@@ -401,32 +401,20 @@ fn test_default_colors_unchanged() raises:
     assert_true("\x1b[95m" in help, msg="Default arg should be magenta (95)")
 
 
-fn test_color_case_insensitive() raises:
-    """Colour names are case-insensitive: 'green', 'Green', 'GREEN' all work."""
-    var command1 = Command("a", "A")
-    command1.add_argument(Argument("x", help="x").long("x"))
-    command1.header_color("green")
-    var h1 = command1._generate_help(color=True)
-    assert_true("\x1b[92m" in h1, msg="'green' lowercase should resolve")
-
-    var command2 = Command("a", "A")
-    command2.add_argument(Argument("x", help="x").long("x"))
-    command2.header_color("Green")
-    var h2 = command2._generate_help(color=True)
-    assert_true("\x1b[92m" in h2, msg="'Green' mixed case should resolve")
-
-    var command3 = Command("a", "A")
-    command3.add_argument(Argument("x", help="x").long("x"))
-    command3.header_color("GREEN")
-    var h3 = command3._generate_help(color=True)
-    assert_true("\x1b[92m" in h3, msg="'GREEN' uppercase should resolve")
+fn test_color_uppercase_only() raises:
+    """Colour names must be uppercase: 'GREEN' works."""
+    var command = Command("a", "A")
+    command.add_argument(Argument("x", help="x").long("x"))
+    command.header_color["GREEN"]()
+    var h = command._generate_help(color=True)
+    assert_true("\x1b[92m" in h, msg="'GREEN' uppercase should resolve")
 
 
 fn test_pink_alias_for_magenta() raises:
     """'PINK' is an alias for MAGENTA (\\x1b[95m)."""
     var command = Command("app", "My app")
     command.add_argument(Argument("f", help="File").long("file"))
-    command.arg_color("PINK")
+    command.arg_color["PINK"]()
 
     var help = command._generate_help(color=True)
     assert_true(
@@ -435,38 +423,25 @@ fn test_pink_alias_for_magenta() raises:
     )
 
 
-fn test_invalid_color_raises() raises:
-    """An unrecognised colour name should raise an Error."""
-    var command = Command("app", "My app")
-    var raised = False
-    try:
-        command.header_color("PURPLE")
-    except e:
-        raised = True
-        assert_true(
-            "Unknown colour" in String(e),
-            msg="Error message should mention 'Unknown colour'",
-        )
-    assert_true(raised, msg="header_color('PURPLE') should raise an error")
+fn test_invalid_color_caught_at_compile_time() raises:
+    """Invalid colour names are caught at compile time via constrained[].
 
-    raised = False
-    try:
-        command.arg_color("LIME")
-    except e:
-        raised = True
-        assert_true(
-            "Unknown colour" in String(e),
-            msg="Error message should mention 'Unknown colour'",
-        )
-    assert_true(raised, msg="arg_color('LIME') should raise an error")
+    This test simply verifies the valid path works.  An invalid name
+    like ``command.header_color["PURPLE"]()`` would fail to compile.
+    """
+    var command = Command("app", "My app")
+    command.header_color["RED"]()
+    command.arg_color["GREEN"]()
+    command.warn_color["YELLOW"]()
+    command.error_color["MAGENTA"]()
 
 
 fn test_custom_color_plain_mode_unaffected() raises:
     """Custom colours should not leak into plain (color=False) output."""
     var command = Command("app", "My app")
     command.add_argument(Argument("x", help="X option").long("x"))
-    command.header_color("RED")
-    command.arg_color("BLUE")
+    command.header_color["RED"]()
+    command.arg_color["BLUE"]()
 
     var help = command._generate_help(color=False)
     assert_false("\x1b" in help, msg="Plain mode should have no ANSI codes")


### PR DESCRIPTION
This PR updates ArgMojo’s color-customization API to use compile-time validated `StringLiteral` parameters (bracket syntax) instead of runtime `String`s, and aligns tests/docs/examples with the new calling convention.

**Changes:**
- Convert `_resolve_color` to a compile-time `StringLiteral`-parametric resolver with `constrained[]` validation.
- Update `Command.header_color/arg_color/warn_color/error_color` to accept compile-time parameters and call the new resolver.
- Refresh tests, examples, and user manual to use `command.*_color["NAME"]()` and document uppercase-only names + compile-time validation.