### PR TITLE
[core] Implement aggressive runtime validation for `Command`

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -75,3 +75,19 @@ jobs:
             echo "=== test run crashed, retrying in 5s... ==="
             sleep 5
           done
+
+      - name: Run example binaries in debug mode (catches developer-facing validation errors)
+        run: |
+          for attempt in 1 2 3; do
+            echo "=== debug attempt $attempt ==="
+            if pixi run debug; then
+              echo "=== debug passed on attempt $attempt ==="
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "=== debug failed after 3 attempts ==="
+              exit 1
+            fi
+            echo "=== debug run crashed, retrying in 5s... ==="
+            sleep 5
+          done

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -2,7 +2,7 @@ name: ArgMojo Unit Tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
   workflow_dispatch:
 

--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -84,6 +84,8 @@ These features appear across multiple libraries and depend only on string operat
 | CJK full-to-half-width correction  | —        | —     | —     | —    | I need it personally         | **Done**      |
 | CJK punctuation detection          | —        | —     | —     | —    | I need it personally         | **Done**      |
 | Typed retrieval (`get_int()` etc.) | ✓        | ✓     | ✓     | ✓    |                              | **Done**      |
+| Comptime `StringLiteral` params    | —        | —     | —     | ✓    | clap derive macros           | **Done**      |
+| Registration-time name validation  | —        | —     | —     | ✓    | clap panic on unknown ID     | **Done**      |
 | `Parseable` trait for type params  | —        | —     | —     | ✓    |                              | Phase unknown |
 | Derive / struct-based schema       | —        | —     | —     | ✓    | Requires Mojo macros         | Phase unknown |
 | Enum → type mapping (real enums)   | —        | —     | —     | ✓    | Requires reflection          | Phase unknown |
@@ -231,6 +233,8 @@ examples/
 | CJK-aware help formatting (`_display_width` for column alignment)                                     | ✓      | ✓     |
 | Full-width → half-width auto-correction (fullwidth ASCII + `U+3000` space)                            | ✓      | ✓     |
 | CJK punctuation auto-correction (em-dash `U+2014` → hyphen-minus)                                     | ✓      | ✓     |
