### PR TITLE
[core] Provide `generate_completion` overload that takes shell name as parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,15 +244,7 @@ argmojo/
 │       ├── command.mojo               # Command struct (parsing logic)
 │       ├── parse_result.mojo          # ParseResult struct (parsed values)
 │       └── utils.mojo                 # ANSI colour constants and utility functions
-├── tests/                             # Test suites (241 tests)
-│   ├── test_parse.mojo
-│   ├── test_groups.mojo
-│   ├── test_collect.mojo
-│   ├── test_help.mojo
-│   ├── test_extras.mojo
-│   ├── test_subcommands.mojo
-│   ├── test_negative_numbers.mojo
-│   └── test_persistent.mojo
+├── tests/                             # Test suites
 ├── pixi.toml                          # pixi configuration
 ├── LICENSE
 └── README.md

--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -174,63 +174,63 @@ examples/
 
 ### 4.2 What's Already Done ✓
 
-| Feature                                                                                            | Status | Tests |
-| -------------------------------------------------------------------------------------------------- | ------ | ----- |
-| `Argument` struct with builder pattern                                                             | ✓      | —     |
-| `Command` struct with `add_argument()`                                                             | ✓      | —     |
-| `ParseResult` with `get_flag()`, `get_string()`, `get_int()`, `has()`                              | ✓      | ✓     |
-| Long flags `--verbose`                                                                             | ✓      | ✓     |
-| Short flags `-v`                                                                                   | ✓      | ✓     |
-| Key-value `--key value`, `--key=value`, `-k value`                                                 | ✓      | ✓     |
-| Positional arguments                                                                               | ✓      | ✓     |
-| Default values for positional and named args                                                       | ✓      | ✓     |
-| Required argument validation                                                                       | ✓      | —     |
-| `--` stop marker                                                                                   | ✓      | ✓     |
-| Auto `--help` / `-h` with generated help text                                                      | ✓      | —     |
-| Auto `--version` / `-V`                                                                            | ✓      | —     |
-| Demo binary (`mojo build`)                                                                         | ✓      | —     |
-| Short flag merging (`-abc` → `-a -b -c`)                                                           | ✓      | ✓     |
-| Short option with attached value (`-ofile.txt`)                                                    | ✓      | ✓     |
-| Choices validation (`.choices()`)                                                                  | ✓      | ✓     |
-| Value Name (`.value_name("FILE")`)                                                                 | ✓      | ✓     |
-| Hidden arguments (`.hidden()`)                                                                     | ✓      | ✓     |
-| Count action (`-vvv` → 3) with ceiling (`.max(N)`)                                                 | ✓      | ✓     |
-| Positional arg count validation                                                                    | ✓      | ✓     |
-| Clean exit for `--help` / `--version`                                                              | ✓      | —     |
-| Mutually exclusive groups                                                                          | ✓      | ✓     |
-| Required-together groups                                                                           | ✓      | ✓     |
-| Negatable flags (`.negatable()` → `--no-X`)                                                        | ✓      | ✓     |
-| Long option prefix matching (`--verb` → `--verbose`)                                               | ✓      | ✓     |
-| Append / collect action (`--tag x --tag y` → list)                                                 | ✓      | ✓     |
-| One-required groups (`command.one_required(["json", "yaml"])`)                                     | ✓      | ✓     |
-| Value delimiter (`.delimiter(",")` → split into list)                                              | ✓      | ✓     |
-| Number of values (`.number_of_values[N]()` → consume N values per occurrence)                      | ✓      | ✓     |
-| Conditional requirements (`command.required_if("output", "save")`)                                 | ✓      | ✓     |
-| Numeric range validation (`.range[1, 65535]()`)                                                    | ✓      | ✓     |
-| Key-value map option (`.map_option()` → `Dict[String, String]`)                                    | ✓      | ✓     |
-| Aliases (`.aliases(["color"])` for `--colour` / `--color`)                                         | ✓      | ✓     |
-| Deprecated arguments (`.deprecated("msg")` → stderr warning)                                       | ✓      | ✓     |
-| Negative number passthrough (`-9`, `-3.14`, `-1.5e10` as positionals)                              | ✓      | ✓     |
-| Subcommand data model (`add_subcommand()`, dispatch, `help` sub)                                   | ✓      | ✓     |
-| Colored warning and error messages (`_warn()`, `_error()`, all errors printed in colour to stderr) | ✓      | ✓     |
-| Range clamping (`.range[1, 100]().clamp()` → adjust + warn instead of error)                       | ✓      | ✓     |
-| Default-if-no-value (`.default_if_no_value("gzip")` → optional value with fallback)                | ✓      | ✓     |
-| Require equals syntax (`.require_equals()` → `--key=value` only)                                   | ✓      | ✓     |
-| Response file (`command.response_file_prefix()` → `@args.txt` expands file contents)               | ✓ ⚠    | ✓     |
-| Typo suggestions (Levenshtein "did you mean ...?" for long options and subcommands)                | ✓      | ✓     |
-| Flag counter ceiling (`.count().max[3]()` → cap with warning)                                      | ✓      | ✓     |
-| Shell completion script generation (`generate_completion("bash"\|"zsh"\|"fish")`)                  | ✓      | ✓     |
-| Subcommand aliases (`command_aliases(["co"])`)                                                     | ✓      | ✓     |
-| Hidden subcommands (`sub.hidden()` → excluded from help, completions, errors)                      | ✓      | ✓     |
-| `NO_COLOR` env variable (suppress ANSI output when set)                                            | ✓      | ✓     |
-| Mutual implication (`command.implies("debug", "verbose")` with chained + cycle detection)          | ✓      | ✓     |
-| Remainder positional (`.remainder()` → consume all remaining tokens)                               | ✓      | ✓     |
-| Partial parsing (`parse_known_arguments()` → collect unknown options)                              | ✓      | ✓     |
-| Allow hyphen values (`.allow_hyphen_values()` → accept `-x` as positional value)                   | ✓      | ✓     |
-| Value name rename (`.metavar()` → `.value_name()`)                                                 | ✓      | ✓     |
-| CJK-aware help formatting (`_display_width` for column alignment)                                  | ✓      | ✓     |
-| Full-width → half-width auto-correction (fullwidth ASCII + `U+3000` space)                         | ✓      | ✓     |
-| CJK punctuation auto-correction (em-dash `U+2014` → hyphen-minus)                                  | ✓      | ✓     |
+| Feature                                                                                               | Status | Tests |
+| ----------------------------------------------------------------------------------------------------- | ------ | ----- |
+| `Argument` struct with builder pattern                                                                | ✓      | —     |
+| `Command` struct with `add_argument()`                                                                | ✓      | —     |
+| `ParseResult` with `get_flag()`, `get_string()`, `get_int()`, `has()`                                 | ✓      | ✓     |
+| Long flags `--verbose`                                                                                | ✓      | ✓     |
+| Short flags `-v`                                                                                      | ✓      | ✓     |
+| Key-value `--key value`, `--key=value`, `-k value`                                                    | ✓      | ✓     |
+| Positional arguments                                                                                  | ✓      | ✓     |
+| Default values for positional and named args                                                          | ✓      | ✓     |
+| Required argument validation                                                                          | ✓      | —     |
+| `--` stop marker                                                                                      | ✓      | ✓     |
+| Auto `--help` / `-h` with generated help text                                                         | ✓      | —     |
+| Auto `--version` / `-V`                                                                               | ✓      | —     |
+| Demo binary (`mojo build`)                                                                            | ✓      | —     |
+| Short flag merging (`-abc` → `-a -b -c`)                                                              | ✓      | ✓     |
+| Short option with attached value (`-ofile.txt`)                                                       | ✓      | ✓     |
+| Choices validation (`.choices()`)                                                                     | ✓      | ✓     |
+| Value Name (`.value_name("FILE")`)                                                                    | ✓      | ✓     |
+| Hidden arguments (`.hidden()`)                                                                        | ✓      | ✓     |
+| Count action (`-vvv` → 3) with ceiling (`.max(N)`)                                                    | ✓      | ✓     |
+| Positional arg count validation                                                                       | ✓      | ✓     |
+| Clean exit for `--help` / `--version`                                                                 | ✓      | —     |
+| Mutually exclusive groups                                                                             | ✓      | ✓     |
+| Required-together groups                                                                              | ✓      | ✓     |
+| Negatable flags (`.negatable()` → `--no-X`)                                                           | ✓      | ✓     |
+| Long option prefix matching (`--verb` → `--verbose`)                                                  | ✓      | ✓     |
+| Append / collect action (`--tag x --tag y` → list)                                                    | ✓      | ✓     |
+| One-required groups (`command.one_required(["json", "yaml"])`)                                        | ✓      | ✓     |
+| Value delimiter (`.delimiter(",")` → split into list)                                                 | ✓      | ✓     |
+| Number of values (`.number_of_values[N]()` → consume N values per occurrence)                         | ✓      | ✓     |
+| Conditional requirements (`command.required_if("output", "save")`)                                    | ✓      | ✓     |
+| Numeric range validation (`.range[1, 65535]()`)                                                       | ✓      | ✓     |
+| Key-value map option (`.map_option()` → `Dict[String, String]`)                                       | ✓      | ✓     |
+| Aliases (`.aliases(["color"])` for `--colour` / `--color`)                                            | ✓      | ✓     |
+| Deprecated arguments (`.deprecated("msg")` → stderr warning)                                          | ✓      | ✓     |
+| Negative number passthrough (`-9`, `-3.14`, `-1.5e10` as positionals)                                 | ✓      | ✓     |
+| Subcommand data model (`add_subcommand()`, dispatch, `help` sub)                                      | ✓      | ✓     |
+| Colored warning and error messages (`_warn()`, `_error()`, all errors printed in colour to stderr)    | ✓      | ✓     |
+| Range clamping (`.range[1, 100]().clamp()` → adjust + warn instead of error)                          | ✓      | ✓     |
+| Default-if-no-value (`.default_if_no_value("gzip")` → optional value with fallback)                   | ✓      | ✓     |
+| Require equals syntax (`.require_equals()` → `--key=value` only)                                      | ✓      | ✓     |
+| Response file (`command.response_file_prefix()` → `@args.txt` expands file contents)                  | ✓ ⚠    | ✓     |
+| Typo suggestions (Levenshtein "did you mean ...?" for long options and subcommands)                   | ✓      | ✓     |
+| Flag counter ceiling (`.count().max[3]()` → cap with warning)                                         | ✓      | ✓     |
+| Shell completion script generation (`generate_completion["bash"]()` or `generate_completion("bash")`) | ✓      | ✓     |
+| Subcommand aliases (`command_aliases(["co"])`)                                                        | ✓      | ✓     |
+| Hidden subcommands (`sub.hidden()` → excluded from help, completions, errors)                         | ✓      | ✓     |
+| `NO_COLOR` env variable (suppress ANSI output when set)                                               | ✓      | ✓     |
+| Mutual implication (`command.implies("debug", "verbose")` with chained + cycle detection)             | ✓      | ✓     |
+| Remainder positional (`.remainder()` → consume all remaining tokens)                                  | ✓      | ✓     |
+| Partial parsing (`parse_known_arguments()` → collect unknown options)                                 | ✓      | ✓     |
+| Allow hyphen values (`.allow_hyphen_values()` → accept `-x` as positional value)                      | ✓      | ✓     |
+| Value name rename (`.metavar()` → `.value_name()`)                                                    | ✓      | ✓     |
+| CJK-aware help formatting (`_display_width` for column alignment)                                     | ✓      | ✓     |
+| Full-width → half-width auto-correction (fullwidth ASCII + `U+3000` space)                            | ✓      | ✓     |
+| CJK punctuation auto-correction (em-dash `U+2014` → hyphen-minus)                                     | ✓      | ✓     |
 
 > ⚠ Response file support is temporarily disabled due to a Mojo compiler deadlock under `-D ASSERT=all`. The implementation is preserved and will be re-enabled when the compiler bug is fixed.
 
@@ -569,7 +569,7 @@ Before adding Phase 5 features, further decompose `parse_arguments()` for readab
 - [x] **Flag counter with ceiling** — `.count().max[3]()` caps `-vvvvv` at 3 with a warning (no major library has this)
 - [x] **Range clamping** — `.range[min, max]().clamp()` adjusts out-of-range values to the nearest boundary with a warning instead of erroring (Click has `IntRange(clamp=True)`)
 - [x] **Colored error output** — ANSI styled error messages (help output already colored)
-- [x] **Shell completion script generation** — `generate_completion("bash"|"zsh"|"fish")` returns a complete completion script; static approach (no runtime hook), covers options/flags/choices/subcommands (clap `generate`, cobra `completion`, click `shell_complete`)
+- [x] **Shell completion script generation** — `generate_completion["bash"]()` (compile-time validated) or `generate_completion("bash")` (runtime, case-insensitive) returns a complete completion script; static approach (no runtime hook), covers options/flags/choices/subcommands (clap `generate`, cobra `completion`, click `shell_complete`)
 - [x] **Argument groups in help** — `.group("name")` groups related options under headings; independent per-section padding; persistent args stay in "Global Options:" (argparse `add_argument_group`) (PR #17)
 - [ ] **Usage line customisation** — two approaches: (1) manual override via `.usage("...")` for git-style hand-written usage strings (e.g. `[-v | --version] [-h | --help] [-C <path>] ...`); (2) auto-expanded mode that enumerates every flag inline like argparse (good for small CLIs, noisy for large ones). Current default `[OPTIONS]` / `<COMMAND>` is the cobra/clap/click convention and is the right default.
 - [x] **Partial parsing** — `parse_known_arguments()` collects unrecognised options instead of erroring; access via `result.get_unknown_args()` (argparse `parse_known_args`) (PR #13)

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -377,7 +377,8 @@ Argument("name", help="...")
 ╠══ Decorators (combine with any path above) ═══════════════════════════════════
 ║   .value_name("FILE")          display name in help      (value / positional)
 ║   └── [wrapped=True]           wrap in <> (default); [False] = bare
-║   .group("Network")            section heading in help   (named options only; ignored for positionals)
+║   .group("Network")            section heading in help
+║                                  (named options only; ignored for positionals)
 ║   .hidden()                    hide from --help          (any)
 ║   .aliases(["alt"])            alternative --names       (named only)
 ║   .deprecated("msg")           deprecation warning       (any)

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -377,7 +377,7 @@ Argument("name", help="...")
 ╠══ Decorators (combine with any path above) ═══════════════════════════════════
 ║   .value_name("FILE")          display name in help      (value / positional)
 ║   └── [wrapped=True]           wrap in <> (default); [False] = bare
-║   .group("Network")            section heading in help   (named only)
+║   .group("Network")            section heading in help   (named options only; ignored for positionals)
 ║   .hidden()                    hide from --help          (any)
 ║   .aliases(["alt"])            alternative --names       (named only)
 ║   .deprecated("msg")           deprecation warning       (any)
@@ -2292,7 +2292,7 @@ Available colour names (uppercase only):
 | `WHITE`   | 97        | bright white       |
 | `ORANGE`  | 33        | orange/dark yellow |
 
-An unrecognised colour name is caught at **compile time** — the program will not compile if you pass an invalid name.
+An unrecognised colour name is caught at **compile time** — the program will not compile if you pass an invalid name. Note that the colour name is a `StringLiteral` parameter and must be provided as a compile-time string literal (bracket-parameter form); dynamic runtime selection of colours is not supported by this API.
 
 Padding calculation is always based on the **plain-text width** (without escape codes), so columns remain correctly aligned regardless of whether colour is enabled.
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -2974,15 +2974,22 @@ app.completions_as_subcommand()     # → myapp comp bash
 
 ### Generating a Script Programmatically
 
-You can also call `generate_completion(shell)` directly to get a completion script as a `String`:
+You can also call `generate_completion` directly to get a completion script as a `String`:
 
 ```mojo
-# Generate for any supported shell
-var script = app.generate_completion("bash")   # or "zsh" or "fish"
+# Compile-time validated (bracket syntax) — invalid shell names fail to compile
+var script = app.generate_completion["bash"]()
 print(script)
 ```
 
-The `shell` argument is **case-insensitive** (`"Bash"`, `"BASH"`, `"bash"` all work). An error is raised for unrecognised shell names.
+A runtime overload is also available for when the shell name comes from user input:
+
+```mojo
+# Runtime dispatch (case-insensitive) — raises on unknown shell
+var script = app.generate_completion(shell_name)   # "bash", "zsh", or "fish"
+```
+
+The runtime overload is **case-insensitive** (`"Bash"`, `"BASH"`, `"bash"` all work). An error is raised for unrecognised shell names.
 
 ### Installing Completions
 

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -1090,12 +1090,11 @@ struct Command(Copyable, Movable, Stringable, Writable):
         self._help_on_no_arguments = True
 
     # [Mojo Miji]
-    # We set `name` as a parameter, instead of an argument, because we
-    # want to check at compile time that it is a valid colour name.
-    # If we made it an argument, the check would be deferred to runtime,
-    # which means that the users, rather than developers, may encounter
-    # errors about a wrong colour name in the terminal when they use
-    # the programme, no matter what colour name they type in.
+    # `name` is a type parameter (StringLiteral) rather than a runtime
+    # argument so that the colour name is validated at compile time.
+    # This ensures developers get a compiler error for invalid colour
+    # names during development, instead of end users seeing runtime
+    # failures caused by a misspelled or unsupported colour.
     fn header_color[name: StringLiteral](mut self):
         """Sets the colour for section headers (Usage, Arguments, Options).
 

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -665,7 +665,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         var app = Command("myapp", "My CLI")
         app.disable_default_completions()
         # --completions is now an unknown option
-        # but app.generate_completion("bash") still works
+        # but app.generate_completion["bash"]() still works
         ```
         """
         self._completions_enabled = False
@@ -3717,18 +3717,48 @@ struct Command(Copyable, Movable, Stringable, Writable):
     # Shell completion generation
     # ===------------------------------------------------------------------=== #
 
-    fn generate_completion(self, shell: String) raises -> String:
-        """Generates a shell completion script for this command tree.
+    fn generate_completion[shell: StringLiteral](self) -> String:
+        """Generates a shell completion script (compile-time validated).
 
-        Supports ``bash``, ``zsh``, and ``fish`` shells.  The returned
-        string is a complete script that the user can source or redirect
-        to a file:
+        The shell name is validated at compile time via ``constrained[]``.
+        Use this overload when the shell is known at development time.
 
-        ```bash
-        myapp --completions bash > ~/.bash_completion.d/myapp
-        myapp --completions zsh  > ~/.zsh/completions/_myapp
-        myapp --completions fish > ~/.config/fish/completions/myapp.fish
+        Parameters:
+            shell: One of ``"bash"``, ``"zsh"``, or ``"fish"``
+                   (case-sensitive). Invalid names are caught at compile
+                   time.
+
+        Returns:
+            The completion script as a string.
+
+        Example:
+
+        ```mojo
+        from argmojo import Command
+        var app = Command("myapp", "My application")
+        var script = app.generate_completion["bash"]()
         ```
+        """
+        constrained[
+            cond = (shell == "fish" or shell == "zsh" or shell == "bash"),
+            msg = (
+                "Unknown shell '" + shell + "'. Choose from: bash, zsh, fish"
+            ),
+        ]()
+
+        @parameter
+        if shell == "fish":
+            return self._completion_fish()
+        elif shell == "zsh":
+            return self._completion_zsh()
+        else:  # shell == "bash"
+            return self._completion_bash()
+
+    fn generate_completion(self, shell: String) raises -> String:
+        """Generates a shell completion script (runtime dispatch).
+
+        The shell name is validated at runtime.  Use this overload when
+        the shell name comes from user input (e.g. ``--completions``).
 
         Args:
             shell: One of ``"bash"``, ``"zsh"``, or ``"fish"``
@@ -3747,13 +3777,16 @@ struct Command(Copyable, Movable, Stringable, Writable):
             return self._completion_zsh()
         if lower == "bash":
             return self._completion_bash()
-        raise Error("Unknown shell '" + shell + "'. Supported: bash, zsh, fish")
+        raise Error(
+            "Unknown shell '" + shell + "'. Choose from: bash, zsh, fish"
+        )
 
     fn _completion_fish(self) -> String:
         """Generates a Fish shell completion script.
 
         Each option/subcommand becomes a single ``complete`` line.
-        Subcommand-specific completions use ``-n '__fish_seen_subcommand_from <sub>'``
+        Subcommand-specific completions use
+        ``-n '__fish_seen_subcommand_from <sub>'``
         to scope them.
 
         Returns:

--- a/tests/test_completion.mojo
+++ b/tests/test_completion.mojo
@@ -5,11 +5,11 @@ import argmojo
 from argmojo import Argument, Command
 
 
-# ── generate_completion() dispatch ───────────────────────────────────────────
+# ── generate_completion[] dispatch (compile-time) ────────────────────────────
 
 
 fn test_fish_dispatch() raises:
-    """Tests that generate_completion('fish') returns Fish syntax."""
+    """Tests that generate_completion["fish"]() returns Fish syntax."""
     var command = Command("myapp", "A test app")
     command.add_argument(
         Argument("verbose", help="Enable verbose output")
@@ -17,7 +17,7 @@ fn test_fish_dispatch() raises:
         .short("v")
         .flag()
     )
-    var script = command.generate_completion("fish")
+    var script = command.generate_completion["fish"]()
     assert_true(
         "complete -c myapp" in script,
         msg="Fish script should contain 'complete -c myapp'",
@@ -25,7 +25,7 @@ fn test_fish_dispatch() raises:
 
 
 fn test_zsh_dispatch() raises:
-    """Tests that generate_completion('zsh') returns Zsh syntax."""
+    """Tests that generate_completion["zsh"]() returns Zsh syntax."""
     var command = Command("myapp", "A test app")
     command.add_argument(
         Argument("verbose", help="Enable verbose output")
@@ -33,7 +33,7 @@ fn test_zsh_dispatch() raises:
         .short("v")
         .flag()
     )
-    var script = command.generate_completion("zsh")
+    var script = command.generate_completion["zsh"]()
     assert_true(
         "#compdef myapp" in script,
         msg="Zsh script should start with '#compdef myapp'",
@@ -45,7 +45,7 @@ fn test_zsh_dispatch() raises:
 
 
 fn test_bash_dispatch() raises:
-    """Tests that generate_completion('bash') returns Bash syntax."""
+    """Tests that generate_completion["bash"]() returns Bash syntax."""
     var command = Command("myapp", "A test app")
     command.add_argument(
         Argument("verbose", help="Enable verbose output")
@@ -53,15 +53,15 @@ fn test_bash_dispatch() raises:
         .short("v")
         .flag()
     )
-    var script = command.generate_completion("bash")
+    var script = command.generate_completion["bash"]()
     assert_true(
         "complete -F _myapp_completion myapp" in script,
         msg="Bash script should register with 'complete -F'",
     )
 
 
-fn test_case_insensitive_shell() raises:
-    """Tests that shell name is case-insensitive."""
+fn test_case_insensitive_shell_runtime() raises:
+    """Runtime overload accepts case-insensitive shell names."""
     var command = Command("myapp", "A test app")
     var fish_upper = command.generate_completion("FISH")
     assert_true(
@@ -80,8 +80,8 @@ fn test_case_insensitive_shell() raises:
     )
 
 
-fn test_unknown_shell_raises() raises:
-    """Tests that an unknown shell name raises an error."""
+fn test_unknown_shell_raises_runtime() raises:
+    """Runtime overload raises for unknown shell names."""
     var command = Command("myapp", "A test app")
     var raised = False
     try:
@@ -89,6 +89,23 @@ fn test_unknown_shell_raises() raises:
     except:
         raised = True
     assert_true(raised, msg="Unknown shell should raise an error")
+
+
+fn test_invalid_shell_caught_at_compile_time() raises:
+    """Invalid shell names are caught at compile time via constrained[].
+
+    This test verifies the valid paths work.  An invalid name
+    like ``command.generate_completion["powershell"]()`` would fail to compile.
+    """
+    var command = Command("myapp", "A test app")
+    var fish = command.generate_completion["fish"]()
+    assert_true(
+        "complete -c myapp" in fish, msg="fish should produce Fish script"
+    )
+    var zsh = command.generate_completion["zsh"]()
+    assert_true("#compdef myapp" in zsh, msg="zsh should produce Zsh script")
+    var bash = command.generate_completion["bash"]()
+    assert_true("complete -F" in bash, msg="bash should produce Bash script")
 
 
 # ── Fish completion details ──────────────────────────────────────────────────
@@ -100,7 +117,7 @@ fn test_fish_long_option() raises:
     command.add_argument(
         Argument("output", help="Output file").long("output").short("o")
     )
-    var script = command.generate_completion("fish")
+    var script = command.generate_completion["fish"]()
     assert_true(
         "-l output" in script,
         msg="Fish script should contain '-l output'",
@@ -117,7 +134,7 @@ fn test_fish_flag_no_require_value() raises:
     command.add_argument(
         Argument("verbose", help="Verbose").long("verbose").flag()
     )
-    var script = command.generate_completion("fish")
+    var script = command.generate_completion["fish"]()
     # Find the line with --verbose
     var lines = script.split("\n")
     for i in range(len(lines)):
@@ -135,7 +152,7 @@ fn test_fish_value_option_has_require() raises:
     """Tests that Fish value-taking options have -r (require value)."""
     var command = Command("myapp", "A test app")
     command.add_argument(Argument("output", help="Output file").long("output"))
-    var script = command.generate_completion("fish")
+    var script = command.generate_completion["fish"]()
     var lines = script.split("\n")
     for i in range(len(lines)):
         if "-l output" in lines[i]:
@@ -157,7 +174,7 @@ fn test_fish_choices() raises:
         .long("format")
         .choices(choices^)
     )
-    var script = command.generate_completion("fish")
+    var script = command.generate_completion["fish"]()
     assert_true(
         "-a 'json csv table'" in script,
         msg="Fish script should list choices with -a",
@@ -168,7 +185,7 @@ fn test_fish_help_text() raises:
     """Tests that Fish script includes description with -d."""
     var command = Command("myapp", "A test app")
     command.add_argument(Argument("output", help="Output file").long("output"))
-    var script = command.generate_completion("fish")
+    var script = command.generate_completion["fish"]()
     assert_true(
         "-d 'Output file'" in script,
         msg="Fish script should include help text with -d",
@@ -187,7 +204,7 @@ fn test_fish_hidden_excluded() raises:
     command.add_argument(
         Argument("visible", help="Visible flag").long("visible").flag()
     )
-    var script = command.generate_completion("fish")
+    var script = command.generate_completion["fish"]()
     assert_false(
         "-l internal" in script,
         msg="Hidden args should not appear in Fish completion",
@@ -201,7 +218,7 @@ fn test_fish_hidden_excluded() raises:
 fn test_fish_builtin_help_version() raises:
     """Tests that Fish script includes built-in --help and --version."""
     var command = Command("myapp", "A test app")
-    var script = command.generate_completion("fish")
+    var script = command.generate_completion["fish"]()
     assert_true(
         "-l help" in script,
         msg="Fish script should include --help",
@@ -223,7 +240,7 @@ fn test_fish_subcommands() raises:
         Argument("max-depth", help="Maximum depth").long("max-depth")
     )
     app.add_subcommand(sub^)
-    var script = app.generate_completion("fish")
+    var script = app.generate_completion["fish"]()
     # Subcommand should be listed.
     assert_true(
         "-a 'search'" in script,
@@ -246,7 +263,7 @@ fn test_fish_escape_single_quote() raises:
     command.add_argument(
         Argument("test", help="It's a test").long("test").flag()
     )
-    var script = command.generate_completion("fish")
+    var script = command.generate_completion["fish"]()
     assert_true(
         "It\\'s a test" in script,
         msg="Fish script should escape single quotes",
@@ -265,7 +282,7 @@ fn test_zsh_simple_flag() raises:
         .short("v")
         .flag()
     )
-    var script = command.generate_completion("zsh")
+    var script = command.generate_completion["zsh"]()
     assert_true(
         "--verbose" in script,
         msg="Zsh script should contain --verbose",
@@ -285,7 +302,7 @@ fn test_zsh_choices() raises:
         .long("format")
         .choices(choices^)
     )
-    var script = command.generate_completion("zsh")
+    var script = command.generate_completion["zsh"]()
     assert_true(
         "json csv" in script,
         msg="Zsh script should include choice values",
@@ -300,7 +317,7 @@ fn test_zsh_subcommands() raises:
         Argument("release", help="Release mode").long("release").flag()
     )
     app.add_subcommand(sub^)
-    var script = app.generate_completion("zsh")
+    var script = app.generate_completion["zsh"]()
     assert_true(
         "'build:" in script,
         msg="Zsh script should list subcommand 'build'",
@@ -321,7 +338,7 @@ fn test_zsh_escape_brackets() raises:
     command.add_argument(
         Argument("test", help="Test [option]").long("test").flag()
     )
-    var script = command.generate_completion("zsh")
+    var script = command.generate_completion["zsh"]()
     assert_true(
         "Test \\[option\\]" in script,
         msg="Zsh script should escape brackets",
@@ -334,7 +351,7 @@ fn test_zsh_escape_colon() raises:
     command.add_argument(
         Argument("test", help="Key: value").long("test").flag()
     )
-    var script = command.generate_completion("zsh")
+    var script = command.generate_completion["zsh"]()
     assert_true(
         "Key\\: value" in script,
         msg="Zsh script should escape colons",
@@ -344,7 +361,7 @@ fn test_zsh_escape_colon() raises:
 fn test_zsh_builtin_help() raises:
     """Tests that Zsh script includes built-in help/version."""
     var command = Command("myapp", "A test app")
-    var script = command.generate_completion("zsh")
+    var script = command.generate_completion["zsh"]()
     assert_true(
         "--help" in script,
         msg="Zsh script should include --help",
@@ -367,7 +384,7 @@ fn test_bash_simple_options() raises:
     command.add_argument(
         Argument("output", help="Output file").long("output").short("o")
     )
-    var script = command.generate_completion("bash")
+    var script = command.generate_completion["bash"]()
     assert_true(
         "--verbose" in script,
         msg="Bash script should contain --verbose",
@@ -392,7 +409,7 @@ fn test_bash_subcommands() raises:
     var sub = Command("deploy", "Deploy the app")
     sub.add_argument(Argument("target", help="Deploy target").long("target"))
     app.add_subcommand(sub^)
-    var script = app.generate_completion("bash")
+    var script = app.generate_completion["bash"]()
     assert_true(
         "deploy" in script,
         msg="Bash script should reference 'deploy' subcommand",
@@ -414,7 +431,7 @@ fn test_bash_choices_prev() raises:
     command.add_argument(
         Argument("level", help="Log level").long("level").choices(choices^)
     )
-    var script = command.generate_completion("bash")
+    var script = command.generate_completion["bash"]()
     assert_true(
         "case $prev in" in script,
         msg="Bash script should have case $prev block",
@@ -434,7 +451,7 @@ fn test_bash_hidden_excluded() raises:
     command.add_argument(
         Argument("public", help="Public").long("public").flag()
     )
-    var script = command.generate_completion("bash")
+    var script = command.generate_completion["bash"]()
     assert_false(
         "--secret" in script,
         msg="Hidden args should not appear in Bash completion",
@@ -448,7 +465,7 @@ fn test_bash_hidden_excluded() raises:
 fn test_bash_builtin_help_version() raises:
     """Tests that Bash script includes --help and --version."""
     var command = Command("myapp", "A test app")
-    var script = command.generate_completion("bash")
+    var script = command.generate_completion["bash"]()
     assert_true(
         "--help" in script,
         msg="Bash script should include --help",
@@ -476,9 +493,9 @@ fn test_all_shells_include_same_options() raises:
         Argument("format", help="Format").long("format").choices(choices^)
     )
 
-    var fish = command.generate_completion("fish")
-    var zsh = command.generate_completion("zsh")
-    var bash = command.generate_completion("bash")
+    var fish = command.generate_completion["fish"]()
+    var zsh = command.generate_completion["zsh"]()
+    var bash = command.generate_completion["bash"]()
 
     # Fish uses -l/--long form syntax, not --verbose directly.
     assert_true("-l verbose" in fish, msg="fish should include -l verbose")
@@ -504,7 +521,7 @@ fn test_count_option_no_value() raises:
         .count()
     )
     # Fish: should NOT have -r
-    var fish = command.generate_completion("fish")
+    var fish = command.generate_completion["fish"]()
     var lines = fish.split("\n")
     var found = False
     for i in range(len(lines)):
@@ -527,7 +544,7 @@ fn test_persistent_flags_in_root() raises:
     var sub = Command("run", "Run something")
     app.add_subcommand(sub^)
 
-    var fish = app.generate_completion("fish")
+    var fish = app.generate_completion["fish"]()
     assert_true(
         "-l debug" in fish,
         msg="Persistent flag should appear in Fish root completions",
@@ -543,9 +560,9 @@ fn test_positional_excluded() raises:
     command.add_argument(
         Argument("verbose", help="Verbose").long("verbose").flag()
     )
-    var fish = command.generate_completion("fish")
-    var zsh = command.generate_completion("zsh")
-    var bash = command.generate_completion("bash")
+    var fish = command.generate_completion["fish"]()
+    var zsh = command.generate_completion["zsh"]()
+    var bash = command.generate_completion["bash"]()
     # Positional should not appear as -l or -- option.
     assert_false(
         "-l pattern" in fish,
@@ -560,9 +577,9 @@ fn test_positional_excluded() raises:
 fn test_generated_by_comment() raises:
     """Tests that all scripts have 'Generated by ArgMojo' comment."""
     var command = Command("myapp", "A test app")
-    var fish = command.generate_completion("fish")
-    var zsh = command.generate_completion("zsh")
-    var bash = command.generate_completion("bash")
+    var fish = command.generate_completion["fish"]()
+    var zsh = command.generate_completion["zsh"]()
+    var bash = command.generate_completion["bash"]()
     assert_true(
         "Generated by ArgMojo" in fish,
         msg="Fish script should have ArgMojo attribution",
@@ -583,7 +600,7 @@ fn test_generated_by_comment() raises:
 fn test_fish_builtin_completions() raises:
     """Tests that Fish script includes the built-in --completions option."""
     var command = Command("myapp", "A test app")
-    var script = command.generate_completion("fish")
+    var script = command.generate_completion["fish"]()
     assert_true(
         "-l completions" in script,
         msg="Fish script should include -l completions",
@@ -597,7 +614,7 @@ fn test_fish_builtin_completions() raises:
 fn test_zsh_builtin_completions() raises:
     """Tests that Zsh script includes the built-in --completions option."""
     var command = Command("myapp", "A test app")
-    var script = command.generate_completion("zsh")
+    var script = command.generate_completion["zsh"]()
     assert_true(
         "--completions" in script,
         msg="Zsh script should include --completions",
@@ -611,7 +628,7 @@ fn test_zsh_builtin_completions() raises:
 fn test_bash_builtin_completions() raises:
     """Tests that Bash script includes the built-in --completions option."""
     var command = Command("myapp", "A test app")
-    var script = command.generate_completion("bash")
+    var script = command.generate_completion["bash"]()
     assert_true(
         "--completions" in script,
         msg="Bash script should include --completions",
@@ -627,9 +644,9 @@ fn test_disable_default_completions_not_in_script() raises:
     """
     var command = Command("myapp", "A test app")
     command.disable_default_completions()
-    var fish = command.generate_completion("fish")
-    var zsh = command.generate_completion("zsh")
-    var bash = command.generate_completion("bash")
+    var fish = command.generate_completion["fish"]()
+    var zsh = command.generate_completion["zsh"]()
+    var bash = command.generate_completion["bash"]()
     assert_false(
         "-l completions" in fish,
         msg=(
@@ -690,9 +707,9 @@ fn test_completions_custom_name_in_scripts() raises:
     """Tests that completions_name() changes the trigger in all scripts."""
     var command = Command("myapp", "A test app")
     command.completions_name("autocomp")
-    var fish = command.generate_completion("fish")
-    var zsh = command.generate_completion("zsh")
-    var bash = command.generate_completion("bash")
+    var fish = command.generate_completion["fish"]()
+    var zsh = command.generate_completion["zsh"]()
+    var bash = command.generate_completion["bash"]()
     assert_true(
         "-l autocomp" in fish,
         msg="Fish script should use '-l autocomp' after completions_name()",
@@ -734,7 +751,7 @@ fn test_completions_custom_name_in_bash_prev() raises:
     """Tests that completions_name() updates bash prev-case pattern."""
     var command = Command("myapp", "A test app")
     command.completions_name("gen-comp")
-    var bash = command.generate_completion("bash")
+    var bash = command.generate_completion["bash"]()
     assert_true(
         "--gen-comp)" in bash,
         msg="Bash prev-case should use '--gen-comp)' after rename",
@@ -780,7 +797,7 @@ fn test_completions_as_subcommand_in_fish() raises:
     var sub = Command("serve", "Start the server")
     command.add_subcommand(sub^)
     command.completions_as_subcommand()
-    var fish = command.generate_completion("fish")
+    var fish = command.generate_completion["fish"]()
     # Should NOT appear as an option.
     assert_false(
         "-l completions" in fish,
@@ -805,7 +822,7 @@ fn test_completions_as_subcommand_in_zsh() raises:
     var sub = Command("serve", "Start the server")
     command.add_subcommand(sub^)
     command.completions_as_subcommand()
-    var zsh = command.generate_completion("zsh")
+    var zsh = command.generate_completion["zsh"]()
     # Should appear in commands array.
     assert_true(
         "'completions:" in zsh,
@@ -829,7 +846,7 @@ fn test_completions_as_subcommand_in_bash() raises:
     var sub = Command("serve", "Start the server")
     command.add_subcommand(sub^)
     command.completions_as_subcommand()
-    var bash = command.generate_completion("bash")
+    var bash = command.generate_completion["bash"]()
     # Should NOT appear as --completions option.
     assert_false(
         " --completions" in bash,
@@ -856,9 +873,9 @@ fn test_completions_custom_name_with_subcommand() raises:
     command.completions_name("comp")
     command.completions_as_subcommand()
     var help_text = command._generate_help(color=False)
-    var fish = command.generate_completion("fish")
-    var zsh = command.generate_completion("zsh")
-    var bash = command.generate_completion("bash")
+    var fish = command.generate_completion["fish"]()
+    var zsh = command.generate_completion["zsh"]()
+    var bash = command.generate_completion["bash"]()
     # Help: 'comp' in Commands, not '--comp' in Options.
     assert_true(
         "comp" in help_text,
@@ -895,7 +912,7 @@ fn test_fish_completion_includes_alias() raises:
     var aliases: List[String] = ["cl"]
     clone.command_aliases(aliases^)
     app.add_subcommand(clone^)
-    var script = app.generate_completion("fish")
+    var script = app.generate_completion["fish"]()
     assert_true(
         "-a 'cl'" in script,
         msg="Fish script should list alias 'cl' as completable",
@@ -918,7 +935,7 @@ fn test_zsh_completion_includes_alias() raises:
     var aliases: List[String] = ["cl"]
     clone.command_aliases(aliases^)
     app.add_subcommand(clone^)
-    var script = app.generate_completion("zsh")
+    var script = app.generate_completion["zsh"]()
     assert_true(
         "'cl:" in script,
         msg="Zsh script should list alias 'cl' in commands array",
@@ -936,7 +953,7 @@ fn test_bash_completion_includes_alias() raises:
     var aliases: List[String] = ["cl"]
     clone.command_aliases(aliases^)
     app.add_subcommand(clone^)
-    var script = app.generate_completion("bash")
+    var script = app.generate_completion["bash"]()
     assert_true(
         "clone|cl)" in script,
         msg="Bash script should have clone|cl) case pattern",
@@ -967,7 +984,7 @@ fn _make_app_with_hidden_sub() raises -> Command:
 fn test_fish_hidden_sub_excluded() raises:
     """Tests that hidden subcommands are absent from Fish completion."""
     var app = _make_app_with_hidden_sub()
-    var script = app.generate_completion("fish")
+    var script = app.generate_completion["fish"]()
     assert_true(
         "clone" in script,
         msg="Fish script should include visible sub 'clone'",
@@ -981,7 +998,7 @@ fn test_fish_hidden_sub_excluded() raises:
 fn test_zsh_hidden_sub_excluded() raises:
     """Tests that hidden subcommands are absent from Zsh completion."""
     var app = _make_app_with_hidden_sub()
-    var script = app.generate_completion("zsh")
+    var script = app.generate_completion["zsh"]()
     assert_true(
         "'clone:" in script,
         msg="Zsh script should include visible sub 'clone'",
@@ -995,7 +1012,7 @@ fn test_zsh_hidden_sub_excluded() raises:
 fn test_bash_hidden_sub_excluded() raises:
     """Tests that hidden subcommands are absent from Bash completion."""
     var app = _make_app_with_hidden_sub()
-    var script = app.generate_completion("bash")
+    var script = app.generate_completion["bash"]()
     assert_true(
         "clone" in script,
         msg="Bash script should include visible sub 'clone'",
@@ -1015,14 +1032,14 @@ fn test_all_hidden_no_subcommand_completion() raises:
     app.add_subcommand(debug^)
 
     # Fish: should NOT contain subcommand-related directives.
-    var fish = app.generate_completion("fish")
+    var fish = app.generate_completion["fish"]()
     assert_false(
         "__fish_seen_subcommand_from" in fish,
         msg="Fish should not have subcommand dispatching when all subs hidden",
     )
 
     # Bash: should not have case/subcmd detection.
-    var bash = app.generate_completion("bash")
+    var bash = app.generate_completion["bash"]()
     assert_false(
         "subcmd" in bash,
         msg="Bash should not have subcmd logic when all subs hidden",

--- a/tests/test_help.mojo
+++ b/tests/test_help.mojo
@@ -435,6 +435,28 @@ fn test_invalid_color_caught_at_compile_time() raises:
     command.warn_color["YELLOW"]()
     command.error_color["MAGENTA"]()
 
+    # Verify that the valid names actually configure the expected ANSI codes.
+    assert_equal(
+        command._header_color,
+        "\x1b[91m",
+        msg="Header color 'RED' should map to bright red (ANSI 91)",
+    )
+    assert_equal(
+        command._arg_color,
+        "\x1b[92m",
+        msg="Arg color 'GREEN' should map to bright green (ANSI 92)",
+    )
+    assert_equal(
+        command._warn_color,
+        "\x1b[93m",
+        msg="Warn color 'YELLOW' should map to bright yellow (ANSI 93)",
+    )
+    assert_equal(
+        command._error_color,
+        "\x1b[95m",
+        msg="Error color 'MAGENTA' should map to bright magenta (ANSI 95)",
+    )
+
 
 fn test_custom_color_plain_mode_unaffected() raises:
     """Custom colours should not leak into plain (color=False) output."""


### PR DESCRIPTION
This PR adds a compile-time validated `Command.generate_completion[...]()` overload (StringLiteral parameter form) while keeping the existing runtime `generate_completion(shell: String)` for user-provided shell names, and updates tests/docs to reflect the new API.

**Changes:**
- Added `generate_completion[shell: StringLiteral]()` overload with compile-time validation and dispatch.
- Updated completion tests to primarily use the compile-time overload, while retaining runtime case-insensitive/unknown-shell coverage.
- Refreshed documentation examples and planning docs to show both compile-time and runtime usage.