+| Compile-time `StringLiteral` builder params (`.long[]`, `.short[]`, `.choice[]`, colours, etc.)       | ✓      | —     |
+| Registration-time validation for group constraints (`mutually_exclusive`, `required_together`, etc.)  | ✓      | ✓     |
 
 > ⚠ Response file support is temporarily disabled due to a Mojo compiler deadlock under `-D ASSERT=all`. The implementation is preserved and will be re-enabled when the compiler bug is fixed.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,7 @@ Comment out unreleased changes here. This file will be edited just before each r
 10. **CJK punctuation auto-correction.** Common CJK punctuation outside the fullwidth ASCII range is also corrected — for example, em-dash (`——verbose`) is converted to `--verbose`. This runs as a separate pass after fullwidth correction. Disabled via `disable_punctuation_correction()` (PR #16).
 11. **Argument groups in help.** Add `.group["name"]()` builder method on `Argument`. Arguments assigned to the same group are displayed under a dedicated heading in `--help` output, in first-appearance order. Ungrouped arguments remain under the default "Options:" heading. Persistent arguments are collected under "Global Options:" as before (PR #17).
 12. **Value-name wrapping control.** Change `.value_name()` to accept compile-time parameters: `.value_name["NAME"]()` or `.value_name["NAME", False]()`. When `wrapped` is `True` (the default), the custom value name is displayed in angle brackets (`<NAME>`) in help output — matching the convention used by clap, cargo, pixi, and git. When `wrapped` is `False`, the value name is displayed bare (`NAME`). The auto-generated default placeholder (`<arg_name>`) is not affected (PR #17).
+13. **Registration-time validation for group constraints.** `mutually_exclusive()`, `required_together()`, `one_required()`, and `required_if()` now validate argument names against `self.args` at the moment they are called. An `Error` is raised immediately if any name is unknown, empty lists are rejected, and duplicates are silently deduplicated. `required_if()` additionally rejects self-referential rules (`target == condition`). This catches developer typos on the very first `mojo run`, without waiting for end-user input (PR #22).
 
 ### 🦋 Changed in v0.4.0
 
@@ -41,6 +42,11 @@ Comment out unreleased changes here. This file will be edited just before each r
 - Fix cross-library comparison: click is described as "Python CLI framework" instead of incorrectly saying "built on top of argparse" (PR #12, review feedback).
 - Reject `.require_equals()` / `.default_if_no_value()` combined with `.number_of_values[N]()` at `add_argument()` time with a clear error (PR #12, review feedback).
 
+### 🛡️ Validation improvements in v0.4.0
+
+- **Compile-time `StringLiteral` parameters.** Builder methods that accept fixed, known values (`.long[]`, `.short[]`, `.choice[]`, `.default[]`, `.delimiter[]`, `.deprecated[]`, `.default_if_no_value[]`, `.group[]`, `.alias_name[]`, `.value_name[]`, `header_color[]`, `arg_color[]`, `warn_color[]`, `error_color[]`, `.max[]`, `.range[]`, `.number_of_values[]`, `response_file_max_depth[]`) now use compile-time `StringLiteral` or `Int` parameters. Invalid values are rejected by the compiler before a binary is produced (PR #18, and earlier PRs).
+- **Registration-time name validation.** `mutually_exclusive()`, `required_together()`, `one_required()`, and `required_if()` now raise an `Error` immediately if any referenced argument name is not registered. Empty lists are rejected and duplicates are deduplicated. `required_if()` rejects self-referential rules. This matches the existing pattern in `implies()` (PR #22).
+
 ### 📚 Documentation and testing in v0.4.0
 
 - Add `tests/test_const_require_equals.mojo` with 30 tests covering default_if_no_value, require_equals, and their interactions with choices, append, prefix matching, merged short flags, persistent flags, and help formatting (PR #12).
@@ -48,6 +54,9 @@ Comment out unreleased changes here. This file will be edited just before each r
 - Add `tests/test_remainder_known.mojo` with 18 tests covering remainder positionals, `parse_known_arguments()`, `allow_hyphen_values()`, and the `value_name` rename (PR #13).
 - Add `tests/test_fullwidth.mojo` with 30 tests covering full-width → half-width auto-correction and CJK punctuation correction, including utility functions, fullwidth flags, equals syntax, embedded fullwidth spaces, opt-out, choices validation, merged short flags, subcommand dispatch, parse_known_arguments, and CJK punctuation em-dash correction (PR #15, #16).
 - Add `tests/test_groups_help.mojo` with 25 tests covering argument groups in help output and value-name wrapping control, including basic grouping, multiple groups, independent padding, hidden arguments in groups, groups with subcommands, wrapped/unwrapped value names with append/nargs/require_equals/default_if_no_value, and coloured output (PR #17).
+- Add 5 tests to `tests/test_groups.mojo` covering registration-time validation: unknown argument detection for `mutually_exclusive`, `required_together`, `one_required`, and `required_if` (both target and condition) (PR #22).
+- Add Developer Validation section to user manual documenting the two-layer validation model (compile-time `StringLiteral` + runtime registration-time `raises`) with recommended workflow (PR #22).
+- Add `pixi run debug` task that runs all examples under `-D ASSERT=all` with `--help` to exercise registration-time validation in CI (PR #22).
 
 ---
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -1318,8 +1318,7 @@ myapp --json --yaml        # Error: Arguments are mutually exclusive: '--json', 
 ```mojo
 command.add_argument(Argument("input", help="Input file").long["input"]().short["i"]())
 command.add_argument(Argument("stdin", help="Read from stdin").long["stdin"]().flag())
-var source: List[String] = ["input", "stdin"]
-command.one_required(source^)
+command.one_required(["input", "stdin"])
 ```
 
 ```bash
@@ -1335,10 +1334,8 @@ myapp                      # Error: At least one of the following arguments is r
 You can declare multiple groups. Each is validated independently:
 
 ```mojo
-var format_group: List[String] = ["json", "yaml"]
-var source_group: List[String] = ["input", "stdin"]
-command.one_required(format_group^)
-command.one_required(source_group^)
+command.one_required(["json", "yaml"])
+command.one_required(["input", "stdin"])
 ```
 
 ```bash

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -81,6 +81,10 @@ from argmojo import Argument, Command
   - [Generating a Script Programmatically](#generating-a-script-programmatically)
   - [Installing Completions](#installing-completions)
   - [What Gets Completed](#what-gets-completed)
+- [Developer Validation](#developer-validation)
+  - [Compile-Time Validation](#compile-time-validation)
+  - [Runtime Registration Validation](#runtime-registration-validation)
+  - [Recommended Workflow](#recommended-workflow)
 - [Cross-Library Method Name Reference](#cross-library-method-name-reference)
   - [Argument-Level Builder Methods](#argument-level-builder-methods)
   - [Command-Level Constraint Methods](#command-level-constraint-methods)
@@ -101,6 +105,10 @@ from argmojo import Argument, Command
   - [Generating a Script Programmatically](#generating-a-script-programmatically)
   - [Installing Completions](#installing-completions)
   - [What Gets Completed](#what-gets-completed)
+- [Developer Validation](#developer-validation)
+  - [Compile-Time Validation](#compile-time-validation)
+  - [Runtime Registration Validation](#runtime-registration-validation)
+  - [Recommended Workflow](#recommended-workflow)
 - [Cross-Library Method Name Reference](#cross-library-method-name-reference)
   - [Argument-Level Builder Methods](#argument-level-builder-methods)
   - [Command-Level Constraint Methods](#command-level-constraint-methods)
@@ -380,16 +388,16 @@ Argument("name", help="...")
 ║       └── (implies .allow_hyphen_values())
 ║
 ╠══ Decorators (combine with any path above) ═══════════════════════════════════
-║   .value_name["FILE"]()             display name in help      (value / positional)
-║   └── [wrapped=False]               wrap in <> (default); [False] = bare
-║   .group["Network"]()               section heading in help
-║                                     (named options only; ignored for positionals)
-║   .hidden()                         hide from --help          (any)
+║   .value_name["FILE"]()                       display name in help      (value / positional)
+║   └── [wrapped=False]                         wrap in <> (default); [False] = bare
+║   .group["Network"]()                         section heading in help
+║                                               (named options only; ignored for positionals)
+║   .hidden()                                   hide from --help          (any)
 ║   .alias_name["alt"]().alias_name["other"]()  alternative --names       (named only)
-║   .deprecated["msg"]()              deprecation warning       (any)
-║   .persistent()                     inherit to subcommands    (named only)
-║   .default_if_no_value["val"]()     default-if-no-value       (value only)
-║   .require_equals()                 force --key=value syntax  (named value only)
+║   .deprecated["msg"]()                        deprecation warning       (any)
+║   .persistent()                               inherit to subcommands    (named only)
+║   .default_if_no_value["val"]()               default-if-no-value       (value only)
+║   .require_equals()                           force --key=value syntax  (named value only)
 ║
 ╠══ Command-level constraints (called on Command, not Argument) ════════════════
 ║   command.mutually_exclusive(["a","b"])  at most one from the group
@@ -3048,6 +3056,90 @@ The generated scripts cover the full command tree:
 | Persistent (global) flags         | Yes (root level) | Inherited flags appear in the root command's completions             |
 
 > **Note:** Negatable flags (`--color` / `--no-color`) — the `--no-X` form is **not** separately listed in completions. The base `--color` flag is completed; users type `--no-` manually. This matches the behaviour of other CLI frameworks.
+
+## Developer Validation
+
+ArgMojo provides **two layers of validation** to catch developer mistakes as early as possible — before end users ever see them.
+
+### Compile-Time Validation
+
+All `Argument` builder methods that accept fixed, known values use **compile-time parameters** (`StringLiteral`). The Mojo compiler rejects invalid values during `mojo build`, so the binary is never produced:
+
+```mojo
+# ✓ Valid — compiles successfully
+Argument("verbose", help="Verbose output").long["verbose"]().short["v"]().flag()
+
+# ✗ Compile error — "REED" is not a valid colour name
+command.header_color["REED"]()   # caught by constrained[] at compile time
+```
+
+Methods validated at compile time include:
+
+| Method                         | What is checked                             |
+| ------------------------------ | ------------------------------------------- |
+| `.long[name]()`                | Long option name is a `StringLiteral`       |
+| `.short[ch]()`                 | Short option character is a `StringLiteral` |
+| `.choice[val]()`               | Choice value is a `StringLiteral`           |
+| `.default[val]()`              | Default value is a `StringLiteral`          |
+| `.value_name[name]()`          | Value placeholder is a `StringLiteral`      |
+| `.max[N]()`                    | Count ceiling is a positive `Int`           |
+| `.number_of_values[N]()`       | Value count is a positive `Int`             |
+| `.range[min, max]()`           | Range bounds are valid `Int` values         |
+| `header_color[name]()`         | Colour name is one of the accepted names    |
+| `arg_color[name]()`            | Same as above                               |
+| `warn_color[name]()`           | Same as above                               |
+| `error_color[name]()`          | Same as above                               |
+| `response_file_max_depth[N]()` | Depth is a positive `Int`                   |
+
+### Runtime Registration Validation
+
+Some `Command`-level methods accept **argument names as strings** to define group constraints or relationships. Because the set of registered arguments is built dynamically at runtime (via `add_argument()`), these names cannot be validated at compile time.
+
+Instead, ArgMojo validates them **at registration time** — the moment you call the method, not when the end user provides input. If any name does not match a registered argument, an `Error` is raised immediately:
+
+```mojo
+var command = Command("myapp", "A sample application")
+command.add_argument(Argument("json", help="JSON output").long["json"]().flag())
+command.add_argument(Argument("yaml", help="YAML output").long["yaml"]().flag())
+
+# ✓ Valid — both names are registered
+command.one_required(["json", "yaml"])
+
+# ✗ Runtime Error — "ymal" is not a registered argument
+# Error: one_required(): unknown argument 'ymal'
+command.one_required(["json", "ymal"])   # typo caught on first execution
+```
+
+This error fires **every time the program starts**, during command construction, regardless of what arguments the end user passes. The developer sees it on their very first `mojo run`.
+
+Methods validated at registration time:
+
+| Method                           | What is checked                                      |
+| -------------------------------- | ---------------------------------------------------- |
+| `mutually_exclusive(names)`      | All names exist in `self.args`                       |
+| `required_together(names)`       | All names exist in `self.args`                       |
+| `one_required(names)`            | All names exist in `self.args`                       |
+| `required_if(target, condition)` | Both names exist in `self.args`                      |
+| `implies(trigger, implied)`      | Both names exist, implied is a flag/count, no cycles |
+
+### Recommended Workflow
+
+To ensure your CLI definition is free of developer errors:
+
+1. **Build your project** — catches compile-time parameter errors (wrong colour names, invalid builder values, etc.).
+2. **Run the executable once** (even without arguments) — catches registration-time errors (typos in argument names passed to group constraints).
+
+Using the provided `pixi` tasks:
+
+```bash
+# Step 1: Compile — catches compile-time errors
+pixi run build
+
+# Step 2: Execute in debug mode — catches registration-time errors
+pixi run debug
+```
+
+Both steps are included in the CI workflow, so pull requests automatically catch both classes of errors.
 
 ## Cross-Library Method Name Reference
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -3126,20 +3126,12 @@ Methods validated at registration time:
 
 To ensure your CLI definition is free of developer errors:
 
-1. **Build your project** — catches compile-time parameter errors (wrong colour names, invalid builder values, etc.).
+1. **Compile your application** (`mojo build …`) — catches compile-time parameter errors (wrong colour names, invalid builder values, etc.).
 2. **Run the executable once** (even without arguments) — catches registration-time errors (typos in argument names passed to group constraints).
 
-Using the provided `pixi` tasks:
+Note that a single `mojo run` is enough (it sequentially builds and then executes the binary).
 
-```bash
-# Step 1: Compile — catches compile-time errors
-pixi run build
-
-# Step 2: Execute in debug mode — catches registration-time errors
-pixi run debug
-```
-
-Both steps are included in the CI workflow, so pull requests automatically catch both classes of errors.
+> **ArgMojo contributors:** the repository provides `pixi run debug`, which packages the library and runs every example under `-D ASSERT=all` with `--help`. This exercises both compile-time and registration-time validation in one step. The CI workflow runs `pixi run package`, `pixi run test`, and `pixi run debug`, so pull requests automatically catch both classes of errors.
 
 ## Cross-Library Method Name Reference
 

--- a/examples/demo.mojo
+++ b/examples/demo.mojo
@@ -298,12 +298,10 @@ fn main() raises:
     export.add_argument(
         Argument("toml", help="Export as TOML").long["toml"]().flag()
     )
-    var format_group: List[String] = ["json", "yaml", "toml"]
-    export.one_required(format_group.copy())
-    export.mutually_exclusive(format_group^)
+    export.one_required(["json", "yaml", "toml"])
+    export.mutually_exclusive(["json", "yaml", "toml"])
     export.help_on_no_arguments()
-    var export_aliases: List[String] = ["ex"]
-    export.command_aliases(export_aliases^)
+    export.command_aliases(["ex"])
     app.add_subcommand(export^)
 
     # ── Subcommand: analyze ──────────────────────────────────────────────
@@ -328,8 +326,7 @@ fn main() raises:
         .clamp()
     )
     analyze.help_on_no_arguments()
-    var analyze_aliases: List[String] = ["an"]
-    analyze.command_aliases(analyze_aliases^)
+    analyze.command_aliases(["an", "ana"])
     app.add_subcommand(analyze^)
 
     # ── Subcommand: run (remainder + allow_hyphen_values) ────────────────

--- a/pixi.toml
+++ b/pixi.toml
@@ -55,11 +55,14 @@ build = """pixi run package \
 """
 
 # run (debug mode) example binaries
+# Uses --help so examples with required positional args exit cleanly.
+# The purpose is to exercise command construction (registration-time
+# validation), not argument parsing.
 debug = """pixi run package \
-&& mojo run -I src -D ASSERT=all examples/mgrep.mojo \
-&& mojo run -I src -D ASSERT=all examples/mgit.mojo \
-&& mojo run -I src -D ASSERT=all examples/demo.mojo \
-&& mojo run -I src -D ASSERT=all examples/yu.mojo \
+&& mojo run -I src -D ASSERT=all examples/mgrep.mojo -- --help \
+&& mojo run -I src -D ASSERT=all examples/mgit.mojo -- --help \
+&& mojo run -I src -D ASSERT=all examples/demo.mojo -- --help \
+&& mojo run -I src -D ASSERT=all examples/yu.mojo -- --help \
 """
 
 # clean build artifacts

--- a/pixi.toml
+++ b/pixi.toml
@@ -54,5 +54,13 @@ build = """pixi run package \
 && mojo build -I src examples/yu.mojo -o yu \
 """
 
+# run (debug mode) example binaries
+debug = """pixi run package \
+&& mojo run -I src -D ASSERT=all examples/mgrep.mojo \
+&& mojo run -I src -D ASSERT=all examples/mgit.mojo \
+&& mojo run -I src -D ASSERT=all examples/demo.mojo \
+&& mojo run -I src -D ASSERT=all examples/yu.mojo \
+"""
+
 # clean build artifacts
 clean = "rm -f argmojo.mojopkg mgrep mgit demo yu"

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -888,15 +888,22 @@ struct Command(Copyable, Movable, Stringable, Writable):
         """
         self._disable_punctuation_correction = True
 
-    # TODO: See whether compile-time validation is possible
-    fn mutually_exclusive(mut self, var names: List[String]):
+    fn mutually_exclusive(mut self, var names: List[String]) raises:
         """Declares a group of mutually exclusive arguments.
 
         At most one argument from each group may be provided. Parsing
         will fail if more than one is present.
 
+        All names must refer to arguments already registered via
+        ``add_argument()``.  An ``Error`` is raised immediately if any
+        name is unknown, so that typos are caught during command
+        construction rather than at end-user runtime.
+
         Args:
             names: The internal names of the arguments in the group.
+
+        Raises:
+            Error: If any name in the group is not a registered argument.
 
         Example:
 
@@ -909,16 +916,34 @@ struct Command(Copyable, Movable, Stringable, Writable):
         command.mutually_exclusive(format_excl^)
         ```
         """
+        for ni in range(len(names)):
+            var found = False
+            for ai in range(len(self.args)):
+                if self.args[ai].name == names[ni]:
+                    found = True
+                    break
+            if not found:
+                raise Error(
+                    "mutually_exclusive(): unknown argument '" + names[ni] + "'"
+                )
         self._exclusive_groups.append(names^)
 
-    fn required_together(mut self, var names: List[String]):
+    fn required_together(mut self, var names: List[String]) raises:
         """Declares a group of arguments that must be provided together.
 
         If any argument from the group is provided, all others in the
         group must also be provided. Parsing will fail otherwise.
 
+        All names must refer to arguments already registered via
+        ``add_argument()``.  An ``Error`` is raised immediately if any
+        name is unknown, so that typos are caught during command
+        construction rather than at end-user runtime.
+
         Args:
             names: The internal names of the arguments in the group.
+
+        Raises:
+            Error: If any name in the group is not a registered argument.
 
         Example:
 
@@ -931,16 +956,34 @@ struct Command(Copyable, Movable, Stringable, Writable):
         command.required_together(auth_group^)
         ```
         """
+        for ni in range(len(names)):
+            var found = False
+            for ai in range(len(self.args)):
+                if self.args[ai].name == names[ni]:
+                    found = True
+                    break
+            if not found:
+                raise Error(
+                    "required_together(): unknown argument '" + names[ni] + "'"
+                )
         self._required_groups.append(names^)
 
-    fn one_required(mut self, var names: List[String]):
+    fn one_required(mut self, var names: List[String]) raises:
         """Declares a group where at least one argument must be provided.
 
         Parsing will fail if none of the arguments in the group are
         present on the command line.
 
+        All names must refer to arguments already registered via
+        ``add_argument()``.  An ``Error`` is raised immediately if any
+        name is unknown, so that typos are caught during command
+        construction rather than at end-user runtime.
+
         Args:
             names: The internal names of the arguments in the group.
+
+        Raises:
+            Error: If any name in the group is not a registered argument.
 
         Example:
 
@@ -952,17 +995,35 @@ struct Command(Copyable, Movable, Stringable, Writable):
         command.one_required(["json", "yaml"])
         ```
         """
+        for ni in range(len(names)):
+            var found = False
+            for ai in range(len(self.args)):
+                if self.args[ai].name == names[ni]:
+                    found = True
+                    break
+            if not found:
+                raise Error(
+                    "one_required(): unknown argument '" + names[ni] + "'"
+                )
         self._one_required_groups.append(names^)
 
-    fn required_if(mut self, target: String, condition: String):
+    fn required_if(mut self, target: String, condition: String) raises:
         """Declares that an argument is required when another is present.
 
         When ``condition`` is provided on the command line, ``target``
         must also be provided.  Parsing will fail otherwise.
 
+        Both ``target`` and ``condition`` must refer to arguments already
+        registered via ``add_argument()``.  An ``Error`` is raised
+        immediately if either name is unknown, so that typos are caught
+        during command construction rather than at end-user runtime.
+
         Args:
             target: The name of the argument that becomes required.
             condition: The name of the argument that triggers the requirement.
+
+        Raises:
+            Error: If either name is not a registered argument.
 
         Example:
 
@@ -974,6 +1035,17 @@ struct Command(Copyable, Movable, Stringable, Writable):
         command.required_if("output", "save")
         ```
         """
+        var checks: List[String] = [target, condition]
+        for ci in range(len(checks)):
+            var found = False
+            for ai in range(len(self.args)):
+                if self.args[ai].name == checks[ci]:
+                    found = True
+                    break
+            if not found:
+                raise Error(
+                    "required_if(): unknown argument '" + checks[ci] + "'"
+                )
         var pair: List[String] = [target, condition]
         self._conditional_reqs.append(pair^)
 

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -744,6 +744,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         """
         self._tips.append(tip)
 
+    # TODO: alias_name[name: StringLiteral](mut self) for compile-time checks
     fn command_aliases(mut self, var names: List[String]):
         """Registers alternate names for this command when used as a subcommand.
 
@@ -790,6 +791,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         """
         self._is_hidden = True
 
+    # TODO: response_file_prefix[prefix: StringLiteral](mut self) for compile-time checks
     fn response_file_prefix(mut self, prefix: String = "@"):
         """Enables response-file expansion for this command.
 
@@ -886,6 +888,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         """
         self._disable_punctuation_correction = True
 
+    # TODO: See whether compile-time validation is possible
     fn mutually_exclusive(mut self, var names: List[String]):
         """Declares a group of mutually exclusive arguments.
 
@@ -946,8 +949,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         var command = Command("myapp", "A sample application")
         command.add_argument(Argument("json", help="Output as JSON").long["json"]().flag())
         command.add_argument(Argument("yaml", help="Output as YAML").long["yaml"]().flag())
-        var format_group: List[String] = ["json", "yaml"]
-        command.one_required(format_group^)
+        command.one_required(["json", "yaml"])
         ```
         """
         self._one_required_groups.append(names^)

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -912,11 +912,20 @@ struct Command(Copyable, Movable, Stringable, Writable):
         var command = Command("myapp", "A sample application")
         command.add_argument(Argument("json", help="Output as JSON").long["json"]().flag())
         command.add_argument(Argument("yaml", help="Output as YAML").long["yaml"]().flag())
-        var format_excl: List[String] = ["json", "yaml"]
-        command.mutually_exclusive(format_excl^)
+        command.mutually_exclusive(["json", "yaml"])
         ```
         """
+        if len(names) == 0:
+            raise Error("mutually_exclusive(): 'names' list must not be empty")
+        var unique = List[String]()
         for ni in range(len(names)):
+            var dup = False
+            for ui in range(len(unique)):
+                if unique[ui] == names[ni]:
+                    dup = True
+                    break
+            if dup:
+                continue  # Proceed to the next name; duplicates are ignored.
             var found = False
             for ai in range(len(self.args)):
                 if self.args[ai].name == names[ni]:
@@ -926,7 +935,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 raise Error(
                     "mutually_exclusive(): unknown argument '" + names[ni] + "'"
                 )
-        self._exclusive_groups.append(names^)
+            unique.append(names[ni])
+        self._exclusive_groups.append(unique^)
 
     fn required_together(mut self, var names: List[String]) raises:
         """Declares a group of arguments that must be provided together.
@@ -952,11 +962,20 @@ struct Command(Copyable, Movable, Stringable, Writable):
         var command = Command("myapp", "A sample application")
         command.add_argument(Argument("username", help="Auth username").long["username"]().short["u"]())
         command.add_argument(Argument("password", help="Auth password").long["password"]().short["p"]())
-        var auth_group: List[String] = ["username", "password"]
-        command.required_together(auth_group^)
+        command.required_together(["username", "password"])
         ```
         """
+        if len(names) == 0:
+            raise Error("required_together(): 'names' list must not be empty")
+        var unique = List[String]()
         for ni in range(len(names)):
+            var dup = False
+            for ui in range(len(unique)):
+                if unique[ui] == names[ni]:
+                    dup = True
+                    break
+            if dup:
+                continue
             var found = False
             for ai in range(len(self.args)):
                 if self.args[ai].name == names[ni]:
@@ -966,7 +985,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 raise Error(
                     "required_together(): unknown argument '" + names[ni] + "'"
                 )
-        self._required_groups.append(names^)
+            unique.append(names[ni])
+        self._required_groups.append(unique^)
 
     fn one_required(mut self, var names: List[String]) raises:
         """Declares a group where at least one argument must be provided.
@@ -995,7 +1015,17 @@ struct Command(Copyable, Movable, Stringable, Writable):
         command.one_required(["json", "yaml"])
         ```
         """
+        if len(names) == 0:
+            raise Error("one_required(): 'names' list must not be empty")
+        var unique = List[String]()
         for ni in range(len(names)):
+            var dup = False
+            for ui in range(len(unique)):
+                if unique[ui] == names[ni]:
+                    dup = True
+                    break
+            if dup:
+                continue
             var found = False
             for ai in range(len(self.args)):
                 if self.args[ai].name == names[ni]:
@@ -1005,7 +1035,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 raise Error(
                     "one_required(): unknown argument '" + names[ni] + "'"
                 )
-        self._one_required_groups.append(names^)
+            unique.append(names[ni])
+        self._one_required_groups.append(unique^)
 
     fn required_if(mut self, target: String, condition: String) raises:
         """Declares that an argument is required when another is present.
@@ -1035,6 +1066,12 @@ struct Command(Copyable, Movable, Stringable, Writable):
         command.required_if("output", "save")
         ```
         """
+        if target == condition:
+            raise Error(
+                "required_if(): target and condition must differ, got '"
+                + target
+                + "'"
+            )
         var checks: List[String] = [target, condition]
         for ci in range(len(checks)):
             var found = False

--- a/tests/test_groups.mojo
+++ b/tests/test_groups.mojo
@@ -246,8 +246,7 @@ fn test_one_required_multiple_provided() raises:
     command.add_argument(
         Argument("yaml", help="YAML output").long["yaml"]().flag()
     )
-    var group: List[String] = ["json", "yaml"]
-    command.one_required(group^)
+    command.one_required(["json", "yaml"])
 
     # Both provided — one_required is satisfied (it only requires at least one).
     var args: List[String] = ["test", "--json", "--yaml"]
@@ -265,8 +264,7 @@ fn test_one_required_none_provided() raises:
     command.add_argument(
         Argument("yaml", help="YAML output").long["yaml"]().flag()
     )
-    var group: List[String] = ["json", "yaml"]
-    command.one_required(group^)
+    command.one_required(["json", "yaml"])
 
     var args: List[String] = ["test"]
     var caught = False
@@ -299,8 +297,7 @@ fn test_one_required_with_value_args() raises:
     command.add_argument(
         Argument("stdin", help="Read from stdin").long["stdin"]().flag()
     )
-    var group: List[String] = ["input", "stdin"]
-    command.one_required(group^)
+    command.one_required(["input", "stdin"])
 
     # Providing --input satisfies the group.
     var args: List[String] = ["test", "--input", "data.txt"]

--- a/tests/test_groups.mojo
+++ b/tests/test_groups.mojo
@@ -694,5 +694,130 @@ fn test_conditional_req_error_uses_display_names() raises:
     assert_true(caught, msg="Should raise error")
 
 
+# ===------------------------------------------------------------------=== #
+# Registration-time validation: unknown argument names
+# ===------------------------------------------------------------------=== #
+
+
+fn test_mutually_exclusive_unknown_arg() raises:
+    """Tests that mutually_exclusive() rejects unknown argument names."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("json", help="JSON output").long["json"]().flag()
+    )
+
+    var caught = False
+    try:
+        var group: List[String] = ["json", "nonexistent"]
+        command.mutually_exclusive(group^)
+    except e:
+        caught = True
+        var msg = String(e)
+        assert_true(
+            "unknown" in String.lower(msg),
+            msg="error should mention 'unknown'",
+        )
+        assert_true(
+            "nonexistent" in msg,
+            msg="error should mention the bad name",
+        )
+    assert_true(caught, msg="unknown arg should raise an error")
+
+
+fn test_required_together_unknown_arg() raises:
+    """Tests that required_together() rejects unknown argument names."""
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("username", help="User").long["username"]())
+
+    var caught = False
+    try:
+        var group: List[String] = ["username", "nonexistent"]
+        command.required_together(group^)
+    except e:
+        caught = True
+        var msg = String(e)
+        assert_true(
+            "unknown" in String.lower(msg),
+            msg="error should mention 'unknown'",
+        )
+        assert_true(
+            "nonexistent" in msg,
+            msg="error should mention the bad name",
+        )
+    assert_true(caught, msg="unknown arg should raise an error")
+
+
+fn test_one_required_unknown_arg() raises:
+    """Tests that one_required() rejects unknown argument names."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("json", help="JSON output").long["json"]().flag()
+    )
+
+    var caught = False
+    try:
+        command.one_required(["json", "nonexistent"])
+    except e:
+        caught = True
+        var msg = String(e)
+        assert_true(
+            "unknown" in String.lower(msg),
+            msg="error should mention 'unknown'",
+        )
+        assert_true(
+            "nonexistent" in msg,
+            msg="error should mention the bad name",
+        )
+    assert_true(caught, msg="unknown arg should raise an error")
+
+
+fn test_required_if_unknown_target() raises:
+    """Tests that required_if() rejects unknown target argument."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("save", help="Save results").long["save"]().flag()
+    )
+
+    var caught = False
+    try:
+        command.required_if("nonexistent", "save")
+    except e:
+        caught = True
+        var msg = String(e)
+        assert_true(
+            "unknown" in String.lower(msg),
+            msg="error should mention 'unknown'",
+        )
+        assert_true(
+            "nonexistent" in msg,
+            msg="error should mention the bad name",
+        )
+    assert_true(caught, msg="unknown target should raise an error")
+
+
+fn test_required_if_unknown_condition() raises:
+    """Tests that required_if() rejects unknown condition argument."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("output", help="Output path").long["output"]()
+    )
+
+    var caught = False
+    try:
+        command.required_if("output", "nonexistent")
+    except e:
+        caught = True
+        var msg = String(e)
+        assert_true(
+            "unknown" in String.lower(msg),
+            msg="error should mention 'unknown'",
+        )
+        assert_true(
+            "nonexistent" in msg,
+            msg="error should mention the bad name",
+        )
+    assert_true(caught, msg="unknown condition should raise an error")
+
+
 fn main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
This PR implements earlier, developer-facing runtime validation for `Command` constraint registration so typos in argument names are caught during command construction (instead of at end-user parse time), and updates docs/tests/CI to reflect and exercise the new behavior.

**Changes:**
- Add registration-time “unknown argument name” checks (and mark as `raises`) for `mutually_exclusive`, `required_together`, `one_required`, and `required_if`.
- Expand unit tests to cover the new validation failures.
- Add a `pixi run debug` task and run it in CI; document the validation model in the user manual.