### PR TITLE
[mojo] Update codebase to Mojo v0.26.2

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-22.04", "macos-latest"]
+        os: ["macos-latest"]
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,8 @@ Comment out unreleased changes here. This file will be edited just before each r
 
 ## Unreleased (v0.4.0)
 
+ArgMojo v0.4.0 targets Mojo v0.26.2.
+
 ### ⭐️ New features in v0.4.0
 
 1. Add `.default_if_no_value["value"]()` builder method for default-if-no-value semantics. When an option has a default-if-no-value, it may appear without an explicit value: `--compress` uses the default-if-no-value, while `--compress=bzip2` uses the explicit value. For long options, `.default_if_no_value()` implies `.require_equals()`. For short options, `-c` uses the default-if-no-value while `-cbzip2` uses the attached value (PR #12).
@@ -26,8 +28,22 @@ Comment out unreleased changes here. This file will be edited just before each r
 14. **Interactive prompting.** Add `.prompt()` and `.prompt["text"]()` builder methods on `Argument`. When an argument marked with `.prompt()` is not provided on the command line, the user is interactively prompted for its value before validation runs. Use `.prompt()` to prompt with the argument's help text, or `.prompt["Custom text"]()` to set a custom message. Works on both required and optional arguments. Prompts show valid choices for `.choice[]()` arguments and show default values in parentheses. For flag arguments, `y`/`n` input is accepted. When stdin is not a terminal (e.g., piped input, CI environments, `/dev/null`), or when `input()` otherwise raises, the exception is caught, prompting stops gracefully, and any values collected so far are preserved (PR #23).
 15. **Argument parents.** Add `add_parent(parent)` method on `Command`. Copies all argument definitions and group constraints (mutually exclusive, required together, one-required, conditional requirements, implications) from a parent `Command` into the current command. This lets you share a common set of arguments across multiple commands without repeating them — equivalent to Python argparse's `parents` parameter. The parent is not modified. All registration-time validation guards run on each inherited argument as usual (PR #25).
 16. **Confirmation option.** Add `confirmation_option()` and `confirmation_option["prompt"]()` builder methods on `Command`. When enabled, the command automatically registers a `--yes` / `-y` flag and prompts the user for confirmation after parsing (and after interactive prompting, if any). If the user does not confirm (`y`/`yes`), the command aborts with an error. Passing `--yes` or `-y` on the command line skips the prompt entirely. When stdin is not interactive (piped input, `/dev/null`), the command aborts gracefully. This is equivalent to Click's `confirmation_option` decorator (PR #26).
-17. **Usage line customisation.** Add `usage(text)` method on `Command`. When set, the given text replaces the auto-generated `Usage: myapp [OPTIONS] ...` line in both `--help` output and error messages. This lets you write git-style usage strings like `git [-v | --version] [-h | --help] [-C <path>] <command> [<args>]`. When not set, the default auto-generated usage line is used.
+17. **Usage line customisation.** Add `usage(text)` method on `Command`. When set, the given text replaces the auto-generated `Usage: myapp [OPTIONS] ...` line in both `--help` output and error messages. This lets you write git-style usage strings like `git [-v | --version] [-h | --help] [-C <path>] <command> [<args>]`. When not set, the default auto-generated usage line is used (PR #29).
 18. **Password / masked input.** Add `.password()` builder method on `Argument`. When combined with `.prompt()` (implied automatically), the user's typed input is hidden — terminal echo is disabled via POSIX `tcsetattr(3)` while the user types, then re-enabled afterwards. This is equivalent to Click's `hide_input=True` / Python's `getpass.getpass()`. If stdin is not a terminal (piped input, CI, `/dev/null`), the call falls back gracefully — prompting stops and defaults are applied as usual. `.password()` cannot be used on flag or count arguments (rejected at `add_argument()` time) (PR #28).
+
+### 🔄 Mojo v0.26.2 migration in v0.4.0
+
+ArgMojo v0.4.0 targets **Mojo v0.26.2** (previously v0.26.1). The following codebase-wide changes were made to adapt to the new language semantics (PR #29):
+
+- **Bump Mojo dependency** from `==0.26.1` to `==0.26.2` in `pixi.toml` and regenerate `pixi.lock`.
+- **Migrate stdlib imports** to the new `std.*` namespace: `from sys` → `from std.sys`, `from os` → `from std.os`, `from os.path` → `from std.os.path`, `from sys.ffi` → `from std.ffi`, `from testing` → `from std.testing` (21 test files).
+- **Replace `constrained[]` with `comptime assert`** across all compile-time validation sites (argument builder methods, colour resolution, shell completion dispatch).
+- **Replace `@parameter if` with `comptime if`** in `_resolve_color[]` and `generate_completion[]`.
+- **Unify move/copy initialisers** to the new `__init__` forms: `__copyinit__` → `__init__(out self, *, copy: Self)`, `__moveinit__` → `__init__(out self, *, deinit take: Self)` for `Argument`, `Command`, and `ParseResult`.
+- **Remove `Stringable` from trait lists**: `Argument`, `Command`, and `ParseResult` now conform to `Copyable, Movable, Writable` only (`Stringable` was removed from the stdlib).
+- **Add `byte=` keyword to all string slicing** operations (`token[i:j]` → `token[byte=i:j]`) in `command.mojo`, `utils.mojo`, and `examples/yu.mojo`.
+- **Fix aliasing violation**: `em_dash + em_dash` → `chr(0x2014) + chr(0x2014)` to avoid the new same-variable borrowing alias check.
+- **Replace `fn` with `def`** across all 30 `.mojo` files (754 declarations). In Mojo v0.26.2, `def` has the same semantics as the old `fn` (non-raising by default, requires explicit `raises`), and `fn` is deprecated.
 
 ### 🦋 Changed in v0.4.0
 
@@ -66,6 +82,7 @@ Comment out unreleased changes here. This file will be edited just before each r
 - Add `tests/test_parents.mojo` with 20 tests covering argument parents: basic flag/value/positional/default inheritance, short flags, multiple parents, child-own args coexistence, group constraint inheritance (mutually exclusive, required together, one-required, conditional, implications), parent shared across children, count/append/range argument inheritance, empty parent, parent immutability, and parent with subcommands (PR #25).
 - Add `tests/test_confirmation.mojo` with 13 tests covering confirmation option: `--yes`/`-y` flag skips, non-interactive stdin abort, custom prompt text, coexistence with other arguments, no-confirmation normal behavior, subcommand integration, copy preservation, prompt argument integration, and parent argument integration (PR #26).
 - Add `tests/test_password.mojo` with 16 tests covering password / masked input: builder method correctness (`.password()` standalone, with `.prompt["text"]()`, ordering), default field values, copy propagation, validation guards (flag and count rejection), prompting skipped when value provided, defaults and choices integration, required argument error, parent inheritance, subcommand integration, positional usage, and graceful fallback on non-interactive stdin (PR #28).
+- Add `tests/test_usage.mojo` with 11 tests covering custom usage line: plain and coloured help output, replacement of auto-generated usage, default usage for various argument configurations (optional positional, subcommands), copy preservation, coexistence with subcommands, description display, parsing correctness, and usage hint in error messages (PR #29).
 
 ---
 

--- a/examples/demo.mojo
+++ b/examples/demo.mojo
@@ -109,7 +109,7 @@ Try these (build first with: pixi run package && mojo build -I src -o demo examp
 from argmojo import Argument, Command
 
 
-fn main() raises:
+def main() raises:
     var app = Command(
         "demo",
         (

--- a/examples/mgit.mojo
+++ b/examples/mgit.mojo
@@ -27,7 +27,7 @@ Try these:
 from argmojo import Argument, Command
 
 
-fn main() raises:
+def main() raises:
     var app = Command(
         "mgit",
         "A git-like CLI to demonstrate argmojo with subcommands.",

--- a/examples/mgrep.mojo
+++ b/examples/mgrep.mojo
@@ -15,7 +15,7 @@ and custom tips.
 Try these:
   grep --help
   grep --version
-  grep "fn main" ./src
+  grep "def main" ./src
   grep -rnic "TODO" ./src --max-depth 5
   grep "pattern" --format json --tag fixme --tag urgent
   grep -E "foo|bar" ./src --color --max-depth 3
@@ -25,7 +25,7 @@ Try these:
 from argmojo import Argument, Command
 
 
-fn main() raises:
+def main() raises:
     var app = Command(
         "mgrep",
         "Search for PATTERN in each FILE.",
@@ -243,7 +243,7 @@ fn main() raises:
     app.allow_negative_numbers()
 
     # ── Custom tips ──────────────────────────────────────────────────────
-    app.add_tip('Use quotes for patterns with spaces: grep "fn main" ./src')
+    app.add_tip('Use quotes for patterns with spaces: grep "def main" ./src')
 
     # ── Show help when invoked with no arguments ─────────────────────────
     app.help_on_no_arguments()

--- a/examples/yu.mojo
+++ b/examples/yu.mojo
@@ -41,7 +41,7 @@ Full-width auto-correction examples (CJK users may type these accidentally):
 from argmojo import Argument, Command
 
 
-fn _build_ling_table() -> Dict[String, String]:
+def _build_ling_table() -> Dict[String, String]:
     """Build 宇浩靈明 lookup table (20 high-frequency characters)."""
     var d: Dict[String, String] = {
         "的": "d",
@@ -70,7 +70,7 @@ fn _build_ling_table() -> Dict[String, String]:
     return d^
 
 
-fn _build_joy_table() -> Dict[String, String]:
+def _build_joy_table() -> Dict[String, String]:
     """Build 宇浩卿雲 lookup table (20 high-frequency characters)."""
     var d: Dict[String, String] = {
         "的": "d",
@@ -99,7 +99,7 @@ fn _build_joy_table() -> Dict[String, String]:
     return d^
 
 
-fn _build_star_table() -> Dict[String, String]:
+def _build_star_table() -> Dict[String, String]:
     """Build 宇浩星陳 lookup table (20 high-frequency characters)."""
     var d: Dict[String, String] = {
         "的": "d",
@@ -128,13 +128,13 @@ fn _build_star_table() -> Dict[String, String]:
     return d^
 
 
-fn _lookup(table: Dict[String, String], ch: String) raises -> String:
+def _lookup(table: Dict[String, String], ch: String) raises -> String:
     if ch in table:
         return table[ch]
     return "（未收錄）"
 
 
-fn main() raises:
+def main() raises:
     var app = Command(
         "yu",
         "宇浩輸入法單字編碼查詢。完整碼表請見 https://shurufa.app",

--- a/examples/yu.mojo
+++ b/examples/yu.mojo
@@ -185,7 +185,7 @@ def main() raises:
             seq_len = 3
         else:
             seq_len = 4
-        chars.append(String(input[i : i + seq_len]))
+        chars.append(String(input[byte = i : i + seq_len]))
         i += seq_len
 
     if show_all:

--- a/pixi.lock
+++ b/pixi.lock
@@ -5,6 +5,8 @@ environments:
     - url: https://conda.modular.com/max/
     - url: https://repo.prefix.dev/modular-community/
     - url: https://conda.anaconda.org/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -34,10 +36,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
-      - conda: https://conda.modular.com/max/noarch/mblack-26.1.0-release.conda
-      - conda: https://conda.modular.com/max/linux-64/mojo-0.26.1.0-release.conda
-      - conda: https://conda.modular.com/max/linux-64/mojo-compiler-0.26.1.0-release.conda
-      - conda: https://conda.modular.com/max/noarch/mojo-python-0.26.1.0-release.conda
+      - conda: https://conda.modular.com/max/noarch/mblack-26.2.0-release.conda
+      - conda: https://conda.modular.com/max/linux-64/mojo-0.26.2.0-release.conda
+      - conda: https://conda.modular.com/max/linux-64/mojo-compiler-0.26.2.0-release.conda
+      - conda: https://conda.modular.com/max/noarch/mojo-python-0.26.2.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
@@ -79,10 +81,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.20-h99b78c6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.51.2-h1ae2325_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
-      - conda: https://conda.modular.com/max/noarch/mblack-26.1.0-release.conda
-      - conda: https://conda.modular.com/max/osx-arm64/mojo-0.26.1.0-release.conda
-      - conda: https://conda.modular.com/max/osx-arm64/mojo-compiler-0.26.1.0-release.conda
-      - conda: https://conda.modular.com/max/noarch/mojo-python-0.26.1.0-release.conda
+      - conda: https://conda.modular.com/max/noarch/mblack-26.2.0-release.conda
+      - conda: https://conda.modular.com/max/osx-arm64/mojo-0.26.2.0-release.conda
+      - conda: https://conda.modular.com/max/osx-arm64/mojo-compiler-0.26.2.0-release.conda
+      - conda: https://conda.modular.com/max/noarch/mojo-python-0.26.2.0-release.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.1-hd24854e_1.conda
@@ -521,9 +523,10 @@ packages:
   license_family: Other
   size: 46438
   timestamp: 1727963202283
-- conda: https://conda.modular.com/max/noarch/mblack-26.1.0-release.conda
+- conda: https://conda.modular.com/max/noarch/mblack-26.2.0-release.conda
   noarch: python
-  sha256: 6ccec52fe7354f44be93a41a122d2214ecdb030e6362afe8e7876eab35472e62
+  sha256: 3c2fceb89cefca899dcd7c8f26a6202acacb2a073e4cb2ef365514a465d01dcd
+  md5: dd13667299b9b66b8b314dc8d95b54a3
   depends:
   - python >=3.10
   - click >=8.0.0
@@ -532,52 +535,56 @@ packages:
   - pathspec >=0.9.0
   - platformdirs >=2
   - tomli >=1.1.0
-  - python
-  license: MIT
-  size: 135743
-  timestamp: 1769478151312
-- conda: https://conda.modular.com/max/linux-64/mojo-0.26.1.0-release.conda
-  sha256: e945e8fbff0fdd2064ea193b26fb4ba95ab782367cfd2a2c4522350066434494
+  license: LicenseRef-Modular-Proprietary
+  size: 133798
+  timestamp: 1773780198354
+- conda: https://conda.modular.com/max/linux-64/mojo-0.26.2.0-release.conda
+  sha256: 4d7047466c13d92b1c8eb19c6d203a8503afbd2b1ad63eb5289a8f4bbf4d2945
+  md5: 61318988733a695066b39704f6e08bd2
   depends:
   - python >=3.10
-  - mojo-compiler ==0.26.1.0 release
-  - mblack ==26.1.0 release
+  - mojo-compiler ==0.26.2.0
+  - mblack ==26.2.0
   - jupyter_client >=8.6.2,<8.7
   license: LicenseRef-Modular-Proprietary
-  size: 89061870
-  timestamp: 1769478151312
-- conda: https://conda.modular.com/max/osx-arm64/mojo-0.26.1.0-release.conda
-  sha256: ba205a5bb4fafc47abee5db87fd58dee091b104d20651363f3dc1e6ca60e1d21
+  size: 89753715
+  timestamp: 1773797215278
+- conda: https://conda.modular.com/max/osx-arm64/mojo-0.26.2.0-release.conda
+  sha256: e35b8d34564b30189c5a985990466b4283f9e1d897baf23fe9ddbcbc9283459c
+  md5: 12e4d8397c451b7c8a55ff5a759ce00b
   depends:
   - python >=3.10
-  - mojo-compiler ==0.26.1.0 release
-  - mblack ==26.1.0 release
+  - mojo-compiler ==0.26.2.0
+  - mblack ==26.2.0
   - jupyter_client >=8.6.2,<8.7
   license: LicenseRef-Modular-Proprietary
-  size: 75217574
-  timestamp: 1769480882531
-- conda: https://conda.modular.com/max/linux-64/mojo-compiler-0.26.1.0-release.conda
-  sha256: aad6cf9e55824ada1147acaee8b37c68ef1973b208a4a4182f7ac85bc20e690c
+  size: 81534498
+  timestamp: 1773797099755
+- conda: https://conda.modular.com/max/linux-64/mojo-compiler-0.26.2.0-release.conda
+  sha256: e53f30d72a65e6b0a67745e6988f978d8f6ecc14531420631c9719eb9c7b9c2b
+  md5: e3a673daa0ddf3ca6af297daee4ceab5
   depends:
-  - mojo-python ==0.26.1.0 release
+  - mojo-python ==0.26.2.0
   license: LicenseRef-Modular-Proprietary
-  size: 85722183
-  timestamp: 1769478151311
-- conda: https://conda.modular.com/max/osx-arm64/mojo-compiler-0.26.1.0-release.conda
-  sha256: 335323a29c632adaf75958366a93352082f2e6a8bee43353269e86eefa86a2cf
+  size: 89091679
+  timestamp: 1773797216619
+- conda: https://conda.modular.com/max/osx-arm64/mojo-compiler-0.26.2.0-release.conda
+  sha256: e82cb7ce1a756876a233d364d5397adca5ad7e20fff5204c1c7e93aefe4549b5
+  md5: 96e3ec50a2ea4abdb9fc4f3f89dc874b
   depends:
-  - mojo-python ==0.26.1.0 release
+  - mojo-python ==0.26.2.0
   license: LicenseRef-Modular-Proprietary
-  size: 65952232
-  timestamp: 1769480882531
-- conda: https://conda.modular.com/max/noarch/mojo-python-0.26.1.0-release.conda
+  size: 67499721
+  timestamp: 1773797103208
+- conda: https://conda.modular.com/max/noarch/mojo-python-0.26.2.0-release.conda
   noarch: python
-  sha256: 9bccbc9045984961426038832c8657198f8ef238d95e00d9bdcff2dd139b7fdf
+  sha256: 2d9e350cfe7a0ae5d96dea13c082b09f21aac8ac4caa3e5def6b075930348fa1
+  md5: 67a4fc0d47e84d3a91c4f12cc912c7ac
   depends:
-  - python
+  - python >=3.10
   license: LicenseRef-Modular-Proprietary
-  size: 24169
-  timestamp: 1769478151311
+  size: 22936
+  timestamp: 1773780198161
 - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
   sha256: 6ed158e4e5dd8f6a10ad9e525631e35cee8557718f83de7a4e3966b1f772c4b1
   md5: e9c622e0d00fa24a6292279af3ab6d06

--- a/pixi.toml
+++ b/pixi.toml
@@ -13,8 +13,7 @@ readme = "README.md"
 version = "0.3.0"
 
 [dependencies]
-mojo = "==0.26.1"
-python = ">=3.13,<3.14"
+mojo = "==0.26.2"
 
 [tasks]
 # format the code

--- a/pixi.toml
+++ b/pixi.toml
@@ -50,6 +50,35 @@ test = """\
 # is temporarily disabled to work around a Mojo compiler deadlock
 # with -D ASSERT=all.  Re-enable when the compiler bug is fixed.
 
+# run tests (parallel, fail if any test fails)
+t = """\
+  pixi run format \
+  && pixi run package \
+  && bash -c '\
+  pids=(); \
+  mojo run -I src -D ASSERT=all tests/test_parse.mojo &              pids+=($!); \
+  mojo run -I src -D ASSERT=all tests/test_groups.mojo &             pids+=($!); \
+  mojo run -I src -D ASSERT=all tests/test_collect.mojo &            pids+=($!); \
+  mojo run -I src -D ASSERT=all tests/test_help.mojo &               pids+=($!); \
+  mojo run -I src -D ASSERT=all tests/test_extras.mojo &             pids+=($!); \
+  mojo run -I src -D ASSERT=all tests/test_subcommands.mojo &        pids+=($!); \
+  mojo run -I src -D ASSERT=all tests/test_negative_numbers.mojo &   pids+=($!); \
+  mojo run -I src -D ASSERT=all tests/test_persistent.mojo &         pids+=($!); \
+  mojo run -I src -D ASSERT=all tests/test_typo_suggestions.mojo &   pids+=($!); \
+  mojo run -I src -D ASSERT=all tests/test_completion.mojo &         pids+=($!); \
+  mojo run -I src -D ASSERT=all tests/test_implies.mojo &            pids+=($!); \
+  mojo run -I src -D ASSERT=all tests/test_const_require_equals.mojo & pids+=($!); \
+  mojo run -I src -D ASSERT=all tests/test_remainder_known.mojo &    pids+=($!); \
+  mojo run -I src -D ASSERT=all tests/test_fullwidth.mojo &          pids+=($!); \
+  mojo run -I src -D ASSERT=all tests/test_groups_help.mojo &        pids+=($!); \
+  mojo run -I src -D ASSERT=all tests/test_prompt.mojo < /dev/null & pids+=($!); \
+  mojo run -I src -D ASSERT=all tests/test_parents.mojo &            pids+=($!); \
+  mojo run -I src -D ASSERT=all tests/test_usage.mojo &              pids+=($!); \
+  mojo run -I src -D ASSERT=all tests/test_confirmation.mojo < /dev/null & pids+=($!); \
+  mojo run -I src -D ASSERT=all tests/test_password.mojo < /dev/null & pids+=($!); \
+  rc=0; for p in "${pids[@]}"; do wait "$p" || rc=1; done; exit $rc'
+"""
+
 # build example binaries (parallel, fail if any build fails)
 build = """pixi run package && bash -c '\
   pids=(); \
@@ -60,11 +89,22 @@ build = """pixi run package && bash -c '\
   rc=0; for p in "${pids[@]}"; do wait "$p" || rc=1; done; exit $rc'
 """
 
+# run (debug mode) example binaries
+# Uses --help so examples with required positional args exit cleanly.
+# The purpose is to exercise command construction (registration-time
+# validation), not argument parsing.
+debug = """pixi run package \
+&& mojo run -I src -D ASSERT=all examples/mgrep.mojo -- --help \
+&& mojo run -I src -D ASSERT=all examples/mgit.mojo -- --help \
+&& mojo run -I src -D ASSERT=all examples/demo.mojo -- --help \
+&& mojo run -I src -D ASSERT=all examples/yu.mojo -- --help \
+"""
+
 # run (debug mode) example binaries (parallel, fail if any run fails)
 # Uses --help so examples with required positional args exit cleanly.
 # The purpose is to exercise command construction (registration-time
 # validation), not argument parsing.
-debug = """pixi run package && bash -c '\
+d = """pixi run package && bash -c '\
   pids=(); \
   mojo run -I src -D ASSERT=all examples/mgrep.mojo -- --help & pids+=($!); \
   mojo run -I src -D ASSERT=all examples/mgit.mojo  -- --help & pids+=($!); \

--- a/pixi.toml
+++ b/pixi.toml
@@ -50,23 +50,27 @@ test = """\
 # is temporarily disabled to work around a Mojo compiler deadlock
 # with -D ASSERT=all.  Re-enable when the compiler bug is fixed.
 
-# build example binaries
-build = """pixi run package \
-&& mojo build -I src examples/mgrep.mojo -o mgrep \
-&& mojo build -I src examples/mgit.mojo -o mgit \
-&& mojo build -I src examples/demo.mojo -o demo \
-&& mojo build -I src examples/yu.mojo -o yu \
+# build example binaries (parallel, fail if any build fails)
+build = """pixi run package && bash -c '\
+  pids=(); \
+  mojo build -I src examples/mgrep.mojo -o mgrep & pids+=($!); \
+  mojo build -I src examples/mgit.mojo  -o mgit  & pids+=($!); \
+  mojo build -I src examples/demo.mojo  -o demo  & pids+=($!); \
+  mojo build -I src examples/yu.mojo    -o yu    & pids+=($!); \
+  rc=0; for p in "${pids[@]}"; do wait "$p" || rc=1; done; exit $rc'
 """
 
-# run (debug mode) example binaries
+# run (debug mode) example binaries (parallel, fail if any run fails)
 # Uses --help so examples with required positional args exit cleanly.
 # The purpose is to exercise command construction (registration-time
 # validation), not argument parsing.
-debug = """pixi run package \
-&& mojo run -I src -D ASSERT=all examples/mgrep.mojo -- --help \
-&& mojo run -I src -D ASSERT=all examples/mgit.mojo -- --help \
-&& mojo run -I src -D ASSERT=all examples/demo.mojo -- --help \
-&& mojo run -I src -D ASSERT=all examples/yu.mojo -- --help \
+debug = """pixi run package && bash -c '\
+  pids=(); \
+  mojo run -I src -D ASSERT=all examples/mgrep.mojo -- --help & pids+=($!); \
+  mojo run -I src -D ASSERT=all examples/mgit.mojo  -- --help & pids+=($!); \
+  mojo run -I src -D ASSERT=all examples/demo.mojo  -- --help & pids+=($!); \
+  mojo run -I src -D ASSERT=all examples/yu.mojo    -- --help & pids+=($!); \
+  rc=0; for p in "${pids[@]}"; do wait "$p" || rc=1; done; exit $rc'
 """
 
 # clean build artifacts

--- a/src/argmojo/argument.mojo
+++ b/src/argmojo/argument.mojo
@@ -1,13 +1,13 @@
 """Defines a single command-line argument."""
 
-from sys import exit, stderr
+from std.sys import exit, stderr
 
 
 comptime Arg = Argument
 """Shorthand alias for ``Argument``."""
 
 
-struct Argument(Copyable, Movable, Stringable, Writable):
+struct Argument(Copyable, Movable, Writable):
     """A command-line argument with its metadata and constraints.
 
     Use the builder pattern to configure the argument and add it to a Command.
@@ -201,7 +201,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         self._prompt_text = ""
         self._hide_input = False
 
-    fn __copyinit__(out self, copy: Self):
+    fn __init__(out self, *, copy: Self):
         """Creates a copy of this argument.
 
         Args:
@@ -249,49 +249,49 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         self._prompt_text = copy._prompt_text
         self._hide_input = copy._hide_input
 
-    fn __moveinit__(out self, deinit move: Self):
+    fn __init__(out self, *, deinit take: Self):
         """Moves the value from another Argument.
 
         Args:
-            move: The Argument to move from.
+            take: The Argument to move from.
         """
-        self.name = move.name^
-        self.help_text = move.help_text^
-        self._long_name = move._long_name^
-        self._short_name = move._short_name^
-        self._is_flag = move._is_flag
-        self._is_required = move._is_required
-        self._is_positional = move._is_positional
-        self._default_value = move._default_value^
-        self._has_default = move._has_default
-        self._choice_values = move._choice_values^
-        self._value_name = move._value_name^
-        self._is_hidden = move._is_hidden
-        self._is_count = move._is_count
-        self._is_negatable = move._is_negatable
-        self._is_append = move._is_append
-        self._delimiter_char = move._delimiter_char^
-        self._number_of_values = move._number_of_values
-        self._range_min = move._range_min
-        self._range_max = move._range_max
-        self._has_range = move._has_range
-        self._is_clamp = move._is_clamp
-        self._is_map = move._is_map
-        self._alias_names = move._alias_names^
-        self._deprecated_msg = move._deprecated_msg^
-        self._count_max = move._count_max
-        self._has_count_max = move._has_count_max
-        self._is_persistent = move._is_persistent
-        self._default_if_no_value = move._default_if_no_value^
-        self._has_default_if_no_value = move._has_default_if_no_value
-        self._require_equals = move._require_equals
-        self._is_remainder = move._is_remainder
-        self._allow_hyphen_values = move._allow_hyphen_values
-        self._value_name_wrapped = move._value_name_wrapped
-        self._group = move._group^
-        self._prompt = move._prompt
-        self._prompt_text = move._prompt_text^
-        self._hide_input = move._hide_input
+        self.name = take.name^
+        self.help_text = take.help_text^
+        self._long_name = take._long_name^
+        self._short_name = take._short_name^
+        self._is_flag = take._is_flag
+        self._is_required = take._is_required
+        self._is_positional = take._is_positional
+        self._default_value = take._default_value^
+        self._has_default = take._has_default
+        self._choice_values = take._choice_values^
+        self._value_name = take._value_name^
+        self._is_hidden = take._is_hidden
+        self._is_count = take._is_count
+        self._is_negatable = take._is_negatable
+        self._is_append = take._is_append
+        self._delimiter_char = take._delimiter_char^
+        self._number_of_values = take._number_of_values
+        self._range_min = take._range_min
+        self._range_max = take._range_max
+        self._has_range = take._has_range
+        self._is_clamp = take._is_clamp
+        self._is_map = take._is_map
+        self._alias_names = take._alias_names^
+        self._deprecated_msg = take._deprecated_msg^
+        self._count_max = take._count_max
+        self._has_count_max = take._has_count_max
+        self._is_persistent = take._is_persistent
+        self._default_if_no_value = take._default_if_no_value^
+        self._has_default_if_no_value = take._has_default_if_no_value
+        self._require_equals = take._require_equals
+        self._is_remainder = take._is_remainder
+        self._allow_hyphen_values = take._allow_hyphen_values
+        self._value_name_wrapped = take._value_name_wrapped
+        self._group = take._group^
+        self._prompt = take._prompt
+        self._prompt_text = take._prompt_text^
+        self._hide_input = take._hide_input
 
     # ===------------------------------------------------------------------=== #
     # Builder methods for configuring the argument
@@ -312,21 +312,14 @@ struct Argument(Copyable, Movable, Stringable, Writable):
             - Must not start with ``-`` (the ``--`` prefix is added automatically).
             - Must not contain ``=`` (conflicts with ``--key=value`` syntax).
         """
-        constrained[
-            len(name) > 0,
-            "long name must not be empty",
-        ]()
-        constrained[
-            not name.startswith("-"),
-            "long name must not start with '-'; omit the '--' prefix",
-        ]()
-        constrained[
-            name.find("=") == -1,
-            (
-                "long name must not contain '='; it conflicts with --key=value"
-                " syntax"
-            ),
-        ]()
+        comptime assert len(name) > 0, "long name must not be empty"
+        comptime assert not name.startswith(
+            "-"
+        ), "long name must not start with '-'; omit the '--' prefix"
+        comptime assert name.find("=") == -1, (
+            "long name must not contain '='; it conflicts with --key=value"
+            " syntax"
+        )
         self._long_name = name
         return self^
 
@@ -344,17 +337,11 @@ struct Argument(Copyable, Movable, Stringable, Writable):
             character (e.g., ``"v"``, ``"o"``), and must not be ``"-"``
             (which would conflict with the ``--`` end-of-options sentinel).
         """
-        constrained[
-            len(name) == 1,
-            "short name must be exactly 1 character",
-        ]()
-        constrained[
-            name != "-",
-            (
-                "short name must not be '-'; it conflicts with the"
-                " end-of-options sentinel '--'"
-            ),
-        ]()
+        comptime assert len(name) == 1, "short name must be exactly 1 character"
+        comptime assert name != "-", (
+            "short name must not be '-'; it conflicts with the"
+            " end-of-options sentinel '--'"
+        )
         self._short_name = name
         return self^
 
@@ -432,7 +419,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         Constraints:
             The value must not be empty.
         """
-        constrained[len(value) > 0, "choice value must not be empty"]()
+        comptime assert len(value) > 0, "choice value must not be empty"
         self._choice_values.append(value)
         return self^
 
@@ -453,7 +440,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         Constraints:
             The value name must be a non-empty string.
         """
-        constrained[len(name) > 0, "value name must be a non-empty string"]()
+        comptime assert len(name) > 0, "value name must be a non-empty string"
         self._value_name = name
         self._value_name_wrapped = wrapped
         return self^
@@ -567,10 +554,9 @@ struct Argument(Copyable, Movable, Stringable, Writable):
             The separator is validated at compile time: it must be one of
             ``,`` | ``;`` | ``:`` | ``|``.
         """
-        constrained[
-            sep == "," or sep == ";" or sep == ":" or sep == "|",
-            "delimiter must be one of: , ; : |",
-        ]()
+        comptime assert (
+            sep == "," or sep == ";" or sep == ":" or sep == "|"
+        ), "delimiter must be one of: , ; : |"
 
         self._delimiter_char = sep
         self._is_append = True
@@ -676,21 +662,14 @@ struct Argument(Copyable, Movable, Stringable, Writable):
             ``.long[]``): must not be empty, must not start with ``-``,
             and must not contain ``=``.
         """
-        constrained[
-            len(name) > 0,
-            "alias name must not be empty",
-        ]()
-        constrained[
-            not name.startswith("-"),
-            "alias name must not start with '-'; omit the '--' prefix",
-        ]()
-        constrained[
-            name.find("=") == -1,
-            (
-                "alias name must not contain '='; it conflicts with"
-                " --key=value syntax"
-            ),
-        ]()
+        comptime assert len(name) > 0, "alias name must not be empty"
+        comptime assert not name.startswith(
+            "-"
+        ), "alias name must not start with '-'; omit the '--' prefix"
+        comptime assert name.find("=") == -1, (
+            "alias name must not contain '='; it conflicts with"
+            " --key=value syntax"
+        )
         self._alias_names.append(name)
         return self^
 
@@ -709,7 +688,9 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         Constraints:
             The message must not be empty.
         """
-        constrained[len(message) > 0, "deprecation message must not be empty"]()
+        comptime assert (
+            len(message) > 0
+        ), "deprecation message must not be empty"
         self._deprecated_msg = message
         return self^
 
@@ -881,7 +862,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         Constraints:
             The group name must not be empty.
         """
-        constrained[len(name) > 0, "group name must not be empty"]()
+        comptime assert len(name) > 0, "group name must not be empty"
         self._group = name
         return self^
 
@@ -938,7 +919,7 @@ struct Argument(Copyable, Movable, Stringable, Writable):
         _ = Argument("token", help="API token").long["token"]().prompt["Enter your API token"]()
         ```
         """
-        constrained[len(text) > 0, "prompt text must not be empty"]()
+        comptime assert len(text) > 0, "prompt text must not be empty"
         self._prompt = True
         self._prompt_text = text
         return self^

--- a/src/argmojo/argument.mojo
+++ b/src/argmojo/argument.mojo
@@ -156,7 +156,7 @@ struct Argument(Copyable, Movable, Writable):
     # Life cycle methods
     # ===------------------------------------------------------------------=== #
 
-    fn __init__(out self, name: String, *, help: String = ""):
+    def __init__(out self, name: String, *, help: String = ""):
         """Creates a new argument definition.
 
         Args:
@@ -201,7 +201,7 @@ struct Argument(Copyable, Movable, Writable):
         self._prompt_text = ""
         self._hide_input = False
 
-    fn __init__(out self, *, copy: Self):
+    def __init__(out self, *, copy: Self):
         """Creates a copy of this argument.
 
         Args:
@@ -249,7 +249,7 @@ struct Argument(Copyable, Movable, Writable):
         self._prompt_text = copy._prompt_text
         self._hide_input = copy._hide_input
 
-    fn __init__(out self, *, deinit take: Self):
+    def __init__(out self, *, deinit take: Self):
         """Moves the value from another Argument.
 
         Args:
@@ -297,7 +297,7 @@ struct Argument(Copyable, Movable, Writable):
     # Builder methods for configuring the argument
     # ===------------------------------------------------------------------=== #
 
-    fn long[name: StringLiteral](var self) -> Self:
+    def long[name: StringLiteral](var self) -> Self:
         """Sets the long option name (e.g., 'verbose' for --verbose).
 
         Parameters:
@@ -323,7 +323,7 @@ struct Argument(Copyable, Movable, Writable):
         self._long_name = name
         return self^
 
-    fn short[name: StringLiteral](var self) -> Self:
+    def short[name: StringLiteral](var self) -> Self:
         """Sets the short option name (e.g., 'l' for -l).
 
         Parameters:
@@ -345,7 +345,7 @@ struct Argument(Copyable, Movable, Writable):
         self._short_name = name
         return self^
 
-    fn flag(var self) -> Self:
+    def flag(var self) -> Self:
         """Marks this argument as a boolean flag (no value needed).
 
         Returns:
@@ -359,7 +359,7 @@ struct Argument(Copyable, Movable, Writable):
         self._is_flag = True
         return self^
 
-    fn required(var self) -> Self:
+    def required(var self) -> Self:
         """Marks this argument as required.
 
         Returns:
@@ -372,7 +372,7 @@ struct Argument(Copyable, Movable, Writable):
         self._is_required = True
         return self^
 
-    fn positional(var self) -> Self:
+    def positional(var self) -> Self:
         """Marks this argument as a positional argument.
 
         Returns:
@@ -381,7 +381,7 @@ struct Argument(Copyable, Movable, Writable):
         self._is_positional = True
         return self^
 
-    fn takes_value(var self) -> Self:
+    def takes_value(var self) -> Self:
         """Marks this argument as taking a value (not a flag).
 
         This is the default behavior; use this for clarity when needed.
@@ -392,7 +392,7 @@ struct Argument(Copyable, Movable, Writable):
         self._is_flag = False
         return self^
 
-    fn default[value: StringLiteral](var self) -> Self:
+    def default[value: StringLiteral](var self) -> Self:
         """Sets a default value for this argument.
 
         Parameters:
@@ -405,7 +405,7 @@ struct Argument(Copyable, Movable, Writable):
         self._has_default = True
         return self^
 
-    fn choice[value: StringLiteral](var self) -> Self:
+    def choice[value: StringLiteral](var self) -> Self:
         """Adds an allowed value for this argument.
 
         Chain multiple calls to build the full set of choices:
@@ -423,7 +423,7 @@ struct Argument(Copyable, Movable, Writable):
         self._choice_values.append(value)
         return self^
 
-    fn value_name[name: StringLiteral, wrapped: Bool = True](var self) -> Self:
+    def value_name[name: StringLiteral, wrapped: Bool = True](var self) -> Self:
         """Sets the display name for the value in help text.
 
         When *wrapped* is True (default), the name is displayed inside angle
@@ -445,7 +445,7 @@ struct Argument(Copyable, Movable, Writable):
         self._value_name_wrapped = wrapped
         return self^
 
-    fn hidden(var self) -> Self:
+    def hidden(var self) -> Self:
         """Marks this argument as hidden (not shown in help output).
 
         Returns:
@@ -454,7 +454,7 @@ struct Argument(Copyable, Movable, Writable):
         self._is_hidden = True
         return self^
 
-    fn count(var self) -> Self:
+    def count(var self) -> Self:
         """Marks this argument as a counter flag.
 
         Each occurrence increments a counter. For example, ``-vvv`` sets
@@ -477,7 +477,7 @@ struct Argument(Copyable, Movable, Writable):
     # rather than developers, may encounter errors about a wrong ceiling value
     # in the terminal when they use the API, no matter they are using it
     # correctly or not. That would be catastrophic.
-    fn max[ceiling: Int](var self) -> Self where ceiling >= 1:
+    def max[ceiling: Int](var self) -> Self where ceiling >= 1:
         """Sets a ceiling for a counter flag.
 
         When a counter flag has a ceiling, the count is capped at the
@@ -505,7 +505,7 @@ struct Argument(Copyable, Movable, Writable):
         self._has_count_max = True
         return self^
 
-    fn negatable(var self) -> Self:
+    def negatable(var self) -> Self:
         """Marks this flag as negatable.
 
         A negatable flag accepts both ``--X`` (sets True) and ``--no-X``
@@ -518,7 +518,7 @@ struct Argument(Copyable, Movable, Writable):
         self._is_negatable = True
         return self^
 
-    fn append(var self) -> Self:
+    def append(var self) -> Self:
         """Marks this argument as an append/collect option.
 
         Each occurrence adds its value to a list. For example,
@@ -531,7 +531,7 @@ struct Argument(Copyable, Movable, Writable):
         self._is_append = True
         return self^
 
-    fn delimiter[sep: StringLiteral](var self) -> Self:
+    def delimiter[sep: StringLiteral](var self) -> Self:
         """Sets a value delimiter for splitting a single value into multiple.
 
         When set, each provided value is split by the delimiter, and each
@@ -562,7 +562,7 @@ struct Argument(Copyable, Movable, Writable):
         self._is_append = True
         return self^
 
-    fn number_of_values[n: Int](var self) -> Self where n >= 2:
+    def number_of_values[n: Int](var self) -> Self where n >= 2:
         """Sets the number of values consumed per occurrence.
 
         When set, each use of the option consumes exactly ``n``
@@ -581,7 +581,7 @@ struct Argument(Copyable, Movable, Writable):
         self._is_append = True
         return self^
 
-    fn range[
+    def range[
         min_val: Int, max_val: Int
     ](var self) -> Self where max_val >= min_val:
         """Sets numeric range validation for this argument.
@@ -606,7 +606,7 @@ struct Argument(Copyable, Movable, Writable):
         self._has_range = True
         return self^
 
-    fn clamp(var self) -> Self:
+    def clamp(var self) -> Self:
         """Enables clamping for numeric range validation.
 
         When clamping is enabled (used after ``.range[min, max]()``),
@@ -625,7 +625,7 @@ struct Argument(Copyable, Movable, Writable):
         self._is_clamp = True
         return self^
 
-    fn map_option(var self) -> Self:
+    def map_option(var self) -> Self:
         """Marks this argument as a key-value map option.
 
         Each value must be in ``key=value`` format.  Values are
@@ -642,7 +642,7 @@ struct Argument(Copyable, Movable, Writable):
         self._is_append = True
         return self^
 
-    fn alias_name[name: StringLiteral](var self) -> Self:
+    def alias_name[name: StringLiteral](var self) -> Self:
         """Sets an alternative long name for this argument.
 
         Any alias resolves to this argument during parsing.  For
@@ -673,7 +673,7 @@ struct Argument(Copyable, Movable, Writable):
         self._alias_names.append(name)
         return self^
 
-    fn deprecated[message: StringLiteral](var self) -> Self:
+    def deprecated[message: StringLiteral](var self) -> Self:
         """Marks this argument as deprecated.
 
         When the user provides a deprecated argument, a warning is
@@ -694,7 +694,7 @@ struct Argument(Copyable, Movable, Writable):
         self._deprecated_msg = message
         return self^
 
-    fn persistent(var self) -> Self:
+    def persistent(var self) -> Self:
         """Marks this argument as persistent (inherited by all subcommands).
 
         A persistent argument defined on a parent command is automatically
@@ -721,7 +721,7 @@ struct Argument(Copyable, Movable, Writable):
         self._is_persistent = True
         return self^
 
-    fn default_if_no_value[value: StringLiteral](var self) -> Self:
+    def default_if_no_value[value: StringLiteral](var self) -> Self:
         """Sets a default value for when the option appears without an explicit value.
 
         When set, the option may appear without a value.  If no value
@@ -764,7 +764,7 @@ struct Argument(Copyable, Movable, Writable):
         self._require_equals = True  # implied for long options
         return self^
 
-    fn require_equals(var self) -> Self:
+    def require_equals(var self) -> Self:
         """Requires that values be provided using ``=`` syntax.
 
         When set, ``--key value`` (space-separated) is rejected;
@@ -787,7 +787,7 @@ struct Argument(Copyable, Movable, Writable):
         self._require_equals = True
         return self^
 
-    fn remainder(var self) -> Self:
+    def remainder(var self) -> Self:
         """Marks this positional argument as a remainder collector.
 
         A remainder argument consumes **all** remaining tokens on the
@@ -820,7 +820,7 @@ struct Argument(Copyable, Movable, Writable):
         self._is_append = True
         return self^
 
-    fn allow_hyphen_values(var self) -> Self:
+    def allow_hyphen_values(var self) -> Self:
         """Allows tokens starting with ``-`` as valid values.
 
         By default, tokens that start with ``-`` are interpreted as option
@@ -845,7 +845,7 @@ struct Argument(Copyable, Movable, Writable):
         self._allow_hyphen_values = True
         return self^
 
-    fn group[name: StringLiteral](var self) -> Self:
+    def group[name: StringLiteral](var self) -> Self:
         """Assigns this argument to a named help-output group.
 
         Arguments sharing the same group name are displayed together
@@ -866,7 +866,7 @@ struct Argument(Copyable, Movable, Writable):
         self._group = name
         return self^
 
-    fn prompt(var self) -> Self:
+    def prompt(var self) -> Self:
         """Enables interactive prompting for this argument.
 
         When prompting is enabled, the user is interactively asked to
@@ -896,7 +896,7 @@ struct Argument(Copyable, Movable, Writable):
         self._prompt = True
         return self^
 
-    fn prompt[text: StringLiteral](var self) -> Self:
+    def prompt[text: StringLiteral](var self) -> Self:
         """Enables interactive prompting with custom text.
 
         When the argument is not supplied on the command line, the
@@ -924,7 +924,7 @@ struct Argument(Copyable, Movable, Writable):
         self._prompt_text = text
         return self^
 
-    fn password(var self) -> Self:
+    def password(var self) -> Self:
         """Marks this argument as a password / sensitive value.
 
         When combined with ``.prompt()``, the user's input is hidden
@@ -957,7 +957,7 @@ struct Argument(Copyable, Movable, Writable):
     # String representation methods
     # ===------------------------------------------------------------------=== #
 
-    fn __str__(self) -> String:
+    def __str__(self) -> String:
         """Returns a string representation of this argument definition."""
         var s = String("Argument(name='") + self.name + "'"
         if self._long_name:
@@ -973,7 +973,7 @@ struct Argument(Copyable, Movable, Writable):
         s += ")"
         return s
 
-    fn write_to[W: Writer](self, mut writer: W):
+    def write_to[W: Writer](self, mut writer: W):
         """Writes the string representation to a writer.
 
         Parameters:

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -30,13 +30,13 @@ from .utils import (
 # Placing `open()` inside a method of a struct that contains `List[Self]` causes
 # the compiler to deadlock when built with `-D ASSERT=warn` or `-D ASSERT=all`.
 # Moving the I/O into a free function avoids the trigger.
-fn _read_file_content(filepath: String) raises -> String:
+def _read_file_content(filepath: String) raises -> String:
     """Reads and returns the entire contents of *filepath*."""
     with open(filepath, "r") as f:
         return f.read()
 
 
-fn _expand_response_files(
+def _expand_response_files(
     raw_args: List[String],
     prefix: String,
     max_depth: Int,
@@ -78,7 +78,7 @@ fn _expand_response_files(
     return expanded^
 
 
-fn _read_response_file(
+def _read_response_file(
     filepath: String,
     mut out_args: List[String],
     depth: Int,
@@ -260,7 +260,7 @@ struct Command(Copyable, Movable, Writable):
     # Life cycle methods
     # ===------------------------------------------------------------------=== #
 
-    fn __init__(
+    def __init__(
         out self,
         name: String,
         description: String = "",
@@ -306,7 +306,7 @@ struct Command(Copyable, Movable, Writable):
         self._warn_color = _DEFAULT_WARN_COLOR
         self._error_color = _DEFAULT_ERROR_COLOR
 
-    fn __init__(out self, *, deinit take: Self):
+    def __init__(out self, *, deinit take: Self):
         """Moves a Command, transferring ownership of all fields.
 
         Args:
@@ -349,7 +349,7 @@ struct Command(Copyable, Movable, Writable):
         self._warn_color = take._warn_color^
         self._error_color = take._error_color^
 
-    fn __init__(out self, *, copy: Self):
+    def __init__(out self, *, copy: Self):
         """Creates a deep copy of a Command.
 
         All field data — including registered args and subcommands — is
@@ -413,7 +413,7 @@ struct Command(Copyable, Movable, Writable):
     # Builder methods for configuring the command
     # ===------------------------------------------------------------------=== #
 
-    fn add_argument(mut self, var argument: Argument) raises:
+    def add_argument(mut self, var argument: Argument) raises:
         """Registers an argument definition.
 
         Raises:
@@ -511,7 +511,7 @@ struct Command(Copyable, Movable, Writable):
             )
         self.args.append(argument^)
 
-    fn add_subcommand(mut self, var sub: Command) raises:
+    def add_subcommand(mut self, var sub: Command) raises:
         """Registers a subcommand.
 
         A subcommand is a full ``Command`` instance that handles a specific verb
@@ -608,7 +608,7 @@ struct Command(Copyable, Movable, Writable):
             self.subcommands.append(h^)
         self.subcommands.append(sub^)
 
-    fn add_parent(mut self, parent: Command) raises:
+    def add_parent(mut self, parent: Command) raises:
         """Inherits argument definitions and group constraints from a parent.
 
         All arguments registered on ``parent`` are copied into this command,
@@ -682,7 +682,7 @@ struct Command(Copyable, Movable, Writable):
         for i in range(len(parent._implications)):
             self._implications.append(parent._implications[i].copy())
 
-    fn disable_help_subcommand(mut self):
+    def disable_help_subcommand(mut self):
         """Opts out of the auto-added ``help`` subcommand.
 
         By default, the first call to ``add_subcommand()`` automatically
@@ -713,7 +713,7 @@ struct Command(Copyable, Movable, Writable):
                 new_subs.append(self.subcommands[i].copy())
         self.subcommands = new_subs^
 
-    fn allow_negative_numbers(mut self):
+    def allow_negative_numbers(mut self):
         """Treats tokens that look like negative numbers as positional arguments.
 
         By default ArgMojo already auto-detects negative-number tokens
@@ -735,7 +735,7 @@ struct Command(Copyable, Movable, Writable):
         """
         self._allow_negative_numbers = True
 
-    fn allow_positional_with_subcommands(mut self):
+    def allow_positional_with_subcommands(mut self):
         """Allows a Command to have both positional args and subcommands.
 
         By default, ArgMojo follows the convention of cobra (Go) and clap
@@ -763,7 +763,7 @@ struct Command(Copyable, Movable, Writable):
         """
         self._allow_positional_with_subcommands = True
 
-    fn disable_default_completions(mut self):
+    def disable_default_completions(mut self):
         """Disables the built-in completion trigger entirely.
 
         By default, every ``Command`` has a built-in ``--completions bash``
@@ -785,7 +785,7 @@ struct Command(Copyable, Movable, Writable):
         """
         self._completions_enabled = False
 
-    fn completions_name(mut self, name: String):
+    def completions_name(mut self, name: String):
         """Sets the name used for the built-in completion trigger.
 
         Default is ``"completions"`` → ``--completions <shell>``.
@@ -813,7 +813,7 @@ struct Command(Copyable, Movable, Writable):
         """
         self._completions_name = name
 
-    fn completions_as_subcommand(mut self):
+    def completions_as_subcommand(mut self):
         """Switches the built-in completion trigger from an option to a subcommand.
 
         Default behaviour: ``myapp --completions bash``
@@ -836,7 +836,7 @@ struct Command(Copyable, Movable, Writable):
         """
         self._completions_is_subcommand = True
 
-    fn add_tip(mut self, tip: String):
+    def add_tip(mut self, tip: String):
         """Adds a custom tip line to the bottom of the help message.
 
         Each tip is printed on its own line below the built-in ``--``
@@ -859,7 +859,7 @@ struct Command(Copyable, Movable, Writable):
         self._tips.append(tip)
 
     # TODO: alias_name[name: StringLiteral](mut self) for compile-time checks
-    fn command_aliases(mut self, var names: List[String]):
+    def command_aliases(mut self, var names: List[String]):
         """Registers alternate names for this command when used as a subcommand.
 
         Aliases are matched during subcommand dispatch and included in
@@ -883,7 +883,7 @@ struct Command(Copyable, Movable, Writable):
         for i in range(len(names)):
             self._command_aliases.append(names[i])
 
-    fn hidden(mut self):
+    def hidden(mut self):
         """Marks this subcommand as hidden.
 
         A hidden subcommand is excluded from help output, shell completion
@@ -906,7 +906,7 @@ struct Command(Copyable, Movable, Writable):
         self._is_hidden = True
 
     # TODO: response_file_prefix[prefix: StringLiteral](mut self) for compile-time checks
-    fn response_file_prefix(mut self, prefix: String = "@"):
+    def response_file_prefix(mut self, prefix: String = "@"):
         """Enables response-file expansion for this command.
 
         Warning: **Temporarily disabled** — the underlying expansion
@@ -945,7 +945,7 @@ struct Command(Copyable, Movable, Writable):
         """
         self._response_file_prefix = prefix
 
-    fn response_file_max_depth[depth: Int](mut self) where depth > 0:
+    def response_file_max_depth[depth: Int](mut self) where depth > 0:
         """Sets the maximum nesting depth for response-file expansion.
 
         Warning: **Temporarily disabled** — see
@@ -957,7 +957,7 @@ struct Command(Copyable, Movable, Writable):
         """
         self._response_file_max_depth = depth
 
-    fn disable_fullwidth_correction(mut self):
+    def disable_fullwidth_correction(mut self):
         """Disables automatic full-width → half-width character correction.
 
         By default, ArgMojo detects fullwidth ASCII characters
@@ -980,7 +980,7 @@ struct Command(Copyable, Movable, Writable):
         """
         self._disable_fullwidth_correction = True
 
-    fn disable_punctuation_correction(mut self):
+    def disable_punctuation_correction(mut self):
         """Disables CJK punctuation detection in error recovery.
 
         By default, when an unknown option is encountered, ArgMojo tries
@@ -1002,7 +1002,7 @@ struct Command(Copyable, Movable, Writable):
         """
         self._disable_punctuation_correction = True
 
-    fn mutually_exclusive(mut self, var names: List[String]) raises:
+    def mutually_exclusive(mut self, var names: List[String]) raises:
         """Declares a group of mutually exclusive arguments.
 
         At most one argument from each group may be provided. Parsing
@@ -1052,7 +1052,7 @@ struct Command(Copyable, Movable, Writable):
             unique.append(names[ni])
         self._exclusive_groups.append(unique^)
 
-    fn required_together(mut self, var names: List[String]) raises:
+    def required_together(mut self, var names: List[String]) raises:
         """Declares a group of arguments that must be provided together.
 
         If any argument from the group is provided, all others in the
@@ -1102,7 +1102,7 @@ struct Command(Copyable, Movable, Writable):
             unique.append(names[ni])
         self._required_groups.append(unique^)
 
-    fn one_required(mut self, var names: List[String]) raises:
+    def one_required(mut self, var names: List[String]) raises:
         """Declares a group where at least one argument must be provided.
 
         Parsing will fail if none of the arguments in the group are
@@ -1152,7 +1152,7 @@ struct Command(Copyable, Movable, Writable):
             unique.append(names[ni])
         self._one_required_groups.append(unique^)
 
-    fn required_if(mut self, target: String, condition: String) raises:
+    def required_if(mut self, target: String, condition: String) raises:
         """Declares that an argument is required when another is present.
 
         When ``condition`` is provided on the command line, ``target``
@@ -1200,7 +1200,7 @@ struct Command(Copyable, Movable, Writable):
         var pair: List[String] = [target, condition]
         self._conditional_reqs.append(pair^)
 
-    fn implies(mut self, trigger: String, implied: String) raises:
+    def implies(mut self, trigger: String, implied: String) raises:
         """Declares that setting one argument automatically sets another.
 
         When ``trigger`` is present in the parse result, ``implied`` is
@@ -1299,7 +1299,7 @@ struct Command(Copyable, Movable, Writable):
         var imp_triple: List[String] = [trigger, implied, implied_kind]
         self._implications.append(imp_triple^)
 
-    fn usage(mut self, text: String):
+    def usage(mut self, text: String):
         """Sets a custom usage line, replacing the auto-generated one.
 
         By default, ArgMojo generates a usage line like::
@@ -1326,7 +1326,7 @@ struct Command(Copyable, Movable, Writable):
         """
         self._custom_usage = text
 
-    fn help_on_no_arguments(mut self) raises:
+    def help_on_no_arguments(mut self) raises:
         """Enables showing help when invoked with no arguments.
 
         When enabled, calling the command with no arguments (only the
@@ -1358,7 +1358,7 @@ struct Command(Copyable, Movable, Writable):
                 )
         self._help_on_no_arguments = True
 
-    fn confirmation_option(mut self) raises:
+    def confirmation_option(mut self) raises:
         """Adds a ``--yes`` / ``-y`` flag to skip a confirmation prompt.
 
         When enabled, the command will prompt the user with
@@ -1408,7 +1408,7 @@ struct Command(Copyable, Movable, Writable):
             .flag()
         )
 
-    fn confirmation_option[prompt: StringLiteral](mut self) raises:
+    def confirmation_option[prompt: StringLiteral](mut self) raises:
         """Adds a ``--yes`` / ``-y`` flag with a custom confirmation prompt.
 
         Behaves like ``confirmation_option()`` but uses the provided
@@ -1445,7 +1445,7 @@ struct Command(Copyable, Movable, Writable):
     # This ensures developers get a compiler error for invalid colour
     # names during development, instead of end users seeing runtime
     # failures caused by a misspelled or unsupported colour.
-    fn header_color[name: StringLiteral](mut self):
+    def header_color[name: StringLiteral](mut self):
         """Sets the colour for section headers (Usage, Arguments, Options).
 
         Headers are always rendered in **bold + underline**; this method
@@ -1468,7 +1468,7 @@ struct Command(Copyable, Movable, Writable):
         """
         self._header_color = _resolve_color[name]()
 
-    fn arg_color[name: StringLiteral](mut self):
+    def arg_color[name: StringLiteral](mut self):
         """Sets the colour for option and argument names in help output.
 
         Accepted colour names: ``RED``, ``GREEN``, ``YELLOW``, ``BLUE``,
@@ -1488,7 +1488,7 @@ struct Command(Copyable, Movable, Writable):
         """
         self._arg_color = _resolve_color[name]()
 
-    fn warn_color[name: StringLiteral](mut self):
+    def warn_color[name: StringLiteral](mut self):
         """Sets the colour for deprecation warning messages.
 
         Accepted colour names: ``RED``, ``GREEN``, ``YELLOW``, ``BLUE``,
@@ -1508,7 +1508,7 @@ struct Command(Copyable, Movable, Writable):
         """
         self._warn_color = _resolve_color[name]()
 
-    fn error_color[name: StringLiteral](mut self):
+    def error_color[name: StringLiteral](mut self):
         """Sets the colour for parse error messages.
 
         Accepted colour names: ``RED``, ``GREEN``, ``YELLOW``, ``BLUE``,
@@ -1533,7 +1533,7 @@ struct Command(Copyable, Movable, Writable):
     # ===------------------------------------------------------------------=== #
 
     @staticmethod
-    fn _no_color_env() -> Bool:
+    def _no_color_env() -> Bool:
         """Returns True when the ``NO_COLOR`` environment variable is set.
 
         Follows the `no-color.org <https://no-color.org/>`_ standard:
@@ -1553,14 +1553,14 @@ struct Command(Copyable, Movable, Writable):
         comptime _SENTINEL = "__ARGMOJO_NO_COLOR_UNSET_SENTINEL__"
         return getenv("NO_COLOR", _SENTINEL) != _SENTINEL
 
-    fn _warn(self, msg: String):
+    def _warn(self, msg: String):
         """Prints a coloured warning message to stderr."""
         if Self._no_color_env():
             print("warning: " + msg, file=stderr)
         else:
             print(self._warn_color + "warning: " + msg + _RESET, file=stderr)
 
-    fn _preprocess_cjk_args(self, mut args: List[String]):
+    def _preprocess_cjk_args(self, mut args: List[String]):
         """Applies fullwidth and CJK punctuation auto-correction to *args*.
 
         Two passes:
@@ -1613,7 +1613,7 @@ struct Command(Copyable, Movable, Writable):
                     punc_args.append(token)
             args = punc_args^
 
-    fn _error(self, msg: String) raises:
+    def _error(self, msg: String) raises:
         """Prints a coloured error message to stderr then raises.
 
         All parse-time errors funnel through this method so that callers
@@ -1634,7 +1634,7 @@ struct Command(Copyable, Movable, Writable):
             )
         raise Error(msg)
 
-    fn _error_with_usage(self, msg: String) raises:
+    def _error_with_usage(self, msg: String) raises:
         """Prints a coloured error with a usage hint and help tip, then raises.
 
         Used for validation errors (missing required args, too many positionals)
@@ -1660,7 +1660,7 @@ struct Command(Copyable, Movable, Writable):
         )
         raise Error(msg)
 
-    fn _plain_usage(self) -> String:
+    def _plain_usage(self) -> String:
         """Returns a plain-text usage line (no ANSI colours).
 
         Example output: ``Usage: git clone <repository> [directory] [OPTIONS]``
@@ -1690,7 +1690,7 @@ struct Command(Copyable, Movable, Writable):
         s += " [OPTIONS]"
         return s
 
-    fn parse(self) raises -> ParseResult:
+    def parse(self) raises -> ParseResult:
         """Parses command-line arguments from ``sys.argv()``.
 
         Errors from parsing (missing/invalid arguments, validation failures)
@@ -1715,7 +1715,7 @@ struct Command(Copyable, Movable, Writable):
             # compiler does not model exit() as @noreturn yet.
             return ParseResult()
 
-    fn parse_arguments(self, raw_args: List[String]) raises -> ParseResult:
+    def parse_arguments(self, raw_args: List[String]) raises -> ParseResult:
         """Parses the given argument list.
 
         The first element, e.g., ``argv[0]``, is expected to be the program name
@@ -1983,7 +1983,7 @@ struct Command(Copyable, Movable, Writable):
 
         return result^
 
-    fn parse_known_arguments(
+    def parse_known_arguments(
         self, raw_args: List[String]
     ) raises -> ParseResult:
         """Parses known arguments, collecting unrecognised ones.
@@ -2206,7 +2206,7 @@ struct Command(Copyable, Movable, Writable):
     # Parsing sub-methods (extracted from parse_arguments for readability)
     # ===------------------------------------------------------------------=== #
 
-    fn _parse_long_option(
+    def _parse_long_option(
         self, raw_args: List[String], start: Int, mut result: ParseResult
     ) raises -> Int:
         """Parses a long option token (``--key``, ``--key=value``, ``--no-X``).
@@ -2350,7 +2350,7 @@ struct Command(Copyable, Movable, Writable):
         i += 1
         return i
 
-    fn _parse_short_single(
+    def _parse_short_single(
         self,
         key: String,
         raw_args: List[String],
@@ -2426,7 +2426,7 @@ struct Command(Copyable, Movable, Writable):
         i += 1
         return i
 
-    fn _parse_short_merged(
+    def _parse_short_merged(
         self,
         key: String,
         raw_args: List[String],
@@ -2561,7 +2561,7 @@ struct Command(Copyable, Movable, Writable):
         i += 1
         return i
 
-    fn _dispatch_subcommand(
+    def _dispatch_subcommand(
         self,
         arg: String,
         raw_args: List[String],
@@ -2703,7 +2703,7 @@ struct Command(Copyable, Movable, Writable):
     # Confirmation prompt
     # ===------------------------------------------------------------------=== #
 
-    fn _confirm(self, result: ParseResult) raises:
+    def _confirm(self, result: ParseResult) raises:
         """Prompts the user for confirmation if ``confirmation_option()`` is
         enabled and ``--yes`` / ``-y`` was not passed.
 
@@ -2736,7 +2736,7 @@ struct Command(Copyable, Movable, Writable):
     # Interactive prompting
     # ===------------------------------------------------------------------=== #
 
-    fn _prompt_missing_args(self, mut result: ParseResult) raises:
+    def _prompt_missing_args(self, mut result: ParseResult) raises:
         """Prompts the user interactively for arguments marked with ``.prompt()``
         that were not provided on the command line.
 
@@ -2887,7 +2887,7 @@ struct Command(Copyable, Movable, Writable):
     # Defaults & validation helpers (extracted for subcommand reuse)
     # ===------------------------------------------------------------------=== #
 
-    fn _apply_defaults(self, mut result: ParseResult):
+    def _apply_defaults(self, mut result: ParseResult):
         """Fills in default values for arguments not provided by the user.
 
         For positional arguments, defaults are placed into the correct slot.
@@ -2929,7 +2929,7 @@ struct Command(Copyable, Movable, Writable):
                     break
                 pos_slot += 1
 
-    fn _apply_implications(self, mut result: ParseResult):
+    def _apply_implications(self, mut result: ParseResult):
         """Propagates implication rules on the parse result.
 
         For each registered ``implies(trigger, implied)`` triple, if
@@ -2961,7 +2961,7 @@ struct Command(Copyable, Movable, Writable):
                         result._flags[implied] = True
                     changed = True
 
-    fn _validate(self, mut result: ParseResult) raises:
+    def _validate(self, mut result: ParseResult) raises:
         """Runs all post-parse validation checks on the result.
 
         Checks (in order):
@@ -3223,7 +3223,7 @@ struct Command(Copyable, Movable, Writable):
     # Argument lookup helpers
     # ===------------------------------------------------------------------=== #
 
-    fn _is_known_option(self, token: String) -> Bool:
+    def _is_known_option(self, token: String) -> Bool:
         """Check if a dash-prefixed token matches a defined option.
 
         Used by the ``allow_hyphen_values`` logic to decide whether a
@@ -3262,7 +3262,7 @@ struct Command(Copyable, Movable, Writable):
             return False
         return False
 
-    fn _find_by_long(self, name: String) raises -> Argument:
+    def _find_by_long(self, name: String) raises -> Argument:
         """Finds an argument definition by its long name, alias, or unambiguous prefix.
 
         Resolution order:
@@ -3375,7 +3375,7 @@ struct Command(Copyable, Movable, Writable):
             "unreachable"
         )  # _error() always raises; satisfies Mojo's return checker
 
-    fn _find_by_short(self, name: String) raises -> Argument:
+    def _find_by_short(self, name: String) raises -> Argument:
         """Finds an argument definition by its short name.
 
         Args:
@@ -3399,7 +3399,7 @@ struct Command(Copyable, Movable, Writable):
             "unreachable"
         )  # _error() always raises; satisfies Mojo's return checker
 
-    fn _find_subcommand(self, name: String) -> Int:
+    def _find_subcommand(self, name: String) -> Int:
         """Returns the index of the registered subcommand matching ``name``.
 
         Checks primary names first, then aliases.
@@ -3421,7 +3421,7 @@ struct Command(Copyable, Movable, Writable):
                     return i
         return -1
 
-    fn _display_name(self, name: String) -> String:
+    def _display_name(self, name: String) -> String:
         """Returns a user-facing display string for an argument.
 
         Checks long name first, then short name, then falls back to
@@ -3442,7 +3442,7 @@ struct Command(Copyable, Movable, Writable):
                 break
         return "'" + name + "'"
 
-    fn _validate_choices(self, arg: Argument, value: String) raises:
+    def _validate_choices(self, arg: Argument, value: String) raises:
         """Validates that the value is in the allowed choices.
 
         Args:
@@ -3472,7 +3472,7 @@ struct Command(Copyable, Movable, Writable):
             + ")"
         )
 
-    fn _store_append_value(
+    def _store_append_value(
         self, arg: Argument, value: String, mut result: ParseResult
     ) raises:
         """Stores a value for an append-type argument, handling delimiter splitting.
@@ -3502,7 +3502,7 @@ struct Command(Copyable, Movable, Writable):
             self._validate_choices(arg, value)
             result._lists[arg.name].append(value)
 
-    fn _store_map_value(
+    def _store_map_value(
         self, arg: Argument, value: String, mut result: ParseResult
     ) raises:
         """Stores a key=value pair for a map-type argument.
@@ -3558,7 +3558,7 @@ struct Command(Copyable, Movable, Writable):
             result._maps[arg.name][k] = v
             result._lists[arg.name].append(value)
 
-    fn _generate_help(self, color: Bool = True) -> String:
+    def _generate_help(self, color: Bool = True) -> String:
         """Generates a help message from registered arguments.
 
         Delegates to five sub-methods, one for each section of the help
@@ -3586,7 +3586,7 @@ struct Command(Copyable, Movable, Writable):
         s += self._help_tips_section(header_color, reset_code)
         return s
 
-    fn _help_usage_line(
+    def _help_usage_line(
         self,
         arg_color: String,
         header_color: String,
@@ -3640,7 +3640,7 @@ struct Command(Copyable, Movable, Writable):
         s += " " + arg_color + "[OPTIONS]" + reset_code + "\n\n"
         return s
 
-    fn _help_positionals_section(
+    def _help_positionals_section(
         self,
         arg_color: String,
         header_color: String,
@@ -3705,7 +3705,7 @@ struct Command(Copyable, Movable, Writable):
         s += "\n"
         return s
 
-    fn _help_options_section(
+    def _help_options_section(
         self,
         arg_color: String,
         header_color: String,
@@ -3948,7 +3948,7 @@ struct Command(Copyable, Movable, Writable):
                     group_names.append(opt_groups[k])
 
         # --- Helper: compute max display width for a subset of options ---
-        fn _section_pad(
+        def _section_pad(
             plains: List[String],
             persistent: List[Bool],
             groups: List[String],
@@ -4020,7 +4020,7 @@ struct Command(Copyable, Movable, Writable):
 
         return s
 
-    fn _help_commands_section(
+    def _help_commands_section(
         self,
         arg_color: String,
         header_color: String,
@@ -4097,7 +4097,7 @@ struct Command(Copyable, Movable, Writable):
 
         return s
 
-    fn _help_tips_section(
+    def _help_tips_section(
         self, header_color: String, reset_code: String
     ) -> String:
         """Generates the 'Tips:' section with hints and user-defined tips.
@@ -4170,7 +4170,7 @@ struct Command(Copyable, Movable, Writable):
     # Shell completion generation
     # ===------------------------------------------------------------------=== #
 
-    fn generate_completion[shell: StringLiteral](self) -> String:
+    def generate_completion[shell: StringLiteral](self) -> String:
         """Generates a shell completion script (compile-time validated).
 
         The shell name is validated at compile time via ``constrained[]``.
@@ -4203,7 +4203,7 @@ struct Command(Copyable, Movable, Writable):
         else:  # shell == "bash"
             return self._completion_bash()
 
-    fn generate_completion(self, shell: String) raises -> String:
+    def generate_completion(self, shell: String) raises -> String:
         """Generates a shell completion script (runtime dispatch).
 
         The shell name is validated at runtime.  Use this overload when
@@ -4230,7 +4230,7 @@ struct Command(Copyable, Movable, Writable):
             "Unknown shell '" + shell + "'. Choose from: bash, zsh, fish"
         )
 
-    fn _completion_fish(self) -> String:
+    def _completion_fish(self) -> String:
         """Generates a Fish shell completion script.
 
         Each option/subcommand becomes a single ``complete`` line.
@@ -4380,7 +4380,7 @@ struct Command(Copyable, Movable, Writable):
                 )
         return s
 
-    fn _fish_options_for(
+    def _fish_options_for(
         self, cmd_name: String, condition: String, persistent_only: Bool = False
     ) -> String:
         """Generates ``complete`` lines for this command's own arguments.
@@ -4421,7 +4421,7 @@ struct Command(Copyable, Movable, Writable):
             s += line + "\n"
         return s
 
-    fn _fish_escape(self, text: String) -> String:
+    def _fish_escape(self, text: String) -> String:
         """Escapes single quotes in text for Fish shell strings.
 
         Args:
@@ -4439,7 +4439,7 @@ struct Command(Copyable, Movable, Writable):
                 result += ch
         return result
 
-    fn _completion_zsh(self) -> String:
+    def _completion_zsh(self) -> String:
         """Generates a Zsh completion script using ``_arguments``.
 
         Returns:
@@ -4469,7 +4469,7 @@ struct Command(Copyable, Movable, Writable):
         s += "compdef _" + self.name + " " + self.name + "\n"
         return s
 
-    fn _zsh_simple(self) -> String:
+    def _zsh_simple(self) -> String:
         """Generates a simple Zsh completion function (no subcommands).
 
         Returns:
@@ -4499,7 +4499,7 @@ struct Command(Copyable, Movable, Writable):
         s += "}\n\n"
         return s
 
-    fn _zsh_with_subcommands(self) -> String:
+    def _zsh_with_subcommands(self) -> String:
         """Generates a Zsh completion function with subcommand dispatch.
 
         Returns:
@@ -4592,7 +4592,7 @@ struct Command(Copyable, Movable, Writable):
         s += "}\n\n"
         return s
 
-    fn _zsh_arg_spec(self, arg: Argument) -> String:
+    def _zsh_arg_spec(self, arg: Argument) -> String:
         """Builds a single ``_arguments`` spec string for an argument.
 
         Args:
@@ -4656,7 +4656,7 @@ struct Command(Copyable, Movable, Writable):
 
         return spec
 
-    fn _zsh_escape(self, text: String) -> String:
+    def _zsh_escape(self, text: String) -> String:
         """Escapes special characters in text for Zsh completion specs.
 
         Escapes ``[``, ``]``, ``'``, and ``:`` which have special meaning
@@ -4681,7 +4681,7 @@ struct Command(Copyable, Movable, Writable):
                 result += ch
         return result
 
-    fn _completion_bash(self) -> String:
+    def _completion_bash(self) -> String:
         """Generates a Bash completion script using ``complete -F``.
 
         Returns:
@@ -4715,7 +4715,7 @@ struct Command(Copyable, Movable, Writable):
         s += "complete -F " + fn_name + " " + self.name + "\n"
         return s
 
-    fn _bash_simple(self) -> String:
+    def _bash_simple(self) -> String:
         """Generates the body of a simple Bash completion function.
 
         Returns:
@@ -4739,7 +4739,7 @@ struct Command(Copyable, Movable, Writable):
         s += '  COMPREPLY=($(compgen -W "' + words + '" -- "$cur"))\n'
         return s
 
-    fn _bash_with_subcommands(self) -> String:
+    def _bash_with_subcommands(self) -> String:
         """Generates the body of a Bash completion function with subcommands.
 
         Uses ``COMP_WORDS`` scanning to detect which subcommand is active,
@@ -4841,7 +4841,7 @@ struct Command(Copyable, Movable, Writable):
         s += "  esac\n"
         return s
 
-    fn _bash_prev_cases(self) -> String:
+    def _bash_prev_cases(self) -> String:
         """Generates ``case $prev`` blocks for options with choices.
 
         When the previous word is an option that has a fixed set of
@@ -4899,7 +4899,7 @@ struct Command(Copyable, Movable, Writable):
         s += "  esac\n"
         return s
 
-    fn _bash_prev_cases_for_args(
+    def _bash_prev_cases_for_args(
         self, args: List[Argument], indent: String
     ) -> String:
         """Generates ``case $prev`` blocks for a given list of arguments.
@@ -4959,7 +4959,7 @@ struct Command(Copyable, Movable, Writable):
         s += indent + "esac\n"
         return s
 
-    fn __str__(self) -> String:
+    def __str__(self) -> String:
         """Returns a string representation of this command."""
         return (
             "Command(name='"
@@ -4969,7 +4969,7 @@ struct Command(Copyable, Movable, Writable):
             + ")"
         )
 
-    fn write_to[W: Writer](self, mut writer: W):
+    def write_to[W: Writer](self, mut writer: W):
         """Writes the string representation to a writer.
 
         Parameters:

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -4173,7 +4173,7 @@ struct Command(Copyable, Movable, Writable):
     def generate_completion[shell: StringLiteral](self) -> String:
         """Generates a shell completion script (compile-time validated).
 
-        The shell name is validated at compile time via ``constrained[]``.
+        The shell name is validated at compile time via ``comptime assert``.
         Use this overload when the shell is known at development time.
 
         Parameters:

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -1,8 +1,8 @@
 """Defines a CLI command and performs argument parsing."""
 
-from os import getenv
-from os.path import exists as _path_exists
-from sys import argv, exit, stderr
+from std.os import getenv
+from std.os.path import exists as _path_exists
+from std.sys import argv, exit, stderr
 
 from .argument import Argument
 from .parse_result import ParseResult
@@ -63,13 +63,13 @@ fn _expand_response_files(
         # Check for escape: doubled prefix → literal.
         if (
             len(token) > plen * 2 - 1
-            and String(token[: plen * 2]) == prefix + prefix
+            and String(token[byte = : plen * 2]) == prefix + prefix
         ):
-            expanded.append(String(token[plen:]))
+            expanded.append(String(token[byte=plen:]))
             continue
 
-        if len(token) > plen and String(token[:plen]) == prefix:
-            var filepath = String(token[plen:])
+        if len(token) > plen and String(token[byte=:plen]) == prefix:
+            var filepath = String(token[byte=plen:])
             _read_response_file(
                 filepath, expanded, 0, prefix, max_depth, cmd_name
             )
@@ -119,14 +119,14 @@ fn _read_response_file(
         # Escape: doubled prefix → literal.
         if (
             len(line) > plen * 2 - 1
-            and String(line[: plen * 2]) == prefix + prefix
+            and String(line[byte = : plen * 2]) == prefix + prefix
         ):
-            out_args.append(String(line[plen:]))
+            out_args.append(String(line[byte=plen:]))
             continue
 
         # Recursive response file.
-        if len(line) > plen and String(line[:plen]) == prefix:
-            var nested_path = String(line[plen:])
+        if len(line) > plen and String(line[byte=:plen]) == prefix:
+            var nested_path = String(line[byte=plen:])
             _read_response_file(
                 nested_path, out_args, depth + 1, prefix, max_depth, cmd_name
             )
@@ -134,7 +134,7 @@ fn _read_response_file(
             out_args.append(line)
 
 
-struct Command(Copyable, Movable, Stringable, Writable):
+struct Command(Copyable, Movable, Writable):
     """Defines a CLI command prototype with its arguments and handles parsing.
 
     Example:
@@ -306,50 +306,50 @@ struct Command(Copyable, Movable, Stringable, Writable):
         self._warn_color = _DEFAULT_WARN_COLOR
         self._error_color = _DEFAULT_ERROR_COLOR
 
-    fn __moveinit__(out self, deinit move: Self):
+    fn __init__(out self, *, deinit take: Self):
         """Moves a Command, transferring ownership of all fields.
 
         Args:
-            move: The Command to move from.
+            take: The Command to move from.
         """
-        self.name = move.name^
-        self.description = move.description^
-        self.version = move.version^
-        self.args = move.args^
-        self.subcommands = move.subcommands^
-        self._exclusive_groups = move._exclusive_groups^
-        self._required_groups = move._required_groups^
-        self._one_required_groups = move._one_required_groups^
-        self._conditional_reqs = move._conditional_reqs^
-        self._implications = move._implications^
-        self._help_on_no_arguments = move._help_on_no_arguments
-        self._is_help_subcommand = move._is_help_subcommand
-        self._help_subcommand_enabled = move._help_subcommand_enabled
-        self._allow_negative_numbers = move._allow_negative_numbers
+        self.name = take.name^
+        self.description = take.description^
+        self.version = take.version^
+        self.args = take.args^
+        self.subcommands = take.subcommands^
+        self._exclusive_groups = take._exclusive_groups^
+        self._required_groups = take._required_groups^
+        self._one_required_groups = take._one_required_groups^
+        self._conditional_reqs = take._conditional_reqs^
+        self._implications = take._implications^
+        self._help_on_no_arguments = take._help_on_no_arguments
+        self._is_help_subcommand = take._is_help_subcommand
+        self._help_subcommand_enabled = take._help_subcommand_enabled
+        self._allow_negative_numbers = take._allow_negative_numbers
         self._allow_positional_with_subcommands = (
-            move._allow_positional_with_subcommands
+            take._allow_positional_with_subcommands
         )
-        self._completions_enabled = move._completions_enabled
-        self._completions_name = move._completions_name^
-        self._completions_is_subcommand = move._completions_is_subcommand
-        self._command_aliases = move._command_aliases^
-        self._tips = move._tips^
-        self._is_hidden = move._is_hidden
-        self._response_file_prefix = move._response_file_prefix^
-        self._response_file_max_depth = move._response_file_max_depth
-        self._disable_fullwidth_correction = move._disable_fullwidth_correction
+        self._completions_enabled = take._completions_enabled
+        self._completions_name = take._completions_name^
+        self._completions_is_subcommand = take._completions_is_subcommand
+        self._command_aliases = take._command_aliases^
+        self._tips = take._tips^
+        self._is_hidden = take._is_hidden
+        self._response_file_prefix = take._response_file_prefix^
+        self._response_file_max_depth = take._response_file_max_depth
+        self._disable_fullwidth_correction = take._disable_fullwidth_correction
         self._disable_punctuation_correction = (
-            move._disable_punctuation_correction
+            take._disable_punctuation_correction
         )
-        self._confirmation_enabled = move._confirmation_enabled
-        self._confirmation_prompt = move._confirmation_prompt^
-        self._custom_usage = move._custom_usage^
-        self._header_color = move._header_color^
-        self._arg_color = move._arg_color^
-        self._warn_color = move._warn_color^
-        self._error_color = move._error_color^
+        self._confirmation_enabled = take._confirmation_enabled
+        self._confirmation_prompt = take._confirmation_prompt^
+        self._custom_usage = take._custom_usage^
+        self._header_color = take._header_color^
+        self._arg_color = take._arg_color^
+        self._warn_color = take._warn_color^
+        self._error_color = take._error_color^
 
-    fn __copyinit__(out self, copy: Self):
+    fn __init__(out self, *, copy: Self):
         """Creates a deep copy of a Command.
 
         All field data — including registered args and subcommands — is
@@ -1433,10 +1433,9 @@ struct Command(Copyable, Movable, Stringable, Writable):
         cmd.confirmation_option["Drop the database? This cannot be undone."]()
         ```
         """
-        constrained[
-            len(prompt) > 0,
-            "confirmation_option: prompt text must not be empty",
-        ]()
+        comptime assert (
+            len(prompt) > 0
+        ), "confirmation_option: prompt text must not be empty"
         self.confirmation_option()
         self._confirmation_prompt = String(prompt)
 
@@ -1932,7 +1931,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                         i += 1
                         continue
                 # ────────────────────────────────────────────────────────────
-                var key = String(arg[1:])
+                var key = String(arg[byte=1:])
                 if len(key) == 1:
                     i = self._parse_short_single(key, args_to_parse, i, result)
                 else:
@@ -2149,7 +2148,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                         i += 1
                         continue
                 try:
-                    var key = String(arg[1:])
+                    var key = String(arg[byte=1:])
                     if len(key) == 1:
                         i = self._parse_short_single(
                             key, args_to_parse, i, result
@@ -2227,7 +2226,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         """
         var i = start
         var arg = raw_args[i]
-        var key = String(arg[2:])  # strip leading "--"
+        var key = String(arg[byte=2:])  # strip leading "--"
         var value = String("")
         var has_eq = False
 
@@ -2235,14 +2234,14 @@ struct Command(Copyable, Movable, Stringable, Writable):
         var eq_pos = key.find("=")
         if eq_pos >= 0:
             # Split into key and value parts.
-            value = String(key[eq_pos + 1 :])
-            key = String(key[:eq_pos])
+            value = String(key[byte = eq_pos + 1 :])
+            key = String(key[byte=:eq_pos])
             has_eq = True
 
         # Check for --no-X negation pattern (with prefix matching).
         var is_negation = False
         if key.startswith("no-") and not has_eq:
-            var base_key = String(key[3:])
+            var base_key = String(key[byte=3:])
             # Exact match first.
             for idx in range(len(self.args)):
                 if (
@@ -2454,7 +2453,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
             The index of the next token to process.
         """
         var i = start
-        var first_char = String(key[0:1])
+        var first_char = String(key[byte=0:1])
         var first_match = self._find_by_short(first_char)
 
         if first_match._is_flag:
@@ -2462,7 +2461,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
             # flags, except the last char which may take a value.
             var j: Int = 0
             while j < len(key):
-                var ch = String(key[j : j + 1])
+                var ch = String(key[byte = j : j + 1])
                 var m = self._find_by_short(ch)
                 # Emit deprecation warning if applicable.
                 if m._deprecated_msg:
@@ -2501,7 +2500,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 else:
                     # This char takes a value — rest of string is
                     # the value.
-                    var val = String(key[j + 1 :])
+                    var val = String(key[byte = j + 1 :])
                     if len(val) == 0:
                         if m._has_default_if_no_value:
                             # No value given — use default-if-no-value,
@@ -2550,13 +2549,13 @@ struct Command(Copyable, Movable, Stringable, Writable):
                     self._validate_choices(first_match, raw_args[i])
                     result._lists[first_match.name].append(raw_args[i])
             elif first_match._is_map:
-                var val = String(key[1:])
+                var val = String(key[byte=1:])
                 self._store_map_value(first_match, val, result)
             elif first_match._is_append:
-                var val = String(key[1:])
+                var val = String(key[byte=1:])
                 self._store_append_value(first_match, val, result)
             else:
-                var val = String(key[1:])
+                var val = String(key[byte=1:])
                 self._validate_choices(first_match, val)
                 result._values[first_match.name] = val
         i += 1
@@ -3238,10 +3237,10 @@ struct Command(Copyable, Movable, Stringable, Writable):
             True if the token matches a known long/short option.
         """
         if token.startswith("--"):
-            var key = String(token[2:])
+            var key = String(token[byte=2:])
             var eq = key.find("=")
             if eq >= 0:
-                key = String(key[:eq])
+                key = String(key[byte=:eq])
             for idx in range(len(self.args)):
                 if self.args[idx]._long_name == key:
                     return True
@@ -3256,7 +3255,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
                         return True
             return False
         elif token.startswith("-") and len(token) > 1:
-            var ch = String(token[1:2])
+            var ch = String(token[byte=1:2])
             for idx in range(len(self.args)):
                 if self.args[idx]._short_name == ch:
                     return True
@@ -3540,8 +3539,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
                             + arg.name
                             + "'"
                         )
-                    var k = String(piece[:eq])
-                    var v = String(piece[eq + 1 :])
+                    var k = String(piece[byte=:eq])
+                    var v = String(piece[byte = eq + 1 :])
                     result._maps[arg.name][k] = v
                     result._lists[arg.name].append(piece)
         else:
@@ -3554,8 +3553,8 @@ struct Command(Copyable, Movable, Stringable, Writable):
                     + arg.name
                     + "'"
                 )
-            var k = String(value[:eq])
-            var v = String(value[eq + 1 :])
+            var k = String(value[byte=:eq])
+            var v = String(value[byte = eq + 1 :])
             result._maps[arg.name][k] = v
             result._lists[arg.name].append(value)
 
@@ -4132,7 +4131,11 @@ struct Command(Copyable, Movable, Stringable, Writable):
                 var has_digit_short = False
                 for _ti in range(len(self.args)):
                     var sc = self.args[_ti]._short_name
-                    if len(sc) == 1 and sc[0:1] >= "0" and sc[0:1] <= "9":
+                    if (
+                        len(sc) == 1
+                        and sc[byte=0:1] >= "0"
+                        and sc[byte=0:1] <= "9"
+                    ):
                         has_digit_short = True
                         break
                 neg_auto = not has_digit_short
@@ -4189,15 +4192,11 @@ struct Command(Copyable, Movable, Stringable, Writable):
         var script = app.generate_completion["bash"]()
         ```
         """
-        constrained[
-            cond = (shell == "fish" or shell == "zsh" or shell == "bash"),
-            msg = (
-                "Unknown shell '" + shell + "'. Choose from: bash, zsh, fish"
-            ),
-        ]()
+        comptime assert shell == "fish" or shell == "zsh" or shell == "bash", (
+            "Unknown shell '" + shell + "'. Choose from: bash, zsh, fish"
+        )
 
-        @parameter
-        if shell == "fish":
+        comptime if shell == "fish":
             return self._completion_fish()
         elif shell == "zsh":
             return self._completion_zsh()
@@ -4433,7 +4432,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         """
         var result = String("")
         for i in range(len(text)):
-            var ch = text[i : i + 1]
+            var ch = text[byte = i : i + 1]
             if ch == "'":
                 result += "\\'"
             else:
@@ -4671,7 +4670,7 @@ struct Command(Copyable, Movable, Stringable, Writable):
         """
         var result = String("")
         for i in range(len(text)):
-            var ch = text[i : i + 1]
+            var ch = text[byte = i : i + 1]
             if ch == "[" or ch == "]":
                 result += "\\" + ch
             elif ch == "'":

--- a/src/argmojo/parse_result.mojo
+++ b/src/argmojo/parse_result.mojo
@@ -35,7 +35,7 @@ struct ParseResult(Copyable, Movable, Writable):
     """Unrecognised arguments collected by ``parse_known_arguments()``.
     Empty when using the standard ``parse_arguments()`` method."""
 
-    fn __init__(out self):
+    def __init__(out self):
         """Creates an empty ParseResult."""
         self._flags = Dict[String, Bool]()
         self._values = Dict[String, String]()
@@ -48,7 +48,7 @@ struct ParseResult(Copyable, Movable, Writable):
         self._subcommand_results = List[ParseResult]()
         self._unknown_args = List[String]()
 
-    fn __init__(out self, *, copy: Self):
+    def __init__(out self, *, copy: Self):
         """Creates a deep copy of a ParseResult.
 
         Args:
@@ -69,7 +69,7 @@ struct ParseResult(Copyable, Movable, Writable):
         self._subcommand_results = copy._subcommand_results.copy()
         self._unknown_args = copy._unknown_args.copy()
 
-    fn __init__(out self, *, deinit take: Self):
+    def __init__(out self, *, deinit take: Self):
         """Moves a ParseResult, transferring all field ownership.
 
         Args:
@@ -86,7 +86,7 @@ struct ParseResult(Copyable, Movable, Writable):
         self._subcommand_results = take._subcommand_results^
         self._unknown_args = take._unknown_args^
 
-    fn get_flag(self, name: String) -> Bool:
+    def get_flag(self, name: String) -> Bool:
         """Gets a boolean flag value. Returns False if not set.
 
         Args:
@@ -100,7 +100,7 @@ struct ParseResult(Copyable, Movable, Writable):
         except:
             return False
 
-    fn get_string(self, name: String) raises -> String:
+    def get_string(self, name: String) raises -> String:
         """Gets a string argument value.
 
         Args:
@@ -126,7 +126,7 @@ struct ParseResult(Copyable, Movable, Writable):
 
         raise Error("Argument '" + name + "' not found")
 
-    fn get_int(self, name: String) raises -> Int:
+    def get_int(self, name: String) raises -> Int:
         """Gets an integer argument value.
 
         Args:
@@ -141,7 +141,7 @@ struct ParseResult(Copyable, Movable, Writable):
         var s = self.get_string(name)
         return Int(atol(s))
 
-    fn get_count(self, name: String) -> Int:
+    def get_count(self, name: String) -> Int:
         """Gets the count for a counter-type argument. Returns 0 if not set.
 
         Args:
@@ -155,7 +155,7 @@ struct ParseResult(Copyable, Movable, Writable):
         except:
             return 0
 
-    fn get_list(self, name: String) -> List[String]:
+    def get_list(self, name: String) -> List[String]:
         """Gets the collected list for an append-type argument.
 
         Returns an empty list if the argument was never provided.
@@ -180,7 +180,7 @@ struct ParseResult(Copyable, Movable, Writable):
         except:
             return List[String]()
 
-    fn get_map(self, name: String) -> Dict[String, String]:
+    def get_map(self, name: String) -> Dict[String, String]:
         """Gets the key-value map for a map-type argument.
 
         Returns an empty Dict if the argument was never provided.
@@ -201,7 +201,7 @@ struct ParseResult(Copyable, Movable, Writable):
         except:
             return Dict[String, String]()
 
-    fn has(self, name: String) -> Bool:
+    def has(self, name: String) -> Bool:
         """Checks whether an argument was provided.
 
         Args:
@@ -225,7 +225,7 @@ struct ParseResult(Copyable, Movable, Writable):
                 return i < len(self._positionals)
         return False
 
-    fn has_subcommand_result(self) -> Bool:
+    def has_subcommand_result(self) -> Bool:
         """Checks whether a subcommand result is present.
 
         Returns:
@@ -234,7 +234,7 @@ struct ParseResult(Copyable, Movable, Writable):
         """
         return len(self._subcommand_results) > 0
 
-    fn get_subcommand_result(self) raises -> ParseResult:
+    def get_subcommand_result(self) raises -> ParseResult:
         """Returns the child ParseResult produced by subcommand parsing.
 
         Returns:
@@ -252,7 +252,7 @@ struct ParseResult(Copyable, Movable, Writable):
         var r: ParseResult = self._subcommand_results[0].copy()
         return r^
 
-    fn get_unknown_args(self) -> List[String]:
+    def get_unknown_args(self) -> List[String]:
         """Returns the list of unrecognised arguments.
 
         Only populated when the result comes from
@@ -264,7 +264,7 @@ struct ParseResult(Copyable, Movable, Writable):
         """
         return self._unknown_args.copy()
 
-    fn print_summary(self, indent: Int = 0):
+    def print_summary(self, indent: Int = 0):
         """Prints a human-readable summary of all parsed arguments.
 
         Displays positionals, flags, values, counts, lists, and maps
@@ -276,7 +276,7 @@ struct ParseResult(Copyable, Movable, Writable):
         """
         self._print_summary_impl(indent, String(""))
 
-    fn _print_summary_impl(self, indent: Int, name: String):
+    def _print_summary_impl(self, indent: Int, name: String):
         """Internal implementation that accepts a subcommand name.
 
         Args:
@@ -379,7 +379,7 @@ struct ParseResult(Copyable, Movable, Writable):
             var sub = self._subcommand_results[0].copy()
             sub._print_summary_impl(indent + 2, self.subcommand)
 
-    fn __str__(self) -> String:
+    def __str__(self) -> String:
         """Return a string representation of the parse result."""
         var s = String("ParseResult(")
         s += "flags=" + String(len(self._flags))
@@ -390,7 +390,7 @@ struct ParseResult(Copyable, Movable, Writable):
         s += ")"
         return s
 
-    fn write_to[W: Writer](self, mut writer: W):
+    def write_to[W: Writer](self, mut writer: W):
         """Writes the string representation to a writer.
 
         Parameters:

--- a/src/argmojo/parse_result.mojo
+++ b/src/argmojo/parse_result.mojo
@@ -1,7 +1,7 @@
 """Stores parsed argument values."""
 
 
-struct ParseResult(Copyable, Movable, Stringable, Writable):
+struct ParseResult(Copyable, Movable, Writable):
     """Stores the results of parsing command-line arguments.
 
     Provides typed accessors to retrieve argument values by name.
@@ -48,7 +48,7 @@ struct ParseResult(Copyable, Movable, Stringable, Writable):
         self._subcommand_results = List[ParseResult]()
         self._unknown_args = List[String]()
 
-    fn __copyinit__(out self, copy: Self):
+    fn __init__(out self, *, copy: Self):
         """Creates a deep copy of a ParseResult.
 
         Args:
@@ -69,22 +69,22 @@ struct ParseResult(Copyable, Movable, Stringable, Writable):
         self._subcommand_results = copy._subcommand_results.copy()
         self._unknown_args = copy._unknown_args.copy()
 
-    fn __moveinit__(out self, deinit move: Self):
+    fn __init__(out self, *, deinit take: Self):
         """Moves a ParseResult, transferring all field ownership.
 
         Args:
-            move: The ParseResult to move from.
+            take: The ParseResult to move from.
         """
-        self._flags = move._flags^
-        self._values = move._values^
-        self._positionals = move._positionals^
-        self._counts = move._counts^
-        self._lists = move._lists^
-        self._maps = move._maps^
-        self._positional_names = move._positional_names^
-        self.subcommand = move.subcommand^
-        self._subcommand_results = move._subcommand_results^
-        self._unknown_args = move._unknown_args^
+        self._flags = take._flags^
+        self._values = take._values^
+        self._positionals = take._positionals^
+        self._counts = take._counts^
+        self._lists = take._lists^
+        self._maps = take._maps^
+        self._positional_names = take._positional_names^
+        self.subcommand = take.subcommand^
+        self._subcommand_results = take._subcommand_results^
+        self._unknown_args = take._unknown_args^
 
     fn get_flag(self, name: String) -> Bool:
         """Gets a boolean flag value. Returns False if not set.

--- a/src/argmojo/utils.mojo
+++ b/src/argmojo/utils.mojo
@@ -26,7 +26,7 @@ comptime _DEFAULT_ERROR_COLOR = _RED
 # ── Utility functions ────────────────────────────────────────────────────────
 
 
-fn _is_wide_codepoint(codepoint: Int) -> Bool:
+def _is_wide_codepoint(codepoint: Int) -> Bool:
     """Returns True if the Unicode codepoint occupies two terminal columns.
 
     Covers CJK Unified Ideographs, CJK Compatibility Ideographs,
@@ -150,7 +150,7 @@ fn _is_wide_codepoint(codepoint: Int) -> Bool:
     return False
 
 
-fn _display_width(s: String) -> Int:
+def _display_width(s: String) -> Int:
     """Returns the terminal display width of a string.
 
     CJK characters and fullwidth forms count as 2 columns each.  ANSI
@@ -190,7 +190,7 @@ fn _display_width(s: String) -> Int:
     return width
 
 
-fn _looks_like_number(token: String) -> Bool:
+def _looks_like_number(token: String) -> Bool:
     """Returns True if *token* is a negative-number literal.
 
     Recognises the forms ``-N``, ``-N.N``, ``-.N``, ``-NeX``, ``-N.NeX``,
@@ -243,12 +243,12 @@ fn _looks_like_number(token: String) -> Bool:
     return j == len(token)
 
 
-fn _is_ascii_digit(ch: String) -> Bool:
+def _is_ascii_digit(ch: String) -> Bool:
     """Returns True if *ch* is a single ASCII digit character ('0'-'9')."""
     return ch >= "0" and ch <= "9"
 
 
-fn _resolve_color[name: StringLiteral]() -> String:
+def _resolve_color[name: StringLiteral]() -> String:
     """Maps a user-facing colour name to its ANSI code at compile time.
 
     Accepted names (uppercase only): RED, GREEN, YELLOW, BLUE,
@@ -295,7 +295,7 @@ fn _resolve_color[name: StringLiteral]() -> String:
         return _ORANGE
 
 
-fn _levenshtein(a: String, b: String) -> Int:
+def _levenshtein(a: String, b: String) -> Int:
     """Returns the Levenshtein edit distance between two strings.
 
     The classic dynamic-programming algorithm, O(m*n) time and O(min(m,n))
@@ -339,7 +339,7 @@ fn _levenshtein(a: String, b: String) -> Int:
     return prev[n]
 
 
-fn _suggest_similar(input: String, candidates: List[String]) -> String:
+def _suggest_similar(input: String, candidates: List[String]) -> String:
     """Returns a 'Did you mean ...?' hint for the closest candidate.
 
     Uses Levenshtein distance with a threshold of ``max(len(input)/2, 2)``.
@@ -370,7 +370,7 @@ fn _suggest_similar(input: String, candidates: List[String]) -> String:
     return ""
 
 
-fn _has_fullwidth_chars(token: String) -> Bool:
+def _has_fullwidth_chars(token: String) -> Bool:
     """Returns True if *token* contains any fullwidth ASCII character.
 
     Checks for fullwidth ASCII ``U+FF01``–``U+FF5E`` and fullwidth space
@@ -383,7 +383,7 @@ fn _has_fullwidth_chars(token: String) -> Bool:
     return False
 
 
-fn _fullwidth_to_halfwidth(token: String) -> String:
+def _fullwidth_to_halfwidth(token: String) -> String:
     """Converts fullwidth ASCII characters to their halfwidth equivalents.
 
     Fullwidth ASCII range ``U+FF01``–``U+FF5E`` is mapped to
@@ -406,7 +406,7 @@ fn _fullwidth_to_halfwidth(token: String) -> String:
     return result
 
 
-fn _split_on_fullwidth_spaces(token: String) -> List[String]:
+def _split_on_fullwidth_spaces(token: String) -> List[String]:
     """Splits a token on fullwidth spaces (``U+3000``) after fullwidth correction.
 
     After converting fullwidth ASCII to halfwidth, embedded fullwidth
@@ -431,7 +431,7 @@ fn _split_on_fullwidth_spaces(token: String) -> List[String]:
     return result^
 
 
-fn _correct_cjk_punctuation(token: String) -> String:
+def _correct_cjk_punctuation(token: String) -> String:
     """Replaces common CJK punctuation with ASCII equivalents.
 
     This handles characters outside the fullwidth ASCII range
@@ -486,7 +486,7 @@ comptime _TCSANOW = 0
 
 
 @always_inline
-fn _lflag_offset(buf: List[UInt32]) -> Int:
+def _lflag_offset(buf: List[UInt32]) -> Int:
     """Returns the UInt32 index of c_lflag in a tcgetattr buffer.
 
     On macOS (tcflag_t = 8 bytes), c_lflag is at UInt32 offset 6.
@@ -505,7 +505,7 @@ fn _lflag_offset(buf: List[UInt32]) -> Int:
     return -1
 
 
-fn _disable_echo() -> List[UInt32]:
+def _disable_echo() -> List[UInt32]:
     """Disables terminal echo on stdin.
 
     Uses POSIX ``tcgetattr`` / ``tcsetattr`` to clear the ``ECHO``
@@ -537,7 +537,7 @@ fn _disable_echo() -> List[UInt32]:
     return saved^
 
 
-fn _restore_echo(var saved: List[UInt32]) -> Bool:
+def _restore_echo(var saved: List[UInt32]) -> Bool:
     """Restores terminal echo on stdin.
 
     Restores the original termios settings saved by ``_disable_echo``.

--- a/src/argmojo/utils.mojo
+++ b/src/argmojo/utils.mojo
@@ -1,6 +1,6 @@
 """ANSI colour constants and small utility functions used by ArgMojo."""
 
-from sys.ffi import external_call
+from std.ffi import external_call
 
 # ── ANSI colour codes ────────────────────────────────────────────────────────
 comptime _RESET = "\x1b[0m"
@@ -197,43 +197,47 @@ fn _looks_like_number(token: String) -> Bool:
     ``-N.NEX``, ``-.NE+X``, and the corresponding ``-Ne+X``, ``-Ne-X``,
     ``-NE+X``, ``-NE-X`` variants.
     """
-    if len(token) < 2 or token[0:1] != "-":
+    if len(token) < 2 or not token.startswith("-"):
         return False
     var j = 1
     # Optional leading '.' after minus (e.g. -.5).
-    if token[j : j + 1] == ".":
+    if token[byte = j : j + 1] == ".":
         j += 1
         if j >= len(token) or not (
-            token[j : j + 1] >= "0" and token[j : j + 1] <= "9"
+            token[byte = j : j + 1] >= "0" and token[byte = j : j + 1] <= "9"
         ):
             return False
-    elif not (token[j : j + 1] >= "0" and token[j : j + 1] <= "9"):
+    elif not (
+        token[byte = j : j + 1] >= "0" and token[byte = j : j + 1] <= "9"
+    ):
         return False
     # Integer digits.
     while j < len(token) and (
-        token[j : j + 1] >= "0" and token[j : j + 1] <= "9"
+        token[byte = j : j + 1] >= "0" and token[byte = j : j + 1] <= "9"
     ):
         j += 1
     # Optional fractional part.
-    if j < len(token) and token[j : j + 1] == ".":
+    if j < len(token) and token[byte = j : j + 1] == ".":
         j += 1
         while j < len(token) and (
-            token[j : j + 1] >= "0" and token[j : j + 1] <= "9"
+            token[byte = j : j + 1] >= "0" and token[byte = j : j + 1] <= "9"
         ):
             j += 1
     # Optional exponent.
-    if j < len(token) and (token[j : j + 1] == "e" or token[j : j + 1] == "E"):
+    if j < len(token) and (
+        token[byte = j : j + 1] == "e" or token[byte = j : j + 1] == "E"
+    ):
         j += 1
         if j < len(token) and (
-            token[j : j + 1] == "+" or token[j : j + 1] == "-"
+            token[byte = j : j + 1] == "+" or token[byte = j : j + 1] == "-"
         ):
             j += 1
         if j >= len(token) or not (
-            token[j : j + 1] >= "0" and token[j : j + 1] <= "9"
+            token[byte = j : j + 1] >= "0" and token[byte = j : j + 1] <= "9"
         ):
             return False
         while j < len(token) and (
-            token[j : j + 1] >= "0" and token[j : j + 1] <= "9"
+            token[byte = j : j + 1] >= "0" and token[byte = j : j + 1] <= "9"
         ):
             j += 1
     return j == len(token)
@@ -256,7 +260,7 @@ fn _resolve_color[name: StringLiteral]() -> String:
     Returns:
         The ANSI escape code for the colour.
     """
-    constrained[
+    comptime assert (
         name == "RED"
         or name == "GREEN"
         or name == "YELLOW"
@@ -265,15 +269,15 @@ fn _resolve_color[name: StringLiteral]() -> String:
         or name == "PINK"
         or name == "CYAN"
         or name == "WHITE"
-        or name == "ORANGE",
+        or name == "ORANGE"
+    ), (
         "Unknown colour '"
         + name
         + "'. Choose from: RED, GREEN, YELLOW, BLUE, MAGENTA, PINK,"
-        " CYAN, WHITE, ORANGE",
-    ]()
+        " CYAN, WHITE, ORANGE"
+    )
 
-    @parameter
-    if name == "RED":
+    comptime if name == "RED":
         return _RED
     elif name == "GREEN":
         return _GREEN
@@ -316,7 +320,7 @@ fn _levenshtein(a: String, b: String) -> Int:
     for i in range(1, m + 1):
         curr[0] = i
         for j in range(1, n + 1):
-            var cost = 0 if a[i - 1 : i] == b[j - 1 : j] else 1
+            var cost = 0 if a[byte = i - 1 : i] == b[byte = j - 1 : j] else 1
             var ins = prev[j] + 1
             var dele = curr[j - 1] + 1
             var sub = prev[j - 1] + cost

--- a/tests/test_collect.mojo
+++ b/tests/test_collect.mojo
@@ -7,7 +7,7 @@ from argmojo import Argument, Command, ParseResult
 # ── Append / collect action ──────────────────────────────────────────────────────
 
 
-fn test_append_single() raises:
+def test_append_single() raises:
     """Tests that a single --tag x produces a list with one element."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -22,7 +22,7 @@ fn test_append_single() raises:
     assert_true(result.has("tag"), msg="tag should be present")
 
 
-fn test_append_multiple() raises:
+def test_append_multiple() raises:
     """Tests that --tag x --tag y --tag z collects all values."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -46,7 +46,7 @@ fn test_append_multiple() raises:
     assert_equal(tags[2], "gamma")
 
 
-fn test_append_short_option() raises:
+def test_append_short_option() raises:
     """Tests that -t x -t y collects values via short option."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -61,7 +61,7 @@ fn test_append_short_option() raises:
     assert_equal(tags[1], "beta")
 
 
-fn test_append_equals_syntax() raises:
+def test_append_equals_syntax() raises:
     """Tests that --tag=x --tag=y collects values with equals syntax."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -76,7 +76,7 @@ fn test_append_equals_syntax() raises:
     assert_equal(tags[1], "beta")
 
 
-fn test_append_attached_short() raises:
+def test_append_attached_short() raises:
     """Tests that -talpha -tbeta collects values with attached short syntax."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -91,7 +91,7 @@ fn test_append_attached_short() raises:
     assert_equal(tags[1], "beta")
 
 
-fn test_append_mixed_syntax() raises:
+def test_append_mixed_syntax() raises:
     """Tests mixing long, short, equals, and attached syntax for append."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -108,7 +108,7 @@ fn test_append_mixed_syntax() raises:
     assert_equal(tags[3], "d")
 
 
-fn test_append_empty() raises:
+def test_append_empty() raises:
     """Tests that get_list returns empty list when option never provided."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -122,7 +122,7 @@ fn test_append_empty() raises:
     assert_false(result.has("tag"), msg="tag should not be present")
 
 
-fn test_append_with_choices() raises:
+def test_append_with_choices() raises:
     """Tests that append respects choices validation."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -166,7 +166,7 @@ fn test_append_with_choices() raises:
     assert_true(caught, msg="Should have raised error for invalid choice")
 
 
-fn test_append_with_other_args() raises:
+def test_append_with_other_args() raises:
     """Tests that append args work alongside regular flags and values."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -204,7 +204,7 @@ fn test_append_with_other_args() raises:
 # ===------------------------------------------------------------------=== #
 
 
-fn test_delimiter_comma() raises:
+def test_delimiter_comma() raises:
     """Tests basic comma delimiter splitting."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -220,7 +220,7 @@ fn test_delimiter_comma() raises:
     assert_equal(tags[2], "c")
 
 
-fn test_delimiter_equals_syntax() raises:
+def test_delimiter_equals_syntax() raises:
     """Tests delimiter with --key=value syntax."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -236,7 +236,7 @@ fn test_delimiter_equals_syntax() raises:
     assert_equal(tags[2], "z")
 
 
-fn test_delimiter_short_option() raises:
+def test_delimiter_short_option() raises:
     """Tests delimiter with short option."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -251,7 +251,7 @@ fn test_delimiter_short_option() raises:
     assert_equal(tags[1], "bar")
 
 
-fn test_delimiter_attached_short() raises:
+def test_delimiter_attached_short() raises:
     """Tests delimiter with attached short value (-tfoo,bar)."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -274,7 +274,7 @@ fn test_delimiter_attached_short() raises:
     assert_equal(tags[1], "b")
 
 
-fn test_delimiter_repeated() raises:
+def test_delimiter_repeated() raises:
     """Tests delimiter with multiple uses — values accumulate."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -291,7 +291,7 @@ fn test_delimiter_repeated() raises:
     assert_equal(tags[3], "d")
 
 
-fn test_delimiter_single_value() raises:
+def test_delimiter_single_value() raises:
     """Tests delimiter with a single value (no delimiter present)."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -305,7 +305,7 @@ fn test_delimiter_single_value() raises:
     assert_equal(tags[0], "single")
 
 
-fn test_delimiter_with_choices() raises:
+def test_delimiter_with_choices() raises:
     """Tests that choices are validated per-piece after splitting."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -340,7 +340,7 @@ fn test_delimiter_with_choices() raises:
     )
 
 
-fn test_delimiter_semicolon() raises:
+def test_delimiter_semicolon() raises:
     """Tests using a non-comma delimiter (semicolon)."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -356,7 +356,7 @@ fn test_delimiter_semicolon() raises:
     assert_equal(paths[2], "/home/lib")
 
 
-fn test_delimiter_implies_append() raises:
+def test_delimiter_implies_append() raises:
     """Tests that .delimiter() implies .append() — get_list works."""
     var command = Command("test", "Test app")
     # Note: no explicit .append() call — delimiter() implies it.
@@ -373,7 +373,7 @@ fn test_delimiter_implies_append() raises:
     assert_equal(tags[1], "y")
 
 
-fn test_delimiter_empty_not_provided() raises:
+def test_delimiter_empty_not_provided() raises:
     """Tests delimiter arg not provided returns empty list."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -386,7 +386,7 @@ fn test_delimiter_empty_not_provided() raises:
     assert_equal(len(tags), 0)
 
 
-fn test_delimiter_trailing_comma() raises:
+def test_delimiter_trailing_comma() raises:
     """Tests that trailing delimiter does not create empty entry."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -406,7 +406,7 @@ fn test_delimiter_trailing_comma() raises:
 # ===------------------------------------------------------------------=== #
 
 
-fn test_nargs_basic() raises:
+def test_nargs_basic() raises:
     """Tests that number_of_values(2) consumes exactly 2 values."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -423,7 +423,7 @@ fn test_nargs_basic() raises:
     assert_equal(lst[1], "20", msg="Second value should be '20'")
 
 
-fn test_nargs_three() raises:
+def test_nargs_three() raises:
     """Tests that number_of_values(3) consumes exactly 3 values."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -439,7 +439,7 @@ fn test_nargs_three() raises:
     assert_equal(lst[2], "0", msg="Third = 0")
 
 
-fn test_nargs_short_option() raises:
+def test_nargs_short_option() raises:
     """Tests nargs with a short option (-p 1 2)."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -459,7 +459,7 @@ fn test_nargs_short_option() raises:
     assert_equal(lst[1], "4", msg="Second = 4")
 
 
-fn test_nargs_repeated() raises:
+def test_nargs_repeated() raises:
     """Tests that nargs collects across repeated occurrences."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -486,7 +486,7 @@ fn test_nargs_repeated() raises:
     assert_equal(lst[3], "4", msg="4th = 4")
 
 
-fn test_nargs_too_few_values() raises:
+def test_nargs_too_few_values() raises:
     """Tests that nargs raises when not enough values are available."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -507,7 +507,7 @@ fn test_nargs_too_few_values() raises:
     assert_true(caught, msg="Should raise when not enough values for nargs")
 
 
-fn test_nargs_too_few_short() raises:
+def test_nargs_too_few_short() raises:
     """Tests that nargs raises with short option when not enough values."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -528,7 +528,7 @@ fn test_nargs_too_few_short() raises:
     assert_true(caught, msg="Should raise when not enough values for nargs")
 
 
-fn test_nargs_with_choices() raises:
+def test_nargs_with_choices() raises:
     """Tests that choices validation applies to each nargs value."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -560,7 +560,7 @@ fn test_nargs_with_choices() raises:
     assert_true(caught, msg="Bad choice in nargs should raise")
 
 
-fn test_nargs_with_other_args() raises:
+def test_nargs_with_other_args() raises:
     """Tests nargs coexisting with flags and regular value args."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -596,7 +596,7 @@ fn test_nargs_with_other_args() raises:
     )
 
 
-fn test_nargs_equals_syntax_rejected() raises:
+def test_nargs_equals_syntax_rejected() raises:
     """Tests that = syntax is rejected for nargs options."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -617,7 +617,7 @@ fn test_nargs_equals_syntax_rejected() raises:
     assert_true(caught, msg="nargs with = should raise")
 
 
-fn test_nargs_prefix_match() raises:
+def test_nargs_prefix_match() raises:
     """Tests that prefix matching works with nargs options."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -637,7 +637,7 @@ fn test_nargs_prefix_match() raises:
 # ── Fullwidth delimiter tests ────────────────────────────────────────────────────
 
 
-fn test_delimiter_fullwidth_comma() raises:
+def test_delimiter_fullwidth_comma() raises:
     """Fullwidth comma ，(U+FF0C) is normalized to , before splitting."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -654,7 +654,7 @@ fn test_delimiter_fullwidth_comma() raises:
     assert_equal(tags[2], "c")
 
 
-fn test_delimiter_fullwidth_semicolon() raises:
+def test_delimiter_fullwidth_semicolon() raises:
     """Fullwidth semicolon ；(U+FF1B) is normalized to ; before splitting."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -670,7 +670,7 @@ fn test_delimiter_fullwidth_semicolon() raises:
     assert_equal(paths[2], "z")
 
 
-fn test_delimiter_fullwidth_disabled() raises:
+def test_delimiter_fullwidth_disabled() raises:
     """Fullwidth commas are NOT normalized when correction is disabled."""
     var command = Command("test", "Test app")
     command.disable_fullwidth_correction()
@@ -690,7 +690,7 @@ fn test_delimiter_fullwidth_disabled() raises:
     assert_equal(tags[0], "a，b，c")
 
 
-fn test_delimiter_fullwidth_mixed() raises:
+def test_delimiter_fullwidth_mixed() raises:
     """Mix of halfwidth and fullwidth commas both split correctly."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -707,5 +707,5 @@ fn test_delimiter_fullwidth_mixed() raises:
     assert_equal(tags[2], "c")
 
 
-fn main() raises:
+def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_collect.mojo
+++ b/tests/test_collect.mojo
@@ -1,6 +1,6 @@
 """Tests for argmojo — collection features (append, delimiter, nargs)."""
 
-from testing import assert_true, assert_false, assert_equal, TestSuite
+from std.testing import assert_true, assert_false, assert_equal, TestSuite
 import argmojo
 from argmojo import Argument, Command, ParseResult
 

--- a/tests/test_completion.mojo
+++ b/tests/test_completion.mojo
@@ -8,7 +8,7 @@ from argmojo import Argument, Command
 # ── generate_completion[] dispatch (compile-time) ────────────────────────────
 
 
-fn test_fish_dispatch() raises:
+def test_fish_dispatch() raises:
     """Tests that generate_completion["fish"]() returns Fish syntax."""
     var command = Command("myapp", "A test app")
     command.add_argument(
@@ -24,7 +24,7 @@ fn test_fish_dispatch() raises:
     )
 
 
-fn test_zsh_dispatch() raises:
+def test_zsh_dispatch() raises:
     """Tests that generate_completion["zsh"]() returns Zsh syntax."""
     var command = Command("myapp", "A test app")
     command.add_argument(
@@ -44,7 +44,7 @@ fn test_zsh_dispatch() raises:
     )
 
 
-fn test_bash_dispatch() raises:
+def test_bash_dispatch() raises:
     """Tests that generate_completion["bash"]() returns Bash syntax."""
     var command = Command("myapp", "A test app")
     command.add_argument(
@@ -60,7 +60,7 @@ fn test_bash_dispatch() raises:
     )
 
 
-fn test_case_insensitive_shell_runtime() raises:
+def test_case_insensitive_shell_runtime() raises:
     """Runtime overload accepts case-insensitive shell names."""
     var command = Command("myapp", "A test app")
     var fish_upper = command.generate_completion("FISH")
@@ -80,7 +80,7 @@ fn test_case_insensitive_shell_runtime() raises:
     )
 
 
-fn test_unknown_shell_raises_runtime() raises:
+def test_unknown_shell_raises_runtime() raises:
     """Runtime overload raises for unknown shell names."""
     var command = Command("myapp", "A test app")
     var raised = False
@@ -91,7 +91,7 @@ fn test_unknown_shell_raises_runtime() raises:
     assert_true(raised, msg="Unknown shell should raise an error")
 
 
-fn test_invalid_shell_caught_at_compile_time() raises:
+def test_invalid_shell_caught_at_compile_time() raises:
     """Invalid shell names are caught at compile time via constrained[].
 
     This test verifies the valid paths work.  An invalid name
@@ -111,7 +111,7 @@ fn test_invalid_shell_caught_at_compile_time() raises:
 # ── Fish completion details ──────────────────────────────────────────────────
 
 
-fn test_fish_long_option() raises:
+def test_fish_long_option() raises:
     """Tests that Fish script includes long options."""
     var command = Command("myapp", "A test app")
     command.add_argument(
@@ -128,7 +128,7 @@ fn test_fish_long_option() raises:
     )
 
 
-fn test_fish_flag_no_require_value() raises:
+def test_fish_flag_no_require_value() raises:
     """Tests that Fish flags do NOT have -r (require value)."""
     var command = Command("myapp", "A test app")
     command.add_argument(
@@ -148,7 +148,7 @@ fn test_fish_flag_no_require_value() raises:
     assert_true(False, msg="Should have found --verbose in Fish output")
 
 
-fn test_fish_value_option_has_require() raises:
+def test_fish_value_option_has_require() raises:
     """Tests that Fish value-taking options have -r (require value)."""
     var command = Command("myapp", "A test app")
     command.add_argument(
@@ -167,7 +167,7 @@ fn test_fish_value_option_has_require() raises:
     assert_true(False, msg="Should have found --output in Fish output")
 
 
-fn test_fish_choices() raises:
+def test_fish_choices() raises:
     """Tests that Fish script includes choices with -a."""
     var command = Command("myapp", "A test app")
     command.add_argument(
@@ -184,7 +184,7 @@ fn test_fish_choices() raises:
     )
 
 
-fn test_fish_help_text() raises:
+def test_fish_help_text() raises:
     """Tests that Fish script includes description with -d."""
     var command = Command("myapp", "A test app")
     command.add_argument(
@@ -197,7 +197,7 @@ fn test_fish_help_text() raises:
     )
 
 
-fn test_fish_hidden_excluded() raises:
+def test_fish_hidden_excluded() raises:
     """Tests that hidden args are excluded from Fish completion."""
     var command = Command("myapp", "A test app")
     command.add_argument(
@@ -220,7 +220,7 @@ fn test_fish_hidden_excluded() raises:
     )
 
 
-fn test_fish_builtin_help_version() raises:
+def test_fish_builtin_help_version() raises:
     """Tests that Fish script includes built-in --help and --version."""
     var command = Command("myapp", "A test app")
     var script = command.generate_completion["fish"]()
@@ -234,7 +234,7 @@ fn test_fish_builtin_help_version() raises:
     )
 
 
-fn test_fish_subcommands() raises:
+def test_fish_subcommands() raises:
     """Tests that Fish script registers subcommand completions."""
     var app = Command("myapp", "A test app")
     var sub = Command("search", "Search for patterns")
@@ -262,7 +262,7 @@ fn test_fish_subcommands() raises:
     )
 
 
-fn test_fish_escape_single_quote() raises:
+def test_fish_escape_single_quote() raises:
     """Tests that single quotes in help text are escaped for Fish."""
     var command = Command("myapp", "A test app")
     command.add_argument(
@@ -278,7 +278,7 @@ fn test_fish_escape_single_quote() raises:
 # ── Zsh completion details ───────────────────────────────────────────────────
 
 
-fn test_zsh_simple_flag() raises:
+def test_zsh_simple_flag() raises:
     """Tests that Zsh script includes flag specs."""
     var command = Command("myapp", "A test app")
     command.add_argument(
@@ -298,7 +298,7 @@ fn test_zsh_simple_flag() raises:
     )
 
 
-fn test_zsh_choices() raises:
+def test_zsh_choices() raises:
     """Tests that Zsh script includes choices in value spec."""
     var command = Command("myapp", "A test app")
     command.add_argument(
@@ -314,7 +314,7 @@ fn test_zsh_choices() raises:
     )
 
 
-fn test_zsh_subcommands() raises:
+def test_zsh_subcommands() raises:
     """Tests that Zsh script handles subcommand dispatch."""
     var app = Command("myapp", "A test app")
     var sub = Command("build", "Build the project")
@@ -337,7 +337,7 @@ fn test_zsh_subcommands() raises:
     )
 
 
-fn test_zsh_escape_brackets() raises:
+def test_zsh_escape_brackets() raises:
     """Tests that brackets in help text are escaped for Zsh specs."""
     var command = Command("myapp", "A test app")
     command.add_argument(
@@ -350,7 +350,7 @@ fn test_zsh_escape_brackets() raises:
     )
 
 
-fn test_zsh_escape_colon() raises:
+def test_zsh_escape_colon() raises:
     """Tests that colons in help text are escaped for Zsh specs."""
     var command = Command("myapp", "A test app")
     command.add_argument(
@@ -363,7 +363,7 @@ fn test_zsh_escape_colon() raises:
     )
 
 
-fn test_zsh_builtin_help() raises:
+def test_zsh_builtin_help() raises:
     """Tests that Zsh script includes built-in help/version."""
     var command = Command("myapp", "A test app")
     var script = command.generate_completion["zsh"]()
@@ -380,7 +380,7 @@ fn test_zsh_builtin_help() raises:
 # ── Bash completion details ──────────────────────────────────────────────────
 
 
-fn test_bash_simple_options() raises:
+def test_bash_simple_options() raises:
     """Tests that Bash script includes all options in COMPREPLY."""
     var command = Command("myapp", "A test app")
     command.add_argument(
@@ -411,7 +411,7 @@ fn test_bash_simple_options() raises:
     )
 
 
-fn test_bash_subcommands() raises:
+def test_bash_subcommands() raises:
     """Tests that Bash script handles subcommand detection."""
     var app = Command("myapp", "A test app")
     var sub = Command("deploy", "Deploy the app")
@@ -432,7 +432,7 @@ fn test_bash_subcommands() raises:
     )
 
 
-fn test_bash_choices_prev() raises:
+def test_bash_choices_prev() raises:
     """Tests that Bash script completes choices based on $prev."""
     var command = Command("myapp", "A test app")
     command.add_argument(
@@ -453,7 +453,7 @@ fn test_bash_choices_prev() raises:
     )
 
 
-fn test_bash_hidden_excluded() raises:
+def test_bash_hidden_excluded() raises:
     """Tests that hidden args are excluded from Bash completion."""
     var command = Command("myapp", "A test app")
     command.add_argument(
@@ -473,7 +473,7 @@ fn test_bash_hidden_excluded() raises:
     )
 
 
-fn test_bash_builtin_help_version() raises:
+def test_bash_builtin_help_version() raises:
     """Tests that Bash script includes --help and --version."""
     var command = Command("myapp", "A test app")
     var script = command.generate_completion["bash"]()
@@ -490,7 +490,7 @@ fn test_bash_builtin_help_version() raises:
 # ── Cross-shell consistency ──────────────────────────────────────────────────
 
 
-fn test_all_shells_include_same_options() raises:
+def test_all_shells_include_same_options() raises:
     """Tests that all three shells list the same user-defined options."""
     var command = Command("myapp", "A test app")
     command.add_argument(
@@ -527,7 +527,7 @@ fn test_all_shells_include_same_options() raises:
     assert_true("--format" in bash, msg="bash should include --format")
 
 
-fn test_count_option_no_value() raises:
+def test_count_option_no_value() raises:
     """Tests that count options are treated like flags (no value required)."""
     var command = Command("myapp", "A test app")
     command.add_argument(
@@ -551,7 +551,7 @@ fn test_count_option_no_value() raises:
     assert_true(found, msg="Fish script should contain '-l verbose' line")
 
 
-fn test_persistent_flags_in_root() raises:
+def test_persistent_flags_in_root() raises:
     """Tests that persistent flags appear in root-level completion."""
     var app = Command("myapp", "A test app")
     app.add_argument(
@@ -567,7 +567,7 @@ fn test_persistent_flags_in_root() raises:
     )
 
 
-fn test_positional_excluded() raises:
+def test_positional_excluded() raises:
     """Tests that positional args are NOT listed as completable options."""
     var command = Command("myapp", "A test app")
     command.add_argument(
@@ -590,7 +590,7 @@ fn test_positional_excluded() raises:
     )
 
 
-fn test_generated_by_comment() raises:
+def test_generated_by_comment() raises:
     """Tests that all scripts have 'Generated by ArgMojo' comment."""
     var command = Command("myapp", "A test app")
     var fish = command.generate_completion["fish"]()
@@ -613,7 +613,7 @@ fn test_generated_by_comment() raises:
 # ── Built-in --completions flag ───────────────────────────────────────────────
 
 
-fn test_fish_builtin_completions() raises:
+def test_fish_builtin_completions() raises:
     """Tests that Fish script includes the built-in --completions option."""
     var command = Command("myapp", "A test app")
     var script = command.generate_completion["fish"]()
@@ -627,7 +627,7 @@ fn test_fish_builtin_completions() raises:
     )
 
 
-fn test_zsh_builtin_completions() raises:
+def test_zsh_builtin_completions() raises:
     """Tests that Zsh script includes the built-in --completions option."""
     var command = Command("myapp", "A test app")
     var script = command.generate_completion["zsh"]()
@@ -641,7 +641,7 @@ fn test_zsh_builtin_completions() raises:
     )
 
 
-fn test_bash_builtin_completions() raises:
+def test_bash_builtin_completions() raises:
     """Tests that Bash script includes the built-in --completions option."""
     var command = Command("myapp", "A test app")
     var script = command.generate_completion["bash"]()
@@ -655,7 +655,7 @@ fn test_bash_builtin_completions() raises:
     )
 
 
-fn test_disable_default_completions_not_in_script() raises:
+def test_disable_default_completions_not_in_script() raises:
     """Tests that disable_default_completions() removes --completions from all scripts.
     """
     var command = Command("myapp", "A test app")
@@ -686,7 +686,7 @@ fn test_disable_default_completions_not_in_script() raises:
     )
 
 
-fn test_disable_default_completions_not_in_help() raises:
+def test_disable_default_completions_not_in_help() raises:
     """Tests that disable_default_completions() hides --completions from help.
     """
     var command = Command("myapp", "A test app")
@@ -701,7 +701,7 @@ fn test_disable_default_completions_not_in_help() raises:
     )
 
 
-fn test_completions_in_help_by_default() raises:
+def test_completions_in_help_by_default() raises:
     """Tests that --completions appears in the Options section of help by default.
     """
     var command = Command("myapp", "A test app")
@@ -719,7 +719,7 @@ fn test_completions_in_help_by_default() raises:
 # ── completions_name() ──────────────────────────────────────────────────────
 
 
-fn test_completions_custom_name_in_scripts() raises:
+def test_completions_custom_name_in_scripts() raises:
     """Tests that completions_name() changes the trigger in all scripts."""
     var command = Command("myapp", "A test app")
     command.completions_name("autocomp")
@@ -748,7 +748,7 @@ fn test_completions_custom_name_in_scripts() raises:
     )
 
 
-fn test_completions_custom_name_in_help() raises:
+def test_completions_custom_name_in_help() raises:
     """Tests that completions_name() changes the trigger shown in help."""
     var command = Command("myapp", "A test app")
     command.completions_name("autocomp")
@@ -763,7 +763,7 @@ fn test_completions_custom_name_in_help() raises:
     )
 
 
-fn test_completions_custom_name_in_bash_prev() raises:
+def test_completions_custom_name_in_bash_prev() raises:
     """Tests that completions_name() updates bash prev-case pattern."""
     var command = Command("myapp", "A test app")
     command.completions_name("gen-comp")
@@ -781,7 +781,7 @@ fn test_completions_custom_name_in_bash_prev() raises:
 # ── completions_as_subcommand() ─────────────────────────────────────────────
 
 
-fn test_completions_as_subcommand_in_help() raises:
+def test_completions_as_subcommand_in_help() raises:
     """Tests that completions_as_subcommand() shows it in Commands, not Options.
     """
     var command = Command("myapp", "A test app")
@@ -807,7 +807,7 @@ fn test_completions_as_subcommand_in_help() raises:
     )
 
 
-fn test_completions_as_subcommand_in_fish() raises:
+def test_completions_as_subcommand_in_fish() raises:
     """Tests that completions_as_subcommand() appears as subcommand in Fish."""
     var command = Command("myapp", "A test app")
     var sub = Command("serve", "Start the server")
@@ -832,7 +832,7 @@ fn test_completions_as_subcommand_in_fish() raises:
     )
 
 
-fn test_completions_as_subcommand_in_zsh() raises:
+def test_completions_as_subcommand_in_zsh() raises:
     """Tests that completions_as_subcommand() appears as subcommand in Zsh."""
     var command = Command("myapp", "A test app")
     var sub = Command("serve", "Start the server")
@@ -856,7 +856,7 @@ fn test_completions_as_subcommand_in_zsh() raises:
     )
 
 
-fn test_completions_as_subcommand_in_bash() raises:
+def test_completions_as_subcommand_in_bash() raises:
     """Tests that completions_as_subcommand() appears as subcommand in Bash."""
     var command = Command("myapp", "A test app")
     var sub = Command("serve", "Start the server")
@@ -881,7 +881,7 @@ fn test_completions_as_subcommand_in_bash() raises:
     )
 
 
-fn test_completions_custom_name_with_subcommand() raises:
+def test_completions_custom_name_with_subcommand() raises:
     """Tests combining completions_name() with completions_as_subcommand()."""
     var command = Command("myapp", "A test app")
     var sub = Command("serve", "Start the server")
@@ -921,7 +921,7 @@ fn test_completions_custom_name_with_subcommand() raises:
 # ── Alias in completion scripts ──────────────────────────────────────────────
 
 
-fn test_fish_completion_includes_alias() raises:
+def test_fish_completion_includes_alias() raises:
     """Tests that Fish completion lists alias as a completable name."""
     var app = Command("myapp", "A test app")
     var clone = Command("clone", "Clone a repository")
@@ -944,7 +944,7 @@ fn test_fish_completion_includes_alias() raises:
     )
 
 
-fn test_zsh_completion_includes_alias() raises:
+def test_zsh_completion_includes_alias() raises:
     """Tests that Zsh completion lists alias entries."""
     var app = Command("myapp", "A test app")
     var clone = Command("clone", "Clone a repository")
@@ -962,7 +962,7 @@ fn test_zsh_completion_includes_alias() raises:
     )
 
 
-fn test_bash_completion_includes_alias() raises:
+def test_bash_completion_includes_alias() raises:
     """Tests that Bash completion includes alias in dispatch pattern."""
     var app = Command("myapp", "A test app")
     var clone = Command("clone", "Clone a repository")
@@ -984,7 +984,7 @@ fn test_bash_completion_includes_alias() raises:
 # ── Hidden subcommands in completions ─────────────────────────────────────────
 
 
-fn _make_app_with_hidden_sub() raises -> Command:
+def _make_app_with_hidden_sub() raises -> Command:
     """Helper: app with 'clone' visible and 'debug' hidden."""
     var app = Command("myapp", "A test app")
     var clone = Command("clone", "Clone a repository")
@@ -997,7 +997,7 @@ fn _make_app_with_hidden_sub() raises -> Command:
     return app^
 
 
-fn test_fish_hidden_sub_excluded() raises:
+def test_fish_hidden_sub_excluded() raises:
     """Tests that hidden subcommands are absent from Fish completion."""
     var app = _make_app_with_hidden_sub()
     var script = app.generate_completion["fish"]()
@@ -1011,7 +1011,7 @@ fn test_fish_hidden_sub_excluded() raises:
     )
 
 
-fn test_zsh_hidden_sub_excluded() raises:
+def test_zsh_hidden_sub_excluded() raises:
     """Tests that hidden subcommands are absent from Zsh completion."""
     var app = _make_app_with_hidden_sub()
     var script = app.generate_completion["zsh"]()
@@ -1025,7 +1025,7 @@ fn test_zsh_hidden_sub_excluded() raises:
     )
 
 
-fn test_bash_hidden_sub_excluded() raises:
+def test_bash_hidden_sub_excluded() raises:
     """Tests that hidden subcommands are absent from Bash completion."""
     var app = _make_app_with_hidden_sub()
     var script = app.generate_completion["bash"]()
@@ -1039,7 +1039,7 @@ fn test_bash_hidden_sub_excluded() raises:
     )
 
 
-fn test_all_hidden_no_subcommand_completion() raises:
+def test_all_hidden_no_subcommand_completion() raises:
     """Tests that when all subs are hidden, completion is simple (no subs)."""
     var app = Command("myapp", "A test app")
     app.add_argument(
@@ -1064,5 +1064,5 @@ fn test_all_hidden_no_subcommand_completion() raises:
     )
 
 
-fn main() raises:
+def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_completion.mojo
+++ b/tests/test_completion.mojo
@@ -1,6 +1,6 @@
 """Tests for argmojo — shell completion script generation (bash, zsh, fish)."""
 
-from testing import assert_true, assert_false, assert_equal, TestSuite
+from std.testing import assert_true, assert_false, assert_equal, TestSuite
 import argmojo
 from argmojo import Argument, Command
 

--- a/tests/test_confirmation.mojo
+++ b/tests/test_confirmation.mojo
@@ -1,6 +1,6 @@
 """Tests for argmojo — confirmation option (--yes / -y)."""
 
-from testing import assert_true, assert_false, assert_equal, TestSuite
+from std.testing import assert_true, assert_false, assert_equal, TestSuite
 import argmojo
 from argmojo import Argument, Command, ParseResult
 

--- a/tests/test_confirmation.mojo
+++ b/tests/test_confirmation.mojo
@@ -7,7 +7,7 @@ from argmojo import Argument, Command, ParseResult
 # ── --yes flag skips confirmation ─────────────────────────────────────────────
 
 
-fn test_confirmation_yes_flag_skips() raises:
+def test_confirmation_yes_flag_skips() raises:
     """Tests that --yes skips the confirmation prompt."""
     var cmd = Command("drop", "Drop the database")
     cmd.add_argument(
@@ -21,7 +21,7 @@ fn test_confirmation_yes_flag_skips() raises:
     assert_true(result.get_flag("yes"), msg="--yes should be True")
 
 
-fn test_confirmation_y_short_flag_skips() raises:
+def test_confirmation_y_short_flag_skips() raises:
     """Tests that -y skips the confirmation prompt."""
     var cmd = Command("drop", "Drop the database")
     cmd.add_argument(
@@ -35,7 +35,7 @@ fn test_confirmation_y_short_flag_skips() raises:
     assert_true(result.get_flag("yes"), msg="-y should be True")
 
 
-fn test_confirmation_yes_before_positional() raises:
+def test_confirmation_yes_before_positional() raises:
     """Tests that --yes can appear before the positional argument."""
     var cmd = Command("drop", "Drop the database")
     cmd.add_argument(
@@ -52,7 +52,7 @@ fn test_confirmation_yes_before_positional() raises:
 # ── Non-interactive stdin aborts ──────────────────────────────────────────────
 
 
-fn test_confirmation_aborts_on_no_stdin() raises:
+def test_confirmation_aborts_on_no_stdin() raises:
     """Tests that confirmation aborts when stdin is unavailable.
 
     When tests run without a terminal (stdin is /dev/null or piped),
@@ -84,7 +84,7 @@ fn test_confirmation_aborts_on_no_stdin() raises:
 # ── Custom prompt text ────────────────────────────────────────────────────────
 
 
-fn test_confirmation_custom_prompt_with_yes() raises:
+def test_confirmation_custom_prompt_with_yes() raises:
     """Tests that custom prompt works and --yes still skips it."""
     var cmd = Command("drop", "Drop the database")
     cmd.add_argument(
@@ -98,7 +98,7 @@ fn test_confirmation_custom_prompt_with_yes() raises:
     assert_true(result.get_flag("yes"), msg="--yes should be True")
 
 
-fn test_confirmation_custom_prompt_aborts_no_stdin() raises:
+def test_confirmation_custom_prompt_aborts_no_stdin() raises:
     """Tests that custom prompt aborts when stdin is unavailable."""
     var cmd = Command("drop", "Drop the database")
     cmd.add_argument(
@@ -123,7 +123,7 @@ fn test_confirmation_custom_prompt_aborts_no_stdin() raises:
 # ── Works with other arguments ────────────────────────────────────────────────
 
 
-fn test_confirmation_with_flag_and_option() raises:
+def test_confirmation_with_flag_and_option() raises:
     """Tests that confirmation works alongside other flags and options."""
     var cmd = Command("deploy", "Deploy the application")
     cmd.add_argument(
@@ -144,7 +144,7 @@ fn test_confirmation_with_flag_and_option() raises:
     assert_true(result.get_flag("yes"), msg="--yes should be True")
 
 
-fn test_confirmation_yes_is_false_by_default() raises:
+def test_confirmation_yes_is_false_by_default() raises:
     """Tests that --yes works alongside defaulted options."""
     var cmd = Command("deploy", "Deploy the application")
     cmd.add_argument(
@@ -163,7 +163,7 @@ fn test_confirmation_yes_is_false_by_default() raises:
 # ── No confirmation → normal behavior ────────────────────────────────────────
 
 
-fn test_no_confirmation_option_normal_parse() raises:
+def test_no_confirmation_option_normal_parse() raises:
     """Tests that without confirmation_option(), parsing works normally."""
     var cmd = Command("list", "List items")
     cmd.add_argument(
@@ -178,7 +178,7 @@ fn test_no_confirmation_option_normal_parse() raises:
 # ── Confirmation with subcommands ─────────────────────────────────────────────
 
 
-fn test_confirmation_on_parent_with_subcommand() raises:
+def test_confirmation_on_parent_with_subcommand() raises:
     """Tests that confirmation on parent command works with subcommands."""
     var app = Command("app", "My app")
     app.confirmation_option()
@@ -201,7 +201,7 @@ fn test_confirmation_on_parent_with_subcommand() raises:
 # ── Confirmation field copy ──────────────────────────────────────────────────
 
 
-fn test_confirmation_preserved_in_copy() raises:
+def test_confirmation_preserved_in_copy() raises:
     """Tests that confirmation settings are preserved when copying a Command."""
     var original = Command("drop", "Drop something")
     original.confirmation_option["Really drop?"]()
@@ -216,7 +216,7 @@ fn test_confirmation_preserved_in_copy() raises:
 # ── Confirmation with prompt arguments ────────────────────────────────────────
 
 
-fn test_confirmation_with_prompt_arg_uses_yes() raises:
+def test_confirmation_with_prompt_arg_uses_yes() raises:
     """Tests that confirmation works alongside .prompt() arguments when --yes is passed.
     """
     var cmd = Command("setup", "Setup the project")
@@ -235,7 +235,7 @@ fn test_confirmation_with_prompt_arg_uses_yes() raises:
 # ── Confirmation with parent args ─────────────────────────────────────────────
 
 
-fn test_confirmation_with_parent_args() raises:
+def test_confirmation_with_parent_args() raises:
     """Tests that confirmation works alongside inherited parent arguments."""
     var parent = Command("_shared")
     parent.add_argument(
@@ -255,5 +255,5 @@ fn test_confirmation_with_parent_args() raises:
     assert_true(result.get_flag("yes"), msg="--yes should be True")
 
 
-fn main() raises:
+def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_const_require_equals.mojo
+++ b/tests/test_const_require_equals.mojo
@@ -7,7 +7,7 @@ from argmojo import Argument, Command, ParseResult
 # ── default_if_no_value — long option ────────────────────────────────────────
 
 
-fn test_const_long_without_value() raises:
+def test_const_long_without_value() raises:
     """--compress (no value) uses the default-if-no-value."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -21,7 +21,7 @@ fn test_const_long_without_value() raises:
     assert_equal(result.get_string("compress"), "gzip")
 
 
-fn test_const_long_with_equals_value() raises:
+def test_const_long_with_equals_value() raises:
     """--compress=bzip2 uses the explicit value."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -35,7 +35,7 @@ fn test_const_long_with_equals_value() raises:
     assert_equal(result.get_string("compress"), "bzip2")
 
 
-fn test_const_long_space_separated_not_consumed() raises:
+def test_const_long_space_separated_not_consumed() raises:
     """--compress followed by a token does not consume it as a value;
     --compress uses default-if-no-value and the next token becomes a positional.
     """
@@ -55,7 +55,7 @@ fn test_const_long_space_separated_not_consumed() raises:
     assert_equal(result.get_string("file"), "myfile.txt")
 
 
-fn test_const_long_not_provided() raises:
+def test_const_long_not_provided() raises:
     """When --compress is not provided at all, no value is set (unless default).
     """
     var command = Command("test", "Test app")
@@ -70,7 +70,7 @@ fn test_const_long_not_provided() raises:
     assert_false(result.has("compress"), msg="compress should not be set")
 
 
-fn test_const_long_with_default() raises:
+def test_const_long_with_default() raises:
     """When default_if_no_value has a default, --compress uses default-if-no-value while omission uses default.
     """
     var command = Command("test", "Test app")
@@ -97,7 +97,7 @@ fn test_const_long_with_default() raises:
     assert_equal(result3.get_string("compress"), "bzip2")
 
 
-fn test_const_long_with_choices() raises:
+def test_const_long_with_choices() raises:
     """Tests default_if_no_value must pass choices validation."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -120,7 +120,7 @@ fn test_const_long_with_choices() raises:
     assert_equal(result2.get_string("compress"), "xz")
 
 
-fn test_const_long_choices_invalid_eq() raises:
+def test_const_long_choices_invalid_eq() raises:
     """Explicit value via = that violates choices is rejected."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -149,7 +149,7 @@ fn test_const_long_choices_invalid_eq() raises:
 # ── default_if_no_value — short option ────────────────────────────────────────────
 
 
-fn test_const_short_without_value() raises:
+def test_const_short_without_value() raises:
     """-c (alone) uses the default-if-no-value."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -164,7 +164,7 @@ fn test_const_short_without_value() raises:
     assert_equal(result.get_string("compress"), "gzip")
 
 
-fn test_const_short_with_attached_value() raises:
+def test_const_short_with_attached_value() raises:
     """-cbzip2 (attached value) uses the explicit value."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -179,7 +179,7 @@ fn test_const_short_with_attached_value() raises:
     assert_equal(result.get_string("compress"), "bzip2")
 
 
-fn test_const_short_does_not_consume_next() raises:
+def test_const_short_does_not_consume_next() raises:
     """-c followed by a positional does not consume it as a value."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -195,7 +195,7 @@ fn test_const_short_does_not_consume_next() raises:
     assert_equal(result.get_string("file"), "myfile.txt")
 
 
-fn test_const_short_merged_flags() raises:
+def test_const_short_merged_flags() raises:
     """-vc in merged flags, where 'c' has default_if_no_value, uses default-if-no-value for 'c'.
     """
     var command = Command("test", "Test app")
@@ -218,7 +218,7 @@ fn test_const_short_merged_flags() raises:
     assert_equal(result.get_string("compress"), "gzip")
 
 
-fn test_const_short_merged_with_attached() raises:
+def test_const_short_merged_with_attached() raises:
     """-vcbzip2 in merged flags: v=flag, c=takes value 'bzip2' (attached)."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -243,7 +243,7 @@ fn test_const_short_merged_with_attached() raises:
 # ── default_if_no_value — prefix matching ─────────────────────────────────────────
 
 
-fn test_const_prefix_match() raises:
+def test_const_prefix_match() raises:
     """--comp (prefix) resolves to --compress and uses default-if-no-value."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -257,7 +257,7 @@ fn test_const_prefix_match() raises:
     assert_equal(result.get_string("compress"), "gzip")
 
 
-fn test_const_prefix_match_with_equals() raises:
+def test_const_prefix_match_with_equals() raises:
     """--comp=bzip2 (prefix + equals) uses explicit value."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -274,7 +274,7 @@ fn test_const_prefix_match_with_equals() raises:
 # ── Require equals — standalone (without default_if_no_value) ─────────────────────
 
 
-fn test_require_equals_with_eq() raises:
+def test_require_equals_with_eq() raises:
     """--output=file.txt is accepted when require_equals is set."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -286,7 +286,7 @@ fn test_require_equals_with_eq() raises:
     assert_equal(result.get_string("output"), "file.txt")
 
 
-fn test_require_equals_space_rejected() raises:
+def test_require_equals_space_rejected() raises:
     """--output file.txt (space) is rejected when require_equals is set."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -307,7 +307,7 @@ fn test_require_equals_space_rejected() raises:
     assert_true(caught, msg="Should have raised for space-separated value")
 
 
-fn test_require_equals_no_value_rejected() raises:
+def test_require_equals_no_value_rejected() raises:
     """--output (alone, no default_if_no_value) is rejected when require_equals is set.
     """
     var command = Command("test", "Test app")
@@ -329,7 +329,7 @@ fn test_require_equals_no_value_rejected() raises:
     assert_true(caught, msg="Should have raised for missing value")
 
 
-fn test_require_equals_prefix_match() raises:
+def test_require_equals_prefix_match() raises:
     """--out=file.txt (prefix) works with require_equals."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -341,7 +341,7 @@ fn test_require_equals_prefix_match() raises:
     assert_equal(result.get_string("output"), "file.txt")
 
 
-fn test_require_equals_empty_value() raises:
+def test_require_equals_empty_value() raises:
     """--output= (empty value after =) is accepted."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -353,7 +353,7 @@ fn test_require_equals_empty_value() raises:
     assert_equal(result.get_string("output"), "")
 
 
-fn test_require_equals_with_choices() raises:
+def test_require_equals_with_choices() raises:
     """Require_equals works with choices validation."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -371,7 +371,7 @@ fn test_require_equals_with_choices() raises:
     assert_equal(result.get_string("format"), "json")
 
 
-fn test_require_equals_choices_invalid() raises:
+def test_require_equals_choices_invalid() raises:
     """Require_equals with invalid choice is rejected."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -395,7 +395,7 @@ fn test_require_equals_choices_invalid() raises:
 # ── Require equals — does not affect short options ───────────────────────────
 
 
-fn test_require_equals_short_still_works() raises:
+def test_require_equals_short_still_works() raises:
     """Short option -o still works normally with space even when require_equals is set.
     """
     var command = Command("test", "Test app")
@@ -416,7 +416,7 @@ fn test_require_equals_short_still_works() raises:
 # ── Require equals + default_if_no_value combined ────────────────────────────
 
 
-fn test_require_equals_and_const_long_bare() raises:
+def test_require_equals_and_const_long_bare() raises:
     """--log (bare) uses default-if-no-value when both require_equals and default_if_no_value are set.
     """
     var command = Command("test", "Test app")
@@ -431,7 +431,7 @@ fn test_require_equals_and_const_long_bare() raises:
     assert_equal(result.get_string("log"), "INFO")
 
 
-fn test_require_equals_and_const_long_explicit() raises:
+def test_require_equals_and_const_long_explicit() raises:
     """--log=DEBUG uses explicit value when default_if_no_value is set."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -448,7 +448,7 @@ fn test_require_equals_and_const_long_explicit() raises:
 # ── Help output ──────────────────────────────────────────────────────────────
 
 
-fn test_help_require_equals_format() raises:
+def test_help_require_equals_format() raises:
     """Help shows --output=<output> format for require_equals."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -462,7 +462,7 @@ fn test_help_require_equals_format() raises:
     )
 
 
-fn test_help_const_format() raises:
+def test_help_const_format() raises:
     """Help shows --compress[=<compress>] format for default_if_no_value."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -478,7 +478,7 @@ fn test_help_const_format() raises:
     )
 
 
-fn test_help_const_with_value_name() raises:
+def test_help_const_with_value_name() raises:
     """Help shows --compress[=ALGO] when default_if_no_value and value_name are both set.
     """
     var command = Command("test", "Test app")
@@ -496,7 +496,7 @@ fn test_help_const_with_value_name() raises:
     )
 
 
-fn test_help_require_equals_with_value_name() raises:
+def test_help_require_equals_with_value_name() raises:
     """Help shows --output=FILE when require_equals and value_name are set."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -516,7 +516,7 @@ fn test_help_require_equals_with_value_name() raises:
 # ── Interaction with other features ──────────────────────────────────────────
 
 
-fn test_const_with_append() raises:
+def test_const_with_append() raises:
     """Tests default_if_no_value works with append:
     --tag collects default-if-no-value, --tag=x collects x.
     """
@@ -536,7 +536,7 @@ fn test_const_with_append() raises:
     assert_equal(tags[1], "custom")
 
 
-fn test_const_with_persistent() raises:
+def test_const_with_persistent() raises:
     """Tests default_if_no_value works on persistent flags with subcommands."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -554,5 +554,5 @@ fn test_const_with_persistent() raises:
     assert_equal(result.subcommand, "build")
 
 
-fn main() raises:
+def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_const_require_equals.mojo
+++ b/tests/test_const_require_equals.mojo
@@ -1,6 +1,6 @@
 """Tests for argmojo — default_if_no_value and require_equals features."""
 
-from testing import assert_true, assert_false, assert_equal, TestSuite
+from std.testing import assert_true, assert_false, assert_equal, TestSuite
 import argmojo
 from argmojo import Argument, Command, ParseResult
 

--- a/tests/test_extras.mojo
+++ b/tests/test_extras.mojo
@@ -1,6 +1,6 @@
 """Tests for argmojo — range validation, key-value map, aliases, deprecated arguments."""
 
-from testing import assert_true, assert_false, assert_equal, TestSuite
+from std.testing import assert_true, assert_false, assert_equal, TestSuite
 import argmojo
 from argmojo import Argument, Command, ParseResult
 

--- a/tests/test_extras.mojo
+++ b/tests/test_extras.mojo
@@ -7,7 +7,7 @@ from argmojo import Argument, Command, ParseResult
 # ── Numeric range validation ─────────────────────────────────────────────────
 
 
-fn test_range_valid_value() raises:
+def test_range_valid_value() raises:
     """Tests that a value within range is accepted."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -19,7 +19,7 @@ fn test_range_valid_value() raises:
     assert_equal(result.get_string("port"), "8080")
 
 
-fn test_range_boundary_min() raises:
+def test_range_boundary_min() raises:
     """Tests that the exact minimum boundary value is accepted."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -31,7 +31,7 @@ fn test_range_boundary_min() raises:
     assert_equal(result.get_string("port"), "1")
 
 
-fn test_range_boundary_max() raises:
+def test_range_boundary_max() raises:
     """Tests that the exact maximum boundary value is accepted."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -43,7 +43,7 @@ fn test_range_boundary_max() raises:
     assert_equal(result.get_string("port"), "65535")
 
 
-fn test_range_below_min() raises:
+def test_range_below_min() raises:
     """Tests that a value below the minimum is rejected."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -64,7 +64,7 @@ fn test_range_below_min() raises:
     assert_true(caught, msg="Should have raised for value below min")
 
 
-fn test_range_above_max() raises:
+def test_range_above_max() raises:
     """Tests that a value above the maximum is rejected."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -84,7 +84,7 @@ fn test_range_above_max() raises:
     assert_true(caught, msg="Should have raised for value above max")
 
 
-fn test_range_not_provided_ok() raises:
+def test_range_not_provided_ok() raises:
     """Tests that an optional range arg is fine when not provided."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -96,7 +96,7 @@ fn test_range_not_provided_ok() raises:
     assert_false(result.has("port"), msg="port should not be set")
 
 
-fn test_range_with_append() raises:
+def test_range_with_append() raises:
     """Tests range validation on appended values."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -117,7 +117,7 @@ fn test_range_with_append() raises:
     assert_true(caught, msg="Should have raised for one value out of range")
 
 
-fn test_range_with_short_option() raises:
+def test_range_with_short_option() raises:
     """Tests range validation with a short option."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -135,7 +135,7 @@ fn test_range_with_short_option() raises:
 # ── Range clamping (.clamp()) ────────────────────────────────────────────────
 
 
-fn test_clamp_above_max() raises:
+def test_clamp_above_max() raises:
     """Tests that .clamp() adjusts a value above max to max."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -151,7 +151,7 @@ fn test_clamp_above_max() raises:
     )
 
 
-fn test_clamp_below_min() raises:
+def test_clamp_below_min() raises:
     """Tests that .clamp() adjusts a value below min to min."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -167,7 +167,7 @@ fn test_clamp_below_min() raises:
     )
 
 
-fn test_clamp_within_range_no_change() raises:
+def test_clamp_within_range_no_change() raises:
     """Tests that .clamp() does not affect a value within range."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -183,7 +183,7 @@ fn test_clamp_within_range_no_change() raises:
     )
 
 
-fn test_clamp_at_boundary() raises:
+def test_clamp_at_boundary() raises:
     """Tests that .clamp() does not trigger at exact boundaries."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -201,7 +201,7 @@ fn test_clamp_at_boundary() raises:
     )
 
 
-fn test_clamp_with_short_option() raises:
+def test_clamp_with_short_option() raises:
     """Tests that .clamp() works with short option syntax."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -221,7 +221,7 @@ fn test_clamp_with_short_option() raises:
     )
 
 
-fn test_clamp_with_append() raises:
+def test_clamp_with_append() raises:
     """Tests that .clamp() adjusts individual values in append mode."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -248,7 +248,7 @@ fn test_clamp_with_append() raises:
     assert_equal(lst[2], "1", msg="0 should clamp to 1")
 
 
-fn test_range_without_clamp_still_errors() raises:
+def test_range_without_clamp_still_errors() raises:
     """Tests that .range() without .clamp() still raises errors."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -269,7 +269,7 @@ fn test_range_without_clamp_still_errors() raises:
 # ── Key-value map option ─────────────────────────────────────────────────────
 
 
-fn test_map_single_pair() raises:
+def test_map_single_pair() raises:
     """Tests parsing a single key=value map entry."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -285,7 +285,7 @@ fn test_map_single_pair() raises:
     assert_equal(m["CC"], "gcc")
 
 
-fn test_map_multiple_pairs() raises:
+def test_map_multiple_pairs() raises:
     """Tests parsing multiple key=value pairs via repeated option."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -302,7 +302,7 @@ fn test_map_multiple_pairs() raises:
     assert_equal(m["CXX"], "g++")
 
 
-fn test_map_equals_syntax() raises:
+def test_map_equals_syntax() raises:
     """Tests parsing key=value with --define=key=value syntax."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -315,7 +315,7 @@ fn test_map_equals_syntax() raises:
     assert_equal(m["CC"], "gcc")
 
 
-fn test_map_with_delimiter() raises:
+def test_map_with_delimiter() raises:
     """Tests parsing multiple key=value pairs from one value using a delimiter.
     """
     var command = Command("test", "Test app")
@@ -333,7 +333,7 @@ fn test_map_with_delimiter() raises:
     assert_equal(m["CXX"], "g++")
 
 
-fn test_map_invalid_no_equals() raises:
+def test_map_invalid_no_equals() raises:
     """Tests that a map value without '=' is rejected."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -351,7 +351,7 @@ fn test_map_invalid_no_equals() raises:
     assert_true(caught, msg="Should have raised for missing '='")
 
 
-fn test_map_has_check() raises:
+def test_map_has_check() raises:
     """Tests that has() returns True for a map arg after providing it."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -363,7 +363,7 @@ fn test_map_has_check() raises:
     assert_true(result.has("define"), msg="has() should be True for map arg")
 
 
-fn test_map_empty_value() raises:
+def test_map_empty_value() raises:
     """Tests that key= (empty value) is accepted."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -376,7 +376,7 @@ fn test_map_empty_value() raises:
     assert_equal(m["KEY"], "")
 
 
-fn test_map_value_with_equals() raises:
+def test_map_value_with_equals() raises:
     """Tests that key=val=ue keeps everything after first '=' as the value."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -392,7 +392,7 @@ fn test_map_value_with_equals() raises:
 # ── Aliases ──────────────────────────────────────────────────────────────────
 
 
-fn test_alias_basic() raises:
+def test_alias_basic() raises:
     """Tests that an alias resolves to the primary argument."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -406,7 +406,7 @@ fn test_alias_basic() raises:
     assert_equal(result.get_string("colour"), "red")
 
 
-fn test_alias_primary_still_works() raises:
+def test_alias_primary_still_works() raises:
     """Tests that using the primary long name still works alongside aliases."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -420,7 +420,7 @@ fn test_alias_primary_still_works() raises:
     assert_equal(result.get_string("colour"), "blue")
 
 
-fn test_alias_multiple() raises:
+def test_alias_multiple() raises:
     """Tests that multiple aliases all resolve correctly."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -439,7 +439,7 @@ fn test_alias_multiple() raises:
     assert_equal(result2.get_string("output"), "yaml")
 
 
-fn test_alias_prefix_match() raises:
+def test_alias_prefix_match() raises:
     """Tests that prefix matching works with aliases."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -453,7 +453,7 @@ fn test_alias_prefix_match() raises:
     assert_equal(result.get_string("colour"), "green")
 
 
-fn test_alias_with_flag() raises:
+def test_alias_with_flag() raises:
     """Tests that aliases work with flags."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -473,7 +473,7 @@ fn test_alias_with_flag() raises:
 # ── Deprecated arguments ─────────────────────────────────────────────────────
 
 
-fn test_deprecated_still_parses() raises:
+def test_deprecated_still_parses() raises:
     """Tests that a deprecated argument is still parsed successfully."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -487,7 +487,7 @@ fn test_deprecated_still_parses() raises:
     assert_equal(result.get_string("format_old"), "csv")
 
 
-fn test_deprecated_short_option() raises:
+def test_deprecated_short_option() raises:
     """Tests that a deprecated short option still parses."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -503,7 +503,7 @@ fn test_deprecated_short_option() raises:
     assert_true(result.get_flag("compat"), msg="-C should still set the flag")
 
 
-fn test_deprecated_not_provided_ok() raises:
+def test_deprecated_not_provided_ok() raises:
     """Tests that not providing a deprecated arg produces no errors."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -519,7 +519,7 @@ fn test_deprecated_not_provided_ok() raises:
     assert_equal(result.get_string("new"), "val")
 
 
-fn test_deprecated_with_alias() raises:
+def test_deprecated_with_alias() raises:
     """Tests that deprecation works when accessed via an alias."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -537,7 +537,7 @@ fn test_deprecated_with_alias() raises:
 # ── Help display: deprecated tag and map placeholder ─────────────────────────
 
 
-fn test_help_deprecated_tag() raises:
+def test_help_deprecated_tag() raises:
     """Tests that deprecated arguments show [deprecated] in help text."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -554,7 +554,7 @@ fn test_help_deprecated_tag() raises:
     )
 
 
-fn test_help_map_placeholder() raises:
+def test_help_map_placeholder() raises:
     """Tests that map options show <key=value> placeholder in help."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -571,7 +571,7 @@ fn test_help_map_placeholder() raises:
     )
 
 
-fn test_help_alias_shown() raises:
+def test_help_alias_shown() raises:
     """Tests that aliases are shown alongside the primary name in help."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -588,5 +588,5 @@ fn test_help_alias_shown() raises:
     )
 
 
-fn main() raises:
+def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_fullwidth.mojo
+++ b/tests/test_fullwidth.mojo
@@ -18,7 +18,7 @@ from argmojo.utils import (
 # ── Unit tests for utility functions ─────────────────────────────────────────
 
 
-fn test_has_fullwidth_chars_ascii() raises:
+def test_has_fullwidth_chars_ascii() raises:
     """Tests that plain ASCII strings have no fullwidth characters."""
     assert_false(
         _has_fullwidth_chars("--verbose"),
@@ -34,7 +34,7 @@ fn test_has_fullwidth_chars_ascii() raises:
     )
 
 
-fn test_has_fullwidth_chars_cjk() raises:
+def test_has_fullwidth_chars_cjk() raises:
     """Tests that CJK ideographs are NOT detected as fullwidth ASCII."""
     # CJK ideographs are NOT in the fullwidth ASCII range FF01-FF5E.
     assert_false(
@@ -43,7 +43,7 @@ fn test_has_fullwidth_chars_cjk() raises:
     )
 
 
-fn test_has_fullwidth_chars_fullwidth_ascii() raises:
+def test_has_fullwidth_chars_fullwidth_ascii() raises:
     """Tests that fullwidth ASCII characters are detected."""
     # U+FF0D = fullwidth hyphen-minus ＝ －
     assert_true(
@@ -56,7 +56,7 @@ fn test_has_fullwidth_chars_fullwidth_ascii() raises:
     )
 
 
-fn test_has_fullwidth_chars_fullwidth_space() raises:
+def test_has_fullwidth_chars_fullwidth_space() raises:
     """Tests that fullwidth space U+3000 is detected."""
     var fw_space = chr(0x3000)
     assert_true(
@@ -65,7 +65,7 @@ fn test_has_fullwidth_chars_fullwidth_space() raises:
     )
 
 
-fn test_has_fullwidth_chars_fullwidth_equals() raises:
+def test_has_fullwidth_chars_fullwidth_equals() raises:
     """Tests that fullwidth equals sign U+FF1D is detected."""
     assert_true(
         _has_fullwidth_chars("--key＝value"),
@@ -73,7 +73,7 @@ fn test_has_fullwidth_chars_fullwidth_equals() raises:
     )
 
 
-fn test_fullwidth_to_halfwidth_no_change() raises:
+def test_fullwidth_to_halfwidth_no_change() raises:
     """Tests that strings without fullwidth chars are unchanged."""
     assert_equal(
         _fullwidth_to_halfwidth("--verbose"),
@@ -85,7 +85,7 @@ fn test_fullwidth_to_halfwidth_no_change() raises:
     )
 
 
-fn test_fullwidth_to_halfwidth_option() raises:
+def test_fullwidth_to_halfwidth_option() raises:
     """Tests fullwidth option name correction."""
     assert_equal(
         _fullwidth_to_halfwidth("－－ｖｅｒｂｏｓｅ"),
@@ -93,7 +93,7 @@ fn test_fullwidth_to_halfwidth_option() raises:
     )
 
 
-fn test_fullwidth_to_halfwidth_short_option() raises:
+def test_fullwidth_to_halfwidth_short_option() raises:
     """Tests fullwidth short option correction."""
     assert_equal(
         _fullwidth_to_halfwidth("－ｖ"),
@@ -101,7 +101,7 @@ fn test_fullwidth_to_halfwidth_short_option() raises:
     )
 
 
-fn test_fullwidth_to_halfwidth_equals() raises:
+def test_fullwidth_to_halfwidth_equals() raises:
     """Tests fullwidth equals sign in --key=value."""
     assert_equal(
         _fullwidth_to_halfwidth("－－ｋｅｙ＝ｖａｌｕｅ"),
@@ -109,7 +109,7 @@ fn test_fullwidth_to_halfwidth_equals() raises:
     )
 
 
-fn test_fullwidth_to_halfwidth_space() raises:
+def test_fullwidth_to_halfwidth_space() raises:
     """Tests fullwidth space U+3000 conversion."""
     var fw_space = chr(0x3000)
     assert_equal(
@@ -118,7 +118,7 @@ fn test_fullwidth_to_halfwidth_space() raises:
     )
 
 
-fn test_fullwidth_to_halfwidth_mixed() raises:
+def test_fullwidth_to_halfwidth_mixed() raises:
     """Tests mixed fullwidth ASCII with CJK characters."""
     # CJK characters should be preserved, only fullwidth ASCII converted.
     var result = _fullwidth_to_halfwidth("－－ｎａｍｅ＝宇浩")
@@ -132,14 +132,14 @@ fn test_fullwidth_to_halfwidth_mixed() raises:
     )
 
 
-fn test_split_on_fullwidth_spaces_no_spaces() raises:
+def test_split_on_fullwidth_spaces_no_spaces() raises:
     """Tests that tokens without fullwidth spaces return a single element."""
     var parts = _split_on_fullwidth_spaces("--verbose")
     assert_equal(len(parts), 1)
     assert_equal(parts[0], "--verbose")
 
 
-fn test_split_on_fullwidth_spaces_with_spaces() raises:
+def test_split_on_fullwidth_spaces_with_spaces() raises:
     """Tests splitting on fullwidth spaces."""
     var fw_space = chr(0x3000)
     var token = "－－ｎａｍｅ" + fw_space + "ｙｕｈａｏ" + fw_space + "－－ｖｅｒｂｏｓｅ"
@@ -153,13 +153,13 @@ fn test_split_on_fullwidth_spaces_with_spaces() raises:
 # ── Unit tests for CJK punctuation correction ──────────────────────────────────
 
 
-fn test_correct_cjk_punctuation_no_change() raises:
+def test_correct_cjk_punctuation_no_change() raises:
     """Tests that strings without CJK punctuation are unchanged."""
     assert_equal(_correct_cjk_punctuation("--verbose"), "--verbose")
     assert_equal(_correct_cjk_punctuation("hello"), "hello")
 
 
-fn test_correct_cjk_punctuation_em_dash() raises:
+def test_correct_cjk_punctuation_em_dash() raises:
     """Tests em-dash (U+2014) → hyphen-minus conversion."""
     # Two em-dashes + "verbose" should become "--verbose".
     var double_em_dash = String(chr(0x2014)) + chr(0x2014)
@@ -169,7 +169,7 @@ fn test_correct_cjk_punctuation_em_dash() raises:
     )
 
 
-fn test_correct_cjk_punctuation_preserves_cjk() raises:
+def test_correct_cjk_punctuation_preserves_cjk() raises:
     """Tests that CJK ideographs are preserved."""
     assert_equal(_correct_cjk_punctuation("宇浩"), "宇浩")
 
@@ -177,7 +177,7 @@ fn test_correct_cjk_punctuation_preserves_cjk() raises:
 # ── Integration tests: parsing with fullwidth correction ─────────────────────
 
 
-fn test_fullwidth_long_flag() raises:
+def test_fullwidth_long_flag() raises:
     """Tests that a fullwidth --verbose flag is auto-corrected and parsed."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -195,7 +195,7 @@ fn test_fullwidth_long_flag() raises:
     )
 
 
-fn test_fullwidth_short_flag() raises:
+def test_fullwidth_short_flag() raises:
     """Tests that a fullwidth -v flag is auto-corrected and parsed."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -213,7 +213,7 @@ fn test_fullwidth_short_flag() raises:
     )
 
 
-fn test_fullwidth_key_value_equals() raises:
+def test_fullwidth_key_value_equals() raises:
     """Tests fullwidth --key＝value auto-correction."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -232,7 +232,7 @@ fn test_fullwidth_key_value_equals() raises:
     )
 
 
-fn test_fullwidth_key_space_value() raises:
+def test_fullwidth_key_space_value() raises:
     """Tests fullwidth --key with space-separated value."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -251,7 +251,7 @@ fn test_fullwidth_key_space_value() raises:
     )
 
 
-fn test_fullwidth_embedded_space() raises:
+def test_fullwidth_embedded_space() raises:
     """Tests that fullwidth spaces in a single token cause splitting."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -279,7 +279,7 @@ fn test_fullwidth_embedded_space() raises:
     )
 
 
-fn test_positional_fullwidth_converted() raises:
+def test_positional_fullwidth_converted() raises:
     """Tests that fullwidth positional values are converted but stay positional.
     """
     var command = Command("test", "Test app")
@@ -299,7 +299,7 @@ fn test_positional_fullwidth_converted() raises:
     )
 
 
-fn test_disable_fullwidth_correction() raises:
+def test_disable_fullwidth_correction() raises:
     """Tests that disable_fullwidth_correction() prevents auto-correction."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -321,7 +321,7 @@ fn test_disable_fullwidth_correction() raises:
     )
 
 
-fn test_fullwidth_with_choices() raises:
+def test_fullwidth_with_choices() raises:
     """Tests fullwidth correction combined with choices validation."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -343,7 +343,7 @@ fn test_fullwidth_with_choices() raises:
     )
 
 
-fn test_fullwidth_merged_short_flags() raises:
+def test_fullwidth_merged_short_flags() raises:
     """Tests fullwidth merged short flags like -abc."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -366,7 +366,7 @@ fn test_fullwidth_merged_short_flags() raises:
     assert_true(result.get_flag("color"), msg="fullwidth -c should work")
 
 
-fn test_fullwidth_with_subcommand() raises:
+def test_fullwidth_with_subcommand() raises:
     """Tests fullwidth option correction with subcommand dispatch."""
     var app = Command("test", "Test app")
     app.add_argument(
@@ -394,7 +394,7 @@ fn test_fullwidth_with_subcommand() raises:
     assert_equal(sub_result.get_string("target"), "release")
 
 
-fn test_fullwidth_parse_known_arguments() raises:
+def test_fullwidth_parse_known_arguments() raises:
     """Tests fullwidth correction works with parse_known_arguments."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -412,7 +412,7 @@ fn test_fullwidth_parse_known_arguments() raises:
     )
 
 
-fn test_fullwidth_cjk_positional_preserved() raises:
+def test_fullwidth_cjk_positional_preserved() raises:
     """Tests that CJK characters in positional values are preserved."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -428,7 +428,7 @@ fn test_fullwidth_cjk_positional_preserved() raises:
     )
 
 
-fn test_fullwidth_punctuation_em_dash_correction() raises:
+def test_fullwidth_punctuation_em_dash_correction() raises:
     """Tests that em-dash is auto-corrected to hyphen-minus in pre-parse."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -446,7 +446,7 @@ fn test_fullwidth_punctuation_em_dash_correction() raises:
     )
 
 
-fn test_fullwidth_punctuation_disabled() raises:
+def test_fullwidth_punctuation_disabled() raises:
     """Tests that disable_punctuation_correction() prevents correction."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -465,5 +465,5 @@ fn test_fullwidth_punctuation_disabled() raises:
     )
 
 
-fn main() raises:
+def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_fullwidth.mojo
+++ b/tests/test_fullwidth.mojo
@@ -1,6 +1,6 @@
 """Tests for argmojo — full-width → half-width auto-correction (Phase 6.2)."""
 
-from testing import assert_true, assert_false, assert_equal, TestSuite
+from std.testing import assert_true, assert_false, assert_equal, TestSuite
 import argmojo
 from argmojo import Argument, Command, ParseResult
 from argmojo.utils import (
@@ -162,9 +162,9 @@ fn test_correct_cjk_punctuation_no_change() raises:
 fn test_correct_cjk_punctuation_em_dash() raises:
     """Tests em-dash (U+2014) → hyphen-minus conversion."""
     # Two em-dashes + "verbose" should become "--verbose".
-    var em_dash = chr(0x2014)
+    var double_em_dash = String(chr(0x2014)) + chr(0x2014)
     assert_equal(
-        _correct_cjk_punctuation(em_dash + em_dash + "verbose"),
+        _correct_cjk_punctuation(double_em_dash + "verbose"),
         "--verbose",
     )
 
@@ -437,8 +437,8 @@ fn test_fullwidth_punctuation_em_dash_correction() raises:
         .short["v"]()
         .flag()
     )
-    var em_dash = chr(0x2014)
-    var args: List[String] = ["test", em_dash + em_dash + "verbose"]
+    var double_em_dash = chr(0x2014) + chr(0x2014)
+    var args: List[String] = ["test", double_em_dash + "verbose"]
     var result = command.parse_arguments(args)
     assert_true(
         result.get_flag("verbose"),
@@ -456,8 +456,8 @@ fn test_fullwidth_punctuation_disabled() raises:
         .flag()
     )
     command.disable_punctuation_correction()
-    var em_dash = chr(0x2014)
-    var args: List[String] = ["test", em_dash + em_dash + "verbose"]
+    var double_em_dash = chr(0x2014) + chr(0x2014)
+    var args: List[String] = ["test", double_em_dash + "verbose"]
     var result = command.parse_arguments(args)
     assert_false(
         result.get_flag("verbose"),

--- a/tests/test_groups.mojo
+++ b/tests/test_groups.mojo
@@ -7,7 +7,7 @@ from argmojo import Argument, Command, ParseResult
 # ── Mutually exclusive groups ────────────────────────────────────────────────────
 
 
-fn test_exclusive_one_provided() raises:
+def test_exclusive_one_provided() raises:
     """Tests that providing one arg from an exclusive group is fine."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -28,7 +28,7 @@ fn test_exclusive_one_provided() raises:
     assert_false(result.get_flag("yaml"), msg="--yaml should be False")
 
 
-fn test_exclusive_none_provided() raises:
+def test_exclusive_none_provided() raises:
     """Tests that providing no arg from an exclusive group is fine."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -46,7 +46,7 @@ fn test_exclusive_none_provided() raises:
     assert_false(result.get_flag("yaml"), msg="--yaml should be False")
 
 
-fn test_exclusive_conflict() raises:
+def test_exclusive_conflict() raises:
     """Tests that providing two args from an exclusive group raises an error."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -83,7 +83,7 @@ fn test_exclusive_conflict() raises:
     assert_true(caught, msg="Should have raised error for exclusive conflict")
 
 
-fn test_exclusive_value_args() raises:
+def test_exclusive_value_args() raises:
     """Tests mutually exclusive with value-taking args."""
     var command = Command("test", "Test app")
     command.add_argument(Argument("input", help="Input file").long["input"]())
@@ -110,7 +110,7 @@ fn test_exclusive_value_args() raises:
 # ── Required-together groups ─────────────────────────────────────────────────────
 
 
-fn test_required_together_all_provided() raises:
+def test_required_together_all_provided() raises:
     """Tests that providing all args from a required-together group is fine."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -134,7 +134,7 @@ fn test_required_together_all_provided() raises:
     assert_equal(result.get_string("password"), "secret")
 
 
-fn test_required_together_none_provided() raises:
+def test_required_together_none_provided() raises:
     """Tests that providing none from a required-together group is fine."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -152,7 +152,7 @@ fn test_required_together_none_provided() raises:
     assert_false(result.has("password"), msg="password should not be set")
 
 
-fn test_required_together_partial() raises:
+def test_required_together_partial() raises:
     """Tests that providing only some from a required-together group raises an
     error."""
     var command = Command("test", "Test app")
@@ -183,7 +183,7 @@ fn test_required_together_partial() raises:
     assert_true(caught, msg="Should have raised error for partial group")
 
 
-fn test_required_together_three_args() raises:
+def test_required_together_three_args() raises:
     """Tests required-together with three arguments, only one provided."""
     var command = Command("test", "Test app")
     command.add_argument(Argument("host", help="Host").long["host"]())
@@ -215,7 +215,7 @@ fn test_required_together_three_args() raises:
 # ===------------------------------------------------------------------=== #
 
 
-fn test_one_required_one_provided() raises:
+def test_one_required_one_provided() raises:
     """Tests one-required group when exactly one is provided."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -237,7 +237,7 @@ fn test_one_required_one_provided() raises:
     assert_false(result.get_flag("toml"), msg="--toml should be False")
 
 
-fn test_one_required_multiple_provided() raises:
+def test_one_required_multiple_provided() raises:
     """Tests one-required group when multiple from the group are provided."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -255,7 +255,7 @@ fn test_one_required_multiple_provided() raises:
     assert_true(result.get_flag("yaml"), msg="--yaml should be True")
 
 
-fn test_one_required_none_provided() raises:
+def test_one_required_none_provided() raises:
     """Tests one-required group when none from the group are provided."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -288,7 +288,7 @@ fn test_one_required_none_provided() raises:
     assert_true(caught, msg="Should have raised error for one-required group")
 
 
-fn test_one_required_with_value_args() raises:
+def test_one_required_with_value_args() raises:
     """Tests one-required group with value-taking arguments."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -305,7 +305,7 @@ fn test_one_required_with_value_args() raises:
     assert_equal(result.get_string("input"), "data.txt")
 
 
-fn test_one_required_with_short_option() raises:
+def test_one_required_with_short_option() raises:
     """Tests one-required with a short option satisfying the group."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -322,7 +322,7 @@ fn test_one_required_with_short_option() raises:
     assert_true(result.get_flag("json"), msg="-j should satisfy one_required")
 
 
-fn test_one_required_error_shows_display_names() raises:
+def test_one_required_error_shows_display_names() raises:
     """Tests that the error message shows --long or -s names, not internal names.
     """
     var command = Command("test", "Test app")
@@ -348,7 +348,7 @@ fn test_one_required_error_shows_display_names() raises:
     assert_true(caught, msg="Should have raised error")
 
 
-fn test_one_required_combined_with_exclusive() raises:
+def test_one_required_combined_with_exclusive() raises:
     """Tests one-required combined with mutually exclusive (exactly one pattern).
     """
     var command = Command("test", "Test app")
@@ -388,7 +388,7 @@ fn test_one_required_combined_with_exclusive() raises:
     assert_true(caught_both, msg="Should error when both provided")
 
 
-fn test_one_required_multiple_groups() raises:
+def test_one_required_multiple_groups() raises:
     """Tests multiple one-required groups."""
     var command = Command("test", "Test app")
     command.add_argument(Argument("json", help="JSON").long["json"]().flag())
@@ -423,7 +423,7 @@ fn test_one_required_multiple_groups() raises:
     assert_true(caught, msg="Should error when second group unsatisfied")
 
 
-fn test_one_required_with_append_arg() raises:
+def test_one_required_with_append_arg() raises:
     """Tests one-required group with an append-type argument."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -448,7 +448,7 @@ fn test_one_required_with_append_arg() raises:
 # ===------------------------------------------------------------------=== #
 
 
-fn test_conditional_req_satisfied() raises:
+def test_conditional_req_satisfied() raises:
     """Tests that conditional requirement passes when both are provided."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -465,7 +465,7 @@ fn test_conditional_req_satisfied() raises:
     assert_equal(result.get_string("output"), "out.txt")
 
 
-fn test_conditional_req_condition_absent() raises:
+def test_conditional_req_condition_absent() raises:
     """Tests that conditional requirement is skipped when condition is absent.
     """
     var command = Command("test", "Test app")
@@ -484,7 +484,7 @@ fn test_conditional_req_condition_absent() raises:
     assert_false(result.has("output"), msg="output should not be present")
 
 
-fn test_conditional_req_violated() raises:
+def test_conditional_req_violated() raises:
     """Tests that providing condition without target raises an error."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -518,7 +518,7 @@ fn test_conditional_req_violated() raises:
     assert_true(caught, msg="Should raise error for missing conditional arg")
 
 
-fn test_conditional_req_target_alone_ok() raises:
+def test_conditional_req_target_alone_ok() raises:
     """Tests that providing target without condition is fine."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -536,7 +536,7 @@ fn test_conditional_req_target_alone_ok() raises:
     assert_false(result.has("save"), msg="save should not be present")
 
 
-fn test_conditional_req_multiple_rules() raises:
+def test_conditional_req_multiple_rules() raises:
     """Tests multiple conditional requirements on the same command."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -604,7 +604,7 @@ fn test_conditional_req_multiple_rules() raises:
     assert_true(caught, msg="Should raise error for second conditional rule")
 
 
-fn test_conditional_req_with_short_option() raises:
+def test_conditional_req_with_short_option() raises:
     """Tests conditional requirement works with short options."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -636,7 +636,7 @@ fn test_conditional_req_with_short_option() raises:
     assert_equal(result.get_string("output"), "out.txt")
 
 
-fn test_conditional_req_with_value_condition() raises:
+def test_conditional_req_with_value_condition() raises:
     """Tests conditional requirement where condition is a value arg."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -660,7 +660,7 @@ fn test_conditional_req_with_value_condition() raises:
     assert_true(caught, msg="Value condition should trigger requirement")
 
 
-fn test_conditional_req_error_uses_display_names() raises:
+def test_conditional_req_error_uses_display_names() raises:
     """Tests that error message uses --long names, not internal names."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -699,7 +699,7 @@ fn test_conditional_req_error_uses_display_names() raises:
 # ===------------------------------------------------------------------=== #
 
 
-fn test_mutually_exclusive_unknown_arg() raises:
+def test_mutually_exclusive_unknown_arg() raises:
     """Tests that mutually_exclusive() rejects unknown argument names."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -724,7 +724,7 @@ fn test_mutually_exclusive_unknown_arg() raises:
     assert_true(caught, msg="unknown arg should raise an error")
 
 
-fn test_required_together_unknown_arg() raises:
+def test_required_together_unknown_arg() raises:
     """Tests that required_together() rejects unknown argument names."""
     var command = Command("test", "Test app")
     command.add_argument(Argument("username", help="User").long["username"]())
@@ -747,7 +747,7 @@ fn test_required_together_unknown_arg() raises:
     assert_true(caught, msg="unknown arg should raise an error")
 
 
-fn test_one_required_unknown_arg() raises:
+def test_one_required_unknown_arg() raises:
     """Tests that one_required() rejects unknown argument names."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -771,7 +771,7 @@ fn test_one_required_unknown_arg() raises:
     assert_true(caught, msg="unknown arg should raise an error")
 
 
-fn test_required_if_unknown_target() raises:
+def test_required_if_unknown_target() raises:
     """Tests that required_if() rejects unknown target argument."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -795,7 +795,7 @@ fn test_required_if_unknown_target() raises:
     assert_true(caught, msg="unknown target should raise an error")
 
 
-fn test_required_if_unknown_condition() raises:
+def test_required_if_unknown_condition() raises:
     """Tests that required_if() rejects unknown condition argument."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -819,5 +819,5 @@ fn test_required_if_unknown_condition() raises:
     assert_true(caught, msg="unknown condition should raise an error")
 
 
-fn main() raises:
+def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_groups.mojo
+++ b/tests/test_groups.mojo
@@ -1,6 +1,6 @@
 """Tests for argmojo — argument group constraints (exclusive, required-together, one-required)."""
 
-from testing import assert_true, assert_false, assert_equal, TestSuite
+from std.testing import assert_true, assert_false, assert_equal, TestSuite
 import argmojo
 from argmojo import Argument, Command, ParseResult
 

--- a/tests/test_groups_help.mojo
+++ b/tests/test_groups_help.mojo
@@ -1,6 +1,6 @@
 """Tests for argmojo — argument groups in help output and value_name wrapping."""
 
-from testing import assert_true, assert_false, assert_equal, TestSuite
+from std.testing import assert_true, assert_false, assert_equal, TestSuite
 import argmojo
 from argmojo import Argument, Command, ParseResult
 

--- a/tests/test_groups_help.mojo
+++ b/tests/test_groups_help.mojo
@@ -10,7 +10,7 @@ from argmojo import Argument, Command, ParseResult
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
-fn test_group_basic() raises:
+def test_group_basic() raises:
     """Options with .group() appear under a group heading in help."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -43,7 +43,7 @@ fn test_group_basic() raises:
     )
 
 
-fn test_group_ungrouped_separate_from_grouped() raises:
+def test_group_ungrouped_separate_from_grouped() raises:
     """Ungrouped options appear under 'Options:' and grouped under their
     own heading — they don't mix."""
     var command = Command("test", "Test app")
@@ -75,7 +75,7 @@ fn test_group_ungrouped_separate_from_grouped() raises:
     )
 
 
-fn test_group_multiple_groups() raises:
+def test_group_multiple_groups() raises:
     """Multiple groups each get their own heading, in first-appearance order."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -124,7 +124,7 @@ fn test_group_multiple_groups() raises:
     )
 
 
-fn test_group_no_groups_unchanged() raises:
+def test_group_no_groups_unchanged() raises:
     """When no groups are used, help output is the same as before (only Options:).
     """
     var command = Command("test", "Test app")
@@ -148,7 +148,7 @@ fn test_group_no_groups_unchanged() raises:
     assert_true(output_pos > options_pos, msg="--output under Options:")
 
 
-fn test_group_builtin_options_ungrouped() raises:
+def test_group_builtin_options_ungrouped() raises:
     """Built-in --help and --version always appear under Options:, not in groups.
     """
     var command = Command("test", "Test app")
@@ -172,7 +172,7 @@ fn test_group_builtin_options_ungrouped() raises:
     )
 
 
-fn test_group_with_persistent() raises:
+def test_group_with_persistent() raises:
     """Persistent (global) args go under Global Options:, not under groups."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -204,7 +204,7 @@ fn test_group_with_persistent() raises:
     )
 
 
-fn test_group_independent_padding() raises:
+def test_group_independent_padding() raises:
     """Each group computes its own padding independently."""
     var command = Command("test", "Test app")
     # Group A: short names → small padding.
@@ -227,7 +227,7 @@ fn test_group_independent_padding() raises:
     assert_true("Beta" in help, msg="Beta help text missing")
 
 
-fn test_group_with_colored_output() raises:
+def test_group_with_colored_output() raises:
     """Group headings use the same header_color styling as Options:/Arguments:.
     """
     var command = Command("test", "Test app")
@@ -243,7 +243,7 @@ fn test_group_with_colored_output() raises:
     )
 
 
-fn test_group_hidden_arg_not_shown() raises:
+def test_group_hidden_arg_not_shown() raises:
     """Hidden args with a group are still excluded from help."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -264,7 +264,7 @@ fn test_group_hidden_arg_not_shown() raises:
     assert_true("Internal:" in help, msg="Internal: heading should show")
 
 
-fn test_group_all_hidden_no_heading() raises:
+def test_group_all_hidden_no_heading() raises:
     """If all args in a group are hidden, the group heading should not appear.
     """
     var command = Command("test", "Test app")
@@ -291,7 +291,7 @@ fn test_group_all_hidden_no_heading() raises:
     )
 
 
-fn test_group_does_not_affect_parsing() raises:
+def test_group_does_not_affect_parsing() raises:
     """Groups are purely cosmetic — they don't change parsing behavior."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -307,7 +307,7 @@ fn test_group_does_not_affect_parsing() raises:
     assert_equal(result.get_string("port"), "8080")
 
 
-fn test_group_with_subcommand_help() raises:
+def test_group_with_subcommand_help() raises:
     """Group headings work correctly on subcommands too."""
     var app = Command("app", "App")
     var sub = Command("serve", "Start server")
@@ -335,7 +335,7 @@ fn test_group_with_subcommand_help() raises:
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
-fn test_value_name_wrapped_by_default() raises:
+def test_value_name_wrapped_by_default() raises:
     """The value_name is wrapped in <> by default."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -352,7 +352,7 @@ fn test_value_name_wrapped_by_default() raises:
     )
 
 
-fn test_value_name_unwrapped() raises:
+def test_value_name_unwrapped() raises:
     """The value_name[False] displays without angle brackets."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -373,7 +373,7 @@ fn test_value_name_unwrapped() raises:
     )
 
 
-fn test_value_name_wrapped_explicit() raises:
+def test_value_name_wrapped_explicit() raises:
     """The value_name[True] explicitly wraps in angle brackets."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -386,7 +386,7 @@ fn test_value_name_wrapped_explicit() raises:
     )
 
 
-fn test_value_name_wrapped_with_append() raises:
+def test_value_name_wrapped_with_append() raises:
     """Wrapped value_name shows <ENV>... for append args."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -403,7 +403,7 @@ fn test_value_name_wrapped_with_append() raises:
     )
 
 
-fn test_value_name_unwrapped_with_append() raises:
+def test_value_name_unwrapped_with_append() raises:
     """Unwrapped value_name shows ENV... for append args."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -424,7 +424,7 @@ fn test_value_name_unwrapped_with_append() raises:
     )
 
 
-fn test_value_name_wrapped_with_nargs() raises:
+def test_value_name_wrapped_with_nargs() raises:
     """Wrapped value_name with nargs repeats <N> <N>."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -441,7 +441,7 @@ fn test_value_name_wrapped_with_nargs() raises:
     )
 
 
-fn test_value_name_unwrapped_with_nargs() raises:
+def test_value_name_unwrapped_with_nargs() raises:
     """Unwrapped value_name with nargs repeats N N."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -462,7 +462,7 @@ fn test_value_name_unwrapped_with_nargs() raises:
     )
 
 
-fn test_value_name_wrapped_require_equals() raises:
+def test_value_name_wrapped_require_equals() raises:
     """Wrapped value_name with require_equals shows --output=<FILE>."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -479,7 +479,7 @@ fn test_value_name_wrapped_require_equals() raises:
     )
 
 
-fn test_value_name_wrapped_default_if_no_value() raises:
+def test_value_name_wrapped_default_if_no_value() raises:
     """Wrapped value_name with default_if_no_value shows --compress[=<ALGO>]."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -497,7 +497,7 @@ fn test_value_name_wrapped_default_if_no_value() raises:
     )
 
 
-fn test_value_name_no_wrapping_does_not_affect_default_placeholder() raises:
+def test_value_name_no_wrapping_does_not_affect_default_placeholder() raises:
     """When no value_name is set, the default placeholder <name> is always used.
     """
     var command = Command("test", "Test app")
@@ -512,7 +512,7 @@ fn test_value_name_no_wrapping_does_not_affect_default_placeholder() raises:
     )
 
 
-fn test_value_name_colored_output_wrapped() raises:
+def test_value_name_colored_output_wrapped() raises:
     """Wrapped value_name works correctly in coloured output."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -533,7 +533,7 @@ fn test_value_name_colored_output_wrapped() raises:
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
-fn test_group_with_value_name_wrapped() raises:
+def test_group_with_value_name_wrapped() raises:
     """Grouped option with wrapped value_name shows correctly."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -551,7 +551,7 @@ fn test_group_with_value_name_wrapped() raises:
     )
 
 
-fn test_group_with_value_name_unwrapped() raises:
+def test_group_with_value_name_unwrapped() raises:
     """Grouped option with unwrapped value_name shows bare text."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -578,5 +578,5 @@ fn test_group_with_value_name_unwrapped() raises:
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
-fn main() raises:
+def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_help.mojo
+++ b/tests/test_help.mojo
@@ -8,7 +8,7 @@ from argmojo.utils import _display_width
 # ── Hidden arguments ──────────────────────────────────────────────────────────────
 
 
-fn test_hidden_not_in_help() raises:
+def test_hidden_not_in_help() raises:
     """Tests that hidden arguments are excluded from help output."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -30,7 +30,7 @@ fn test_hidden_not_in_help() raises:
     assert_false("debug" in help, msg="hidden arg should NOT be in help")
 
 
-fn test_hidden_still_works() raises:
+def test_hidden_still_works() raises:
     """Tests that hidden arguments can still be used at the command line."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -49,7 +49,7 @@ fn test_hidden_still_works() raises:
 # ── Metavar ──────────────────────────────────────────────────────────────────────
 
 
-fn test_value_name_in_help() raises:
+def test_value_name_in_help() raises:
     """Tests that value_name appears in help output."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -68,7 +68,7 @@ fn test_value_name_in_help() raises:
     )
 
 
-fn test_choices_in_help() raises:
+def test_choices_in_help() raises:
     """Tests that choices are displayed in help when no value_name."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -90,7 +90,7 @@ fn test_choices_in_help() raises:
 # ── Count action ──────────────────────────────────────────────────────────────────
 
 
-fn test_negatable_in_help() raises:
+def test_negatable_in_help() raises:
     """Test that negatable flags show --X / --no-X in help."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -109,7 +109,7 @@ fn test_negatable_in_help() raises:
     )
 
 
-fn test_append_in_help() raises:
+def test_append_in_help() raises:
     """Tests that append args show ... suffix in help output."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -138,7 +138,7 @@ fn test_append_in_help() raises:
 # ===------------------------------------------------------------------=== #
 
 
-fn test_help_question_mark_in_help_output() raises:
+def test_help_question_mark_in_help_output() raises:
     """Tests that -h, --help appears in the generated help text."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -152,7 +152,7 @@ fn test_help_question_mark_in_help_output() raises:
     )
 
 
-fn test_dynamic_padding_short_options() raises:
+def test_dynamic_padding_short_options() raises:
     """Tests that help padding adapts to short option names."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -173,7 +173,7 @@ fn test_dynamic_padding_short_options() raises:
             break
 
 
-fn test_dynamic_padding_long_options() raises:
+def test_dynamic_padding_long_options() raises:
     """Tests that padding grows when a very long option is present."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -211,7 +211,7 @@ fn test_dynamic_padding_long_options() raises:
     )
 
 
-fn test_help_and_version_aligned() raises:
+def test_help_and_version_aligned() raises:
     """Tests that built-in -h and -V lines align with user options."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -247,7 +247,7 @@ fn test_help_and_version_aligned() raises:
     )
 
 
-fn test_help_on_no_arguments_disabled_by_default() raises:
+def test_help_on_no_arguments_disabled_by_default() raises:
     """Tests that parse_arguments works with no args when help_on_no_arguments is off.
     """
     var command = Command("test", "Test app")
@@ -264,7 +264,7 @@ fn test_help_on_no_arguments_disabled_by_default() raises:
     assert_false(result.get_flag("verbose"), msg="verbose should be False")
 
 
-fn test_positional_args_aligned_in_help() raises:
+def test_positional_args_aligned_in_help() raises:
     """Tests that positional arguments are dynamically aligned in help."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -294,7 +294,7 @@ fn test_positional_args_aligned_in_help() raises:
     )
 
 
-fn test_help_contains_ansi_colors() raises:
+def test_help_contains_ansi_colors() raises:
     """Tests that colored help output contains ANSI escape codes."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -326,7 +326,7 @@ fn test_help_contains_ansi_colors() raises:
     assert_true("Options:" in plain, msg="plain help should have 'Options:'")
 
 
-fn test_help_color_false_no_codes() raises:
+def test_help_color_false_no_codes() raises:
     """Tests that color=False produces identical output to pre-color era."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -341,7 +341,7 @@ fn test_help_color_false_no_codes() raises:
     assert_false("\x1b" in help, msg="No escape chars in plain mode")
 
 
-fn test_custom_header_color() raises:
+def test_custom_header_color() raises:
     """Setting header_color changes the header ANSI code in help output."""
     var command = Command("app", "My app")
     command.add_argument(Argument("file", help="Input file").long["file"]())
@@ -360,7 +360,7 @@ fn test_custom_header_color() raises:
     )
 
 
-fn test_custom_arg_color() raises:
+def test_custom_arg_color() raises:
     """Setting arg_color changes the arg-name ANSI code in help output."""
     var command = Command("app", "My app")
     command.add_argument(
@@ -381,7 +381,7 @@ fn test_custom_arg_color() raises:
     )
 
 
-fn test_custom_both_colors() raises:
+def test_custom_both_colors() raises:
     """Setting both header_color and arg_color at the same time."""
     var command = Command("app", "My app")
     command.add_argument(Argument("file", help="Input").long["file"]())
@@ -397,7 +397,7 @@ fn test_custom_both_colors() raises:
     )
 
 
-fn test_default_colors_unchanged() raises:
+def test_default_colors_unchanged() raises:
     """Without any setter, help uses default yellow headers + magenta args."""
     var command = Command("app", "My app")
     command.add_argument(Argument("name", help="Your name").long["name"]())
@@ -408,7 +408,7 @@ fn test_default_colors_unchanged() raises:
     assert_true("\x1b[95m" in help, msg="Default arg should be magenta (95)")
 
 
-fn test_color_uppercase_only() raises:
+def test_color_uppercase_only() raises:
     """Colour names must be uppercase: 'GREEN' works."""
     var command = Command("a", "A")
     command.add_argument(Argument("x", help="x").long["x"]())
@@ -417,7 +417,7 @@ fn test_color_uppercase_only() raises:
     assert_true("\x1b[92m" in h, msg="'GREEN' uppercase should resolve")
 
 
-fn test_pink_alias_for_magenta() raises:
+def test_pink_alias_for_magenta() raises:
     """'PINK' is an alias for MAGENTA (\\x1b[95m)."""
     var command = Command("app", "My app")
     command.add_argument(Argument("f", help="File").long["file"]())
@@ -430,7 +430,7 @@ fn test_pink_alias_for_magenta() raises:
     )
 
 
-fn test_invalid_color_caught_at_compile_time() raises:
+def test_invalid_color_caught_at_compile_time() raises:
     """Invalid colour names are caught at compile time via constrained[].
 
     This test simply verifies the valid path works.  An invalid name
@@ -465,7 +465,7 @@ fn test_invalid_color_caught_at_compile_time() raises:
     )
 
 
-fn test_custom_color_plain_mode_unaffected() raises:
+def test_custom_color_plain_mode_unaffected() raises:
     """Custom colours should not leak into plain (color=False) output."""
     var command = Command("app", "My app")
     command.add_argument(Argument("x", help="X option").long["x"]())
@@ -482,7 +482,7 @@ fn test_custom_color_plain_mode_unaffected() raises:
 # ===------------------------------------------------------------------=== #
 
 
-fn test_nargs_in_help() raises:
+def test_nargs_in_help() raises:
     """Tests that nargs options show repeated placeholders in help."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -515,7 +515,7 @@ fn test_nargs_in_help() raises:
     )
 
 
-fn test_nargs_with_value_name() raises:
+def test_nargs_with_value_name() raises:
     """Tests nargs with a custom value_name in help."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -535,7 +535,7 @@ fn test_nargs_with_value_name() raises:
 # ── Subcommand help UX ───────────────────────────────────────────────────────────
 
 
-fn test_root_help_shows_commands_section() raises:
+def test_root_help_shows_commands_section() raises:
     """Tests that root help includes a Commands: section when subcommands are registered.
     """
     var app = Command("app", "My CLI tool")
@@ -564,7 +564,7 @@ fn test_root_help_shows_commands_section() raises:
     )
 
 
-fn test_root_help_no_commands_when_no_subcommands() raises:
+def test_root_help_no_commands_when_no_subcommands() raises:
     """Tests that Commands: section is omitted when no subcommands are registered.
     """
     var command = Command("test", "Test app")
@@ -576,7 +576,7 @@ fn test_root_help_no_commands_when_no_subcommands() raises:
     assert_false("Commands:" in help, msg="No Commands: without subcommands")
 
 
-fn test_root_help_commands_excludes_help_sub() raises:
+def test_root_help_commands_excludes_help_sub() raises:
     """Tests that the auto-inserted 'help' subcommand is not listed in Commands.
     """
     var app = Command("app", "My app")
@@ -615,7 +615,7 @@ fn test_root_help_commands_excludes_help_sub() raises:
     )
 
 
-fn test_root_help_usage_shows_command_placeholder() raises:
+def test_root_help_usage_shows_command_placeholder() raises:
     """Tests that usage line includes <COMMAND> when subcommands are registered.
     """
     var app = Command("app", "My app")
@@ -628,7 +628,7 @@ fn test_root_help_usage_shows_command_placeholder() raises:
     )
 
 
-fn test_root_help_usage_no_command_placeholder_without_subs() raises:
+def test_root_help_usage_no_command_placeholder_without_subs() raises:
     """Tests that usage line does NOT include <COMMAND> when no subcommands."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -642,7 +642,7 @@ fn test_root_help_usage_no_command_placeholder_without_subs() raises:
     )
 
 
-fn test_persistent_args_under_global_options() raises:
+def test_persistent_args_under_global_options() raises:
     """Tests that persistent args appear under a 'Global Options:' heading."""
     var app = Command("app", "My app")
     app.add_argument(
@@ -673,7 +673,7 @@ fn test_persistent_args_under_global_options() raises:
     )
 
 
-fn test_no_global_options_without_persistent() raises:
+def test_no_global_options_without_persistent() raises:
     """Tests that Global Options: section is absent when no persistent args."""
     var app = Command("app", "My app")
     app.add_argument(
@@ -688,7 +688,7 @@ fn test_no_global_options_without_persistent() raises:
     )
 
 
-fn test_child_help_shows_full_command_path() raises:
+def test_child_help_shows_full_command_path() raises:
     """Tests that child help shows full command path (e.g. 'app search')."""
     var app = Command("app", "My app")
     var search = Command("search", "Search for patterns")
@@ -713,7 +713,7 @@ fn test_child_help_shows_full_command_path() raises:
     )
 
 
-fn test_child_help_shows_inherited_persistent_args() raises:
+def test_child_help_shows_inherited_persistent_args() raises:
     """Tests that child help includes inherited persistent args under Global Options.
     """
     var app = Command("app", "My app")
@@ -755,7 +755,7 @@ fn test_child_help_shows_inherited_persistent_args() raises:
     )
 
 
-fn test_add_tip_appears_in_help() raises:
+def test_add_tip_appears_in_help() raises:
     """Tests that custom tips appear in help output."""
     var command = Command("test", "Test app")
     command.add_tip("Set DEBUG=1 for debug logging.")
@@ -775,7 +775,7 @@ fn test_add_tip_appears_in_help() raises:
 # ── Alias in help output ──────────────────────────────────────────────────────
 
 
-fn test_alias_shown_inline_in_help() raises:
+def test_alias_shown_inline_in_help() raises:
     """Tests that subcommand aliases appear inline in help output."""
     var app = Command("app", "Test app")
     var clone = Command("clone", "Clone a repo")
@@ -790,7 +790,7 @@ fn test_alias_shown_inline_in_help() raises:
     )
 
 
-fn test_multiple_aliases_shown_in_help() raises:
+def test_multiple_aliases_shown_in_help() raises:
     """Tests that multiple aliases are all shown inline in help."""
     var app = Command("app", "Test app")
     var commit = Command("commit", "Record changes")
@@ -808,7 +808,7 @@ fn test_multiple_aliases_shown_in_help() raises:
 # ── Hidden subcommands ────────────────────────────────────────────────────────
 
 
-fn test_hidden_subcommand_not_in_help() raises:
+def test_hidden_subcommand_not_in_help() raises:
     """Tests that hidden subcommands are excluded from help output."""
     var app = Command("app", "Test app")
     var clone = Command("clone", "Clone a repository")
@@ -822,7 +822,7 @@ fn test_hidden_subcommand_not_in_help() raises:
     assert_false("debug" in help, msg="hidden sub should NOT be in help")
 
 
-fn test_hidden_subcommand_not_in_usage_line() raises:
+def test_hidden_subcommand_not_in_usage_line() raises:
     """Tests that usage line omits [command] if all subs are hidden."""
     var app = Command("app", "Test app")
     var debug = Command("debug", "Internal debug command")
@@ -836,7 +836,7 @@ fn test_hidden_subcommand_not_in_usage_line() raises:
     )
 
 
-fn test_hidden_subcommand_usage_line_with_visible() raises:
+def test_hidden_subcommand_usage_line_with_visible() raises:
     """Tests that usage line shows [command] when visible subs remain."""
     var app = Command("app", "Test app")
     var clone = Command("clone", "Clone a repository")
@@ -855,7 +855,7 @@ fn test_hidden_subcommand_usage_line_with_visible() raises:
 # ── NO_COLOR ──────────────────────────────────────────────────────────────────
 
 
-fn test_no_color_env_static_method() raises:
+def test_no_color_env_static_method() raises:
     """Tests _no_color_env() returns the correct value based on environment."""
     # We can't set env vars from Mojo easily, so just verify the method
     # exists and returns a Bool without crashing.
@@ -871,7 +871,7 @@ fn test_no_color_env_static_method() raises:
 # ── CJK-aware help alignment ────────────────────────────────────────────────
 
 
-fn test_cjk_options_aligned() raises:
+def test_cjk_options_aligned() raises:
     """Tests that CJK help text doesn't break column alignment."""
     var command = Command("test", "測試應用")
     command.add_argument(
@@ -902,7 +902,7 @@ fn test_cjk_options_aligned() raises:
     )
 
 
-fn test_cjk_subcommands_aligned() raises:
+def test_cjk_subcommands_aligned() raises:
     """Tests that CJK subcommand descriptions align correctly."""
     var app = Command("工具", "一個命令行工具")
     var init = Command("初始化", "建立新項目")
@@ -930,7 +930,7 @@ fn test_cjk_subcommands_aligned() raises:
     )
 
 
-fn test_cjk_positionals_aligned() raises:
+def test_cjk_positionals_aligned() raises:
     """Tests that CJK positional argument help aligns correctly."""
     var command = Command("test", "測試")
     command.add_argument(Argument("檔案", help="輸入檔案路徑"))
@@ -956,7 +956,7 @@ fn test_cjk_positionals_aligned() raises:
     )
 
 
-fn test_mixed_ascii_cjk_aligned() raises:
+def test_mixed_ascii_cjk_aligned() raises:
     """Tests alignment when mixing ASCII and CJK option names."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -984,5 +984,5 @@ fn test_mixed_ascii_cjk_aligned() raises:
     )
 
 
-fn main() raises:
+def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_help.mojo
+++ b/tests/test_help.mojo
@@ -1,6 +1,6 @@
 """Tests for argmojo — help output formatting and colours."""
 
-from testing import assert_true, assert_false, assert_equal, TestSuite
+from std.testing import assert_true, assert_false, assert_equal, TestSuite
 import argmojo
 from argmojo import Argument, Command, ParseResult
 from argmojo.utils import _display_width
@@ -597,14 +597,16 @@ fn test_root_help_commands_excludes_help_sub() raises:
             continue
         if in_commands:
             # End of section if we hit a blank line or another heading.
-            if not lines[i] or (len(lines[i]) > 0 and lines[i][0:1] != " "):
+            if not lines[i] or (
+                len(lines[i]) > 0 and not lines[i].startswith(" ")
+            ):
                 in_commands = False
                 continue
             # Check for '  help' as a subcommand entry.
             var stripped = String("")
             for c in range(len(lines[i])):
-                if lines[i][c : c + 1] != " ":
-                    stripped = String(lines[i][c:])
+                if lines[i].as_bytes()[c] != 32:
+                    stripped = String(lines[i][byte=c:])
                     break
             if stripped.startswith("help"):
                 found_help_cmd = True
@@ -887,10 +889,10 @@ fn test_cjk_options_aligned() raises:
     for idx in range(len(lines)):
         if "--verbose" in lines[idx]:
             var bp = lines[idx].find("顯示詳細資訊")
-            col_verbose = _display_width(String(lines[idx][0:bp]))
+            col_verbose = _display_width(String(lines[idx][byte=0:bp]))
         if "--output" in lines[idx]:
             var bp = lines[idx].find("輸出路徑")
-            col_output = _display_width(String(lines[idx][0:bp]))
+            col_output = _display_width(String(lines[idx][byte=0:bp]))
     assert_true(col_verbose > 0, msg="verbose help should appear")
     assert_true(col_output > 0, msg="output help should appear")
     assert_equal(
@@ -915,10 +917,10 @@ fn test_cjk_subcommands_aligned() raises:
     for idx in range(len(lines)):
         if "初始化" in lines[idx] and "建立新項目" in lines[idx]:
             var bp = lines[idx].find("建立新項目")
-            col_init = _display_width(String(lines[idx][0:bp]))
+            col_init = _display_width(String(lines[idx][byte=0:bp]))
         if "構建" in lines[idx] and "編譯項目" in lines[idx]:
             var bp = lines[idx].find("編譯項目")
-            col_build = _display_width(String(lines[idx][0:bp]))
+            col_build = _display_width(String(lines[idx][byte=0:bp]))
     assert_true(col_init > 0, msg="init description should appear")
     assert_true(col_build > 0, msg="build description should appear")
     assert_equal(
@@ -941,10 +943,10 @@ fn test_cjk_positionals_aligned() raises:
     for idx in range(len(lines)):
         if "檔案" in lines[idx] and "輸入檔案路徑" in lines[idx]:
             var bp = lines[idx].find("輸入檔案路徑")
-            col_file = _display_width(String(lines[idx][0:bp]))
+            col_file = _display_width(String(lines[idx][byte=0:bp]))
         if "目標" in lines[idx] and "輸出目標位置" in lines[idx]:
             var bp = lines[idx].find("輸出目標位置")
-            col_target = _display_width(String(lines[idx][0:bp]))
+            col_target = _display_width(String(lines[idx][byte=0:bp]))
     assert_true(col_file > 0, msg="file help should appear")
     assert_true(col_target > 0, msg="target help should appear")
     assert_equal(
@@ -969,10 +971,10 @@ fn test_mixed_ascii_cjk_aligned() raises:
     for idx in range(len(lines)):
         if "--output" in lines[idx]:
             var bp = lines[idx].find("Output path")
-            col_output = _display_width(String(lines[idx][0:bp]))
+            col_output = _display_width(String(lines[idx][byte=0:bp]))
         if "--編碼" in lines[idx]:
             var bp = lines[idx].find("設定編碼")
-            col_enc = _display_width(String(lines[idx][0:bp]))
+            col_enc = _display_width(String(lines[idx][byte=0:bp]))
     assert_true(col_output > 0, msg="output help should appear")
     assert_true(col_enc > 0, msg="encoding help should appear")
     assert_equal(

--- a/tests/test_implies.mojo
+++ b/tests/test_implies.mojo
@@ -1,6 +1,6 @@
 """Tests for argmojo — mutual implication (implies) feature."""
 
-from testing import assert_true, assert_false, assert_equal, TestSuite
+from std.testing import assert_true, assert_false, assert_equal, TestSuite
 import argmojo
 from argmojo import Argument, Command, ParseResult
 

--- a/tests/test_implies.mojo
+++ b/tests/test_implies.mojo
@@ -7,7 +7,7 @@ from argmojo import Argument, Command, ParseResult
 # ── Basic implication ─────────────────────────────────────────────────────────
 
 
-fn test_implies_basic_flag() raises:
+def test_implies_basic_flag() raises:
     """Tests that --debug implies --verbose (both flags)."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -26,7 +26,7 @@ fn test_implies_basic_flag() raises:
     )
 
 
-fn test_implies_no_trigger() raises:
+def test_implies_no_trigger() raises:
     """Tests that without --debug, --verbose is not auto-set."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -43,7 +43,7 @@ fn test_implies_no_trigger() raises:
     assert_false(result.has("verbose"), msg="verbose should not be set")
 
 
-fn test_implies_both_set_explicitly() raises:
+def test_implies_both_set_explicitly() raises:
     """Tests that both --debug --verbose works without conflict."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -60,7 +60,7 @@ fn test_implies_both_set_explicitly() raises:
     assert_true(result.get_flag("verbose"), msg="verbose should be True")
 
 
-fn test_implies_unidirectional() raises:
+def test_implies_unidirectional() raises:
     """Tests that implication is unidirectional: --verbose alone doesn't set --debug.
     """
     var command = Command("test", "Test app")
@@ -81,7 +81,7 @@ fn test_implies_unidirectional() raises:
 # ── Chained implication ──────────────────────────────────────────────────────
 
 
-fn test_implies_chain() raises:
+def test_implies_chain() raises:
     """Tests chained implication: --debug → --verbose → --log."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -107,7 +107,7 @@ fn test_implies_chain() raises:
     )
 
 
-fn test_implies_chain_middle() raises:
+def test_implies_chain_middle() raises:
     """Tests chain from middle: --verbose sets --log but not --debug."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -132,7 +132,7 @@ fn test_implies_chain_middle() raises:
 # ── Multiple implications from same trigger ──────────────────────────────────
 
 
-fn test_implies_multiple_from_same_trigger() raises:
+def test_implies_multiple_from_same_trigger() raises:
     """Tests that one trigger can imply multiple targets."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -157,7 +157,7 @@ fn test_implies_multiple_from_same_trigger() raises:
 # ── Count arguments ──────────────────────────────────────────────────────────
 
 
-fn test_implies_count_argument() raises:
+def test_implies_count_argument() raises:
     """Tests that implication works with count-type arguments."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -181,7 +181,7 @@ fn test_implies_count_argument() raises:
     )
 
 
-fn test_implies_count_already_set() raises:
+def test_implies_count_already_set() raises:
     """Tests that explicit count is preserved when trigger is also set."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -208,7 +208,7 @@ fn test_implies_count_already_set() raises:
 # ── Cycle detection ──────────────────────────────────────────────────────────
 
 
-fn test_implies_self_cycle() raises:
+def test_implies_self_cycle() raises:
     """Tests that A implies A is rejected."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -228,7 +228,7 @@ fn test_implies_self_cycle() raises:
     assert_true(caught, msg="self-cycle should raise an error")
 
 
-fn test_implies_direct_cycle() raises:
+def test_implies_direct_cycle() raises:
     """Tests that A→B, B→A cycle is detected at registration."""
     var command = Command("test", "Test app")
     command.add_argument(Argument("a", help="Flag A").long["a"]().flag())
@@ -248,7 +248,7 @@ fn test_implies_direct_cycle() raises:
     assert_true(caught, msg="direct cycle should raise an error")
 
 
-fn test_implies_indirect_cycle() raises:
+def test_implies_indirect_cycle() raises:
     """Tests that A→B→C, C→A cycle is detected at registration."""
     var command = Command("test", "Test app")
     command.add_argument(Argument("a", help="Flag A").long["a"]().flag())
@@ -270,7 +270,7 @@ fn test_implies_indirect_cycle() raises:
     assert_true(caught, msg="indirect cycle should raise an error")
 
 
-fn test_implies_no_false_cycle() raises:
+def test_implies_no_false_cycle() raises:
     """Tests that non-cyclic diamond shape is allowed: A→B, A→C, B→D, C→D."""
     var command = Command("test", "Test app")
     command.add_argument(Argument("a", help="A").long["a"]().flag())
@@ -293,7 +293,7 @@ fn test_implies_no_false_cycle() raises:
 # ── Integration with other constraints ───────────────────────────────────────
 
 
-fn test_implies_with_required_if() raises:
+def test_implies_with_required_if() raises:
     """Tests implies combined with required_if: debug implies verbose,
     verbose requires output."""
     var command = Command("test", "Test app")
@@ -325,7 +325,7 @@ fn test_implies_with_required_if() raises:
     )
 
 
-fn test_implies_with_required_if_satisfied() raises:
+def test_implies_with_required_if_satisfied() raises:
     """Tests implies + required_if when the requirement is satisfied."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -347,7 +347,7 @@ fn test_implies_with_required_if_satisfied() raises:
     assert_equal(result.get_string("output"), "/tmp/log")
 
 
-fn test_implies_with_mutually_exclusive() raises:
+def test_implies_with_mutually_exclusive() raises:
     """Tests that implies does not override mutual exclusion checks.
     If debug implies verbose, and verbose is exclusive with quiet,
     then --debug --quiet should fail."""
@@ -377,7 +377,7 @@ fn test_implies_with_mutually_exclusive() raises:
 # ── Registration validation ──────────────────────────────────────────────────
 
 
-fn test_implies_unknown_trigger() raises:
+def test_implies_unknown_trigger() raises:
     """Tests that implies() rejects unknown trigger argument."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -397,7 +397,7 @@ fn test_implies_unknown_trigger() raises:
     assert_true(caught, msg="unknown trigger should raise an error")
 
 
-fn test_implies_unknown_implied() raises:
+def test_implies_unknown_implied() raises:
     """Tests that implies() rejects unknown implied argument."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -417,7 +417,7 @@ fn test_implies_unknown_implied() raises:
     assert_true(caught, msg="unknown implied should raise an error")
 
 
-fn test_implies_rejects_value_taking_implied() raises:
+def test_implies_rejects_value_taking_implied() raises:
     """Tests that implies() rejects value-taking argument as implied target."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -440,5 +440,5 @@ fn test_implies_rejects_value_taking_implied() raises:
     assert_true(caught, msg="value-taking implied should raise an error")
 
 
-fn main() raises:
+def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_negative_numbers.mojo
+++ b/tests/test_negative_numbers.mojo
@@ -11,7 +11,7 @@ Covers:
   - Non-numeric '-x' tokens still raise "Unknown option" as expected.
 """
 
-from testing import assert_true, assert_false, assert_equal, TestSuite
+from std.testing import assert_true, assert_false, assert_equal, TestSuite
 import argmojo
 from argmojo import Argument, Command, ParseResult
 

--- a/tests/test_negative_numbers.mojo
+++ b/tests/test_negative_numbers.mojo
@@ -19,7 +19,7 @@ from argmojo import Argument, Command, ParseResult
 # ── Auto-detect tests (no digit short options registered) ───────────────────
 
 
-fn test_negative_integer_auto_detect() raises:
+def test_negative_integer_auto_detect() raises:
     """A negative integer token is treated as a positional when no digit
     short option is registered (auto-detect mode)."""
     var command = Command("test", "Test app")
@@ -32,7 +32,7 @@ fn test_negative_integer_auto_detect() raises:
     assert_equal(result.get_string("value"), "-9876543")
 
 
-fn test_negative_float_auto_detect() raises:
+def test_negative_float_auto_detect() raises:
     """A negative float token (-3.14) is treated as a positional."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -44,7 +44,7 @@ fn test_negative_float_auto_detect() raises:
     assert_equal(result.get_string("value"), "-3.14")
 
 
-fn test_negative_leading_dot_auto_detect() raises:
+def test_negative_leading_dot_auto_detect() raises:
     """A negative leading-dot float (-.5) is treated as a positional."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -56,7 +56,7 @@ fn test_negative_leading_dot_auto_detect() raises:
     assert_equal(result.get_string("value"), "-.5")
 
 
-fn test_negative_scientific_auto_detect() raises:
+def test_negative_scientific_auto_detect() raises:
     """A negative scientific notation token (-1.5e10) is treated as a positional.
     """
     var command = Command("test", "Test app")
@@ -69,7 +69,7 @@ fn test_negative_scientific_auto_detect() raises:
     assert_equal(result.get_string("value"), "-1.5e10")
 
 
-fn test_negative_scientific_negative_exp_auto_detect() raises:
+def test_negative_scientific_negative_exp_auto_detect() raises:
     """A token with negative exponent (-2.0e-3) is treated as a positional."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -81,7 +81,7 @@ fn test_negative_scientific_negative_exp_auto_detect() raises:
     assert_equal(result.get_string("value"), "-2.0e-3")
 
 
-fn test_multiple_negative_positionals() raises:
+def test_multiple_negative_positionals() raises:
     """Two negative number tokens are both collected as positionals."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -99,7 +99,7 @@ fn test_multiple_negative_positionals() raises:
     assert_equal(result.get_string("b"), "-2.5")
 
 
-fn test_mixed_negative_and_options() raises:
+def test_mixed_negative_and_options() raises:
     """Negative positionals coexist with normal named options."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -121,7 +121,7 @@ fn test_mixed_negative_and_options() raises:
 # ── Explicit allow_negative_numbers() tests ─────────────────────────────────
 
 
-fn test_explicit_allow_negative_numbers() raises:
+def test_explicit_allow_negative_numbers() raises:
     """The allow_negative_numbers() method forces negative-number tokens to positional
     even when a digit short option is registered."""
     var command = Command("test", "Test app")
@@ -144,7 +144,7 @@ fn test_explicit_allow_negative_numbers() raises:
     assert_equal(result.get_string("value"), "-3.14")
 
 
-fn test_explicit_allow_keeps_digit_short_option() raises:
+def test_explicit_allow_keeps_digit_short_option() raises:
     """With allow_negative_numbers(), an exact digit flag (-3 with no
     fractional part) that has a registered short option is still ambiguous —
     here we verify the exact integer form goes through as a positional too,
@@ -170,7 +170,7 @@ fn test_explicit_allow_keeps_digit_short_option() raises:
 # ── Digit short option blocks auto-detect ───────────────────────────────────
 
 
-fn test_digit_short_suppresses_auto_detect() raises:
+def test_digit_short_suppresses_auto_detect() raises:
     """When a digit short option is registered and allow_negative_numbers()
     has NOT been called, the auto-detect is suppressed and the '-3' token
     is consumed as the flag."""
@@ -192,7 +192,7 @@ fn test_digit_short_suppresses_auto_detect() raises:
 # ── '--' separator ───────────────────────────────────────────────────────────
 
 
-fn test_double_dash_passes_negative_number() raises:
+def test_double_dash_passes_negative_number() raises:
     """'-- -10.18' always passes -10.18 as a positional (pre-existing behaviour).
     """
     var command = Command("test", "Test app")
@@ -205,7 +205,7 @@ fn test_double_dash_passes_negative_number() raises:
     assert_equal(result.get_string("value"), "-10.18")
 
 
-fn test_double_dash_passes_option_like_string() raises:
+def test_double_dash_passes_option_like_string() raises:
     """'-- --foo' passes '--foo' as a positional via the '--' separator."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -220,7 +220,7 @@ fn test_double_dash_passes_option_like_string() raises:
 # ── Non-numeric dash tokens still error ─────────────────────────────────────
 
 
-fn test_unknown_short_option_still_errors() raises:
+def test_unknown_short_option_still_errors() raises:
     """A non-numeric short option that is not registered still raises an error.
     """
     var command = Command("test", "Test app")
@@ -235,7 +235,7 @@ fn test_unknown_short_option_still_errors() raises:
     assert_true(raised, msg="'-x' should raise Unknown option error")
 
 
-fn test_invalid_numeric_form_still_errors() raises:
+def test_invalid_numeric_form_still_errors() raises:
     """Tokens like '-1-2' or '-1abc' are NOT valid numbers, so they are
     still treated as short-option strings and raise an error."""
     var command = Command("test", "Test app")
@@ -249,5 +249,5 @@ fn test_invalid_numeric_form_still_errors() raises:
     assert_true(raised, msg="'-1abc' is not a number and should raise an error")
 
 
-fn main() raises:
+def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_parents.mojo
+++ b/tests/test_parents.mojo
@@ -1,6 +1,6 @@
 """Tests for argmojo — argument parents (shared argument definitions)."""
 
-from testing import assert_true, assert_false, assert_equal, TestSuite
+from std.testing import assert_true, assert_false, assert_equal, TestSuite
 import argmojo
 from argmojo import Argument, Command, ParseResult
 

--- a/tests/test_parents.mojo
+++ b/tests/test_parents.mojo
@@ -7,7 +7,7 @@ from argmojo import Argument, Command, ParseResult
 # ── Basic inheritance ────────────────────────────────────────────────────────
 
 
-fn test_parent_flag_inherited() raises:
+def test_parent_flag_inherited() raises:
     """Tests that a flag argument from a parent is inherited."""
     var parent = Command("_shared")
     parent.add_argument(
@@ -25,7 +25,7 @@ fn test_parent_flag_inherited() raises:
     assert_true(result.get_flag("verbose"), msg="--verbose should be True")
 
 
-fn test_parent_flag_short() raises:
+def test_parent_flag_short() raises:
     """Tests that short flags from a parent work."""
     var parent = Command("_shared")
     parent.add_argument(
@@ -43,7 +43,7 @@ fn test_parent_flag_short() raises:
     assert_true(result.get_flag("verbose"), msg="-v should set verbose True")
 
 
-fn test_parent_value_arg_inherited() raises:
+def test_parent_value_arg_inherited() raises:
     """Tests that a value-taking argument from a parent is inherited."""
     var parent = Command("_shared")
     parent.add_argument(
@@ -62,7 +62,7 @@ fn test_parent_value_arg_inherited() raises:
     assert_equal(result.get_string("format"), "json")
 
 
-fn test_parent_default_inherited() raises:
+def test_parent_default_inherited() raises:
     """Tests that default values from parent arguments are inherited."""
     var parent = Command("_shared")
     parent.add_argument(
@@ -79,7 +79,7 @@ fn test_parent_default_inherited() raises:
     assert_equal(result.get_string("format"), "json")
 
 
-fn test_parent_positional_inherited() raises:
+def test_parent_positional_inherited() raises:
     """Tests that positional arguments from a parent are inherited."""
     var parent = Command("_shared")
     parent.add_argument(
@@ -97,7 +97,7 @@ fn test_parent_positional_inherited() raises:
 # ── Multiple parents ─────────────────────────────────────────────────────────
 
 
-fn test_multiple_parents() raises:
+def test_multiple_parents() raises:
     """Tests that arguments from multiple parents are all inherited."""
     var parent_a = Command("_shared_a")
     parent_a.add_argument(
@@ -125,7 +125,7 @@ fn test_multiple_parents() raises:
 # ── Parent with own arguments ────────────────────────────────────────────────
 
 
-fn test_parent_plus_child_args() raises:
+def test_parent_plus_child_args() raises:
     """Tests that parent args coexist with child's own arguments."""
     var parent = Command("_shared")
     parent.add_argument(
@@ -150,7 +150,7 @@ fn test_parent_plus_child_args() raises:
 # ── Group constraint inheritance ─────────────────────────────────────────────
 
 
-fn test_parent_exclusive_group_inherited() raises:
+def test_parent_exclusive_group_inherited() raises:
     """Tests that mutually exclusive groups from a parent are inherited."""
     var parent = Command("_shared")
     parent.add_argument(
@@ -180,7 +180,7 @@ fn test_parent_exclusive_group_inherited() raises:
     assert_true(caught, msg="exclusive group from parent should be enforced")
 
 
-fn test_parent_required_together_inherited() raises:
+def test_parent_required_together_inherited() raises:
     """Tests that required-together groups from a parent are inherited."""
     var parent = Command("_shared")
     parent.add_argument(Argument("user", help="Username").long["user"]())
@@ -206,7 +206,7 @@ fn test_parent_required_together_inherited() raises:
     assert_true(caught, msg="required-together from parent should be enforced")
 
 
-fn test_parent_one_required_inherited() raises:
+def test_parent_one_required_inherited() raises:
     """Tests that one-required groups from a parent are inherited."""
     var parent = Command("_shared")
     parent.add_argument(
@@ -236,7 +236,7 @@ fn test_parent_one_required_inherited() raises:
     assert_true(caught, msg="one-required from parent should be enforced")
 
 
-fn test_parent_one_required_satisfied() raises:
+def test_parent_one_required_satisfied() raises:
     """Tests that one-required group from parent passes when satisfied."""
     var parent = Command("_shared")
     parent.add_argument(
@@ -256,7 +256,7 @@ fn test_parent_one_required_satisfied() raises:
     assert_true(result.get_flag("json"), msg="--json should be True")
 
 
-fn test_parent_conditional_req_inherited() raises:
+def test_parent_conditional_req_inherited() raises:
     """Tests that conditional requirements from a parent are inherited."""
     var parent = Command("_shared")
     parent.add_argument(
@@ -285,7 +285,7 @@ fn test_parent_conditional_req_inherited() raises:
     )
 
 
-fn test_parent_implies_inherited() raises:
+def test_parent_implies_inherited() raises:
     """Tests that implications from a parent are inherited."""
     var parent = Command("_shared")
     parent.add_argument(
@@ -311,7 +311,7 @@ fn test_parent_implies_inherited() raises:
 # ── Parent shared across multiple children ───────────────────────────────────
 
 
-fn test_parent_shared_across_children() raises:
+def test_parent_shared_across_children() raises:
     """Tests that the same parent can be shared across multiple children."""
     var parent = Command("_shared")
     parent.add_argument(
@@ -341,7 +341,7 @@ fn test_parent_shared_across_children() raises:
 # ── Parent with append/count/range ───────────────────────────────────────────
 
 
-fn test_parent_count_arg_inherited() raises:
+def test_parent_count_arg_inherited() raises:
     """Tests that count arguments from a parent are inherited."""
     var parent = Command("_shared")
     parent.add_argument(
@@ -360,7 +360,7 @@ fn test_parent_count_arg_inherited() raises:
     assert_equal(result.get_count("verbose"), 3)
 
 
-fn test_parent_append_arg_inherited() raises:
+def test_parent_append_arg_inherited() raises:
     """Tests that append arguments from a parent are inherited."""
     var parent = Command("_shared")
     parent.add_argument(
@@ -378,7 +378,7 @@ fn test_parent_append_arg_inherited() raises:
     assert_equal(tags[1], "b")
 
 
-fn test_parent_range_arg_inherited() raises:
+def test_parent_range_arg_inherited() raises:
     """Tests that range-validated arguments from a parent are inherited."""
     var parent = Command("_shared")
     parent.add_argument(
@@ -396,7 +396,7 @@ fn test_parent_range_arg_inherited() raises:
 # ── Edge cases ───────────────────────────────────────────────────────────────
 
 
-fn test_parent_no_args() raises:
+def test_parent_no_args() raises:
     """Tests that inheriting from a parent with no arguments is a no-op."""
     var parent = Command("_empty")
 
@@ -408,7 +408,7 @@ fn test_parent_no_args() raises:
     assert_equal(result.subcommand, "")
 
 
-fn test_parent_does_not_modify_parent() raises:
+def test_parent_does_not_modify_parent() raises:
     """Tests that add_parent does not mutate the parent Command."""
     var parent = Command("_shared")
     parent.add_argument(
@@ -425,7 +425,7 @@ fn test_parent_does_not_modify_parent() raises:
     assert_equal(len(child.args), 2)
 
 
-fn test_parent_with_subcommands() raises:
+def test_parent_with_subcommands() raises:
     """Tests that parent args work on a command with subcommands."""
     var parent = Command("_shared")
     parent.add_argument(
@@ -451,5 +451,5 @@ fn test_parent_with_subcommands() raises:
     assert_equal(sub_result.get_string("target"), "main")
 
 
-fn main() raises:
+def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_parse.mojo
+++ b/tests/test_parse.mojo
@@ -5,7 +5,7 @@ import argmojo
 from argmojo import Argument, Command, ParseResult
 
 
-fn test_flag_long() raises:
+def test_flag_long() raises:
     """Tests parsing a long flag (--verbose)."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -20,7 +20,7 @@ fn test_flag_long() raises:
     assert_true(result.get_flag("verbose"), msg="--verbose should be True")
 
 
-fn test_flag_short() raises:
+def test_flag_short() raises:
     """Tests parsing a short flag (-v)."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -35,7 +35,7 @@ fn test_flag_short() raises:
     assert_true(result.get_flag("verbose"), msg="-v should be True")
 
 
-fn test_flag_default_false() raises:
+def test_flag_default_false() raises:
     """Tests that an unset flag defaults to False."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -50,7 +50,7 @@ fn test_flag_default_false() raises:
     assert_false(result.get_flag("verbose"), msg="unset flag should be False")
 
 
-fn test_key_value_long_space() raises:
+def test_key_value_long_space() raises:
     """Tests parsing --key value (space separated)."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -62,7 +62,7 @@ fn test_key_value_long_space() raises:
     assert_equal(result.get_string("output"), "file.txt")
 
 
-fn test_key_value_long_equals() raises:
+def test_key_value_long_equals() raises:
     """Tests parsing --key=value (equals separated)."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -74,7 +74,7 @@ fn test_key_value_long_equals() raises:
     assert_equal(result.get_string("output"), "file.txt")
 
 
-fn test_key_value_short() raises:
+def test_key_value_short() raises:
     """Tests parsing -o value (short option with value)."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -86,7 +86,7 @@ fn test_key_value_short() raises:
     assert_equal(result.get_string("output"), "file.txt")
 
 
-fn test_positional_args() raises:
+def test_positional_args() raises:
     """Tests parsing positional arguments."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -102,7 +102,7 @@ fn test_positional_args() raises:
     assert_equal(result.get_string("path"), "./src")
 
 
-fn test_positional_with_default() raises:
+def test_positional_with_default() raises:
     """Tests that positional arguments use defaults when not provided."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -118,7 +118,7 @@ fn test_positional_with_default() raises:
     assert_equal(result.get_string("path"), ".")
 
 
-fn test_mixed_args() raises:
+def test_mixed_args() raises:
     """Tests parsing a mix of positional args and options."""
     var command = Command("sou", "Search tool")
     command.add_argument(
@@ -162,7 +162,7 @@ fn test_mixed_args() raises:
     assert_equal(result.get_string("max-depth"), "3")
 
 
-fn test_double_dash_stop() raises:
+def test_double_dash_stop() raises:
     """Tests that '--' stops option parsing."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -179,7 +179,7 @@ fn test_double_dash_stop() raises:
     assert_equal(result._positionals[0], "--verbose")
 
 
-fn test_has() raises:
+def test_has() raises:
     """Tests the has() method."""
     var command = Command("test", "Test app")
     command.add_argument(Argument("verbose").long["verbose"]().flag())
@@ -194,7 +194,7 @@ fn test_has() raises:
 # ── Short flag merging ────────────────────────────────────────────────────────────
 
 
-fn test_merged_short_flags() raises:
+def test_merged_short_flags() raises:
     """Tests that -abc is expanded to -a -b -c for flags."""
     var command = Command("test", "Test app")
     command.add_argument(Argument("all", help="All").short["a"]().flag())
@@ -208,7 +208,7 @@ fn test_merged_short_flags() raises:
     assert_true(result.get_flag("color"), msg="-c should be True from -abc")
 
 
-fn test_merged_flags_partial() raises:
+def test_merged_flags_partial() raises:
     """Tests that -ab only sets those two flags, leaving -c unset."""
     var command = Command("test", "Test app")
     command.add_argument(Argument("all", help="All").short["a"]().flag())
@@ -222,7 +222,7 @@ fn test_merged_flags_partial() raises:
     assert_false(result.get_flag("color"), msg="-c should be False (not given)")
 
 
-fn test_merged_flags_with_trailing_value() raises:
+def test_merged_flags_with_trailing_value() raises:
     """Tests -avo file.txt where -a and -v are flags, -o takes a value."""
     var command = Command("test", "Test app")
     command.add_argument(Argument("all", help="All").short["a"]().flag())
@@ -241,7 +241,7 @@ fn test_merged_flags_with_trailing_value() raises:
 # ── Attached short value ─────────────────────────────────────────────────────────
 
 
-fn test_attached_short_value() raises:
+def test_attached_short_value() raises:
     """Tests -ofile.txt where -o takes 'file.txt' as attached value."""
     var command = Command("test", "Test app")
     command.add_argument(Argument("output", help="Output").short["o"]())
@@ -251,7 +251,7 @@ fn test_attached_short_value() raises:
     assert_equal(result.get_string("output"), "file.txt")
 
 
-fn test_merged_flags_with_attached_value() raises:
+def test_merged_flags_with_attached_value() raises:
     """Tests -abofile.txt where -a,-b are flags, -o takes 'file.txt' inline."""
     var command = Command("test", "Test app")
     command.add_argument(Argument("all", help="All").short["a"]().flag())
@@ -268,7 +268,7 @@ fn test_merged_flags_with_attached_value() raises:
 # ── Choices validation ───────────────────────────────────────────────────────────
 
 
-fn test_choices_valid() raises:
+def test_choices_valid() raises:
     """Tests that a valid choice is accepted."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -285,7 +285,7 @@ fn test_choices_valid() raises:
     assert_equal(result.get_string("format"), "json")
 
 
-fn test_choices_invalid() raises:
+def test_choices_invalid() raises:
     """Tests that an invalid choice raises an error."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -314,7 +314,7 @@ fn test_choices_invalid() raises:
     assert_true(caught, msg="Should have raised an error for invalid choice")
 
 
-fn test_choices_with_short_attached() raises:
+def test_choices_with_short_attached() raises:
     """Tests choices validation with attached short value like -fxml."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -334,7 +334,7 @@ fn test_choices_with_short_attached() raises:
 # ── Count action ─────────────────────────────────────────────────────────────────
 
 
-fn test_count_single() raises:
+def test_count_single() raises:
     """Tests that -v sets count to 1."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -349,7 +349,7 @@ fn test_count_single() raises:
     assert_equal(result.get_count("verbose"), 1)
 
 
-fn test_count_triple() raises:
+def test_count_triple() raises:
     """Tests that -vvv sets count to 3."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -364,7 +364,7 @@ fn test_count_triple() raises:
     assert_equal(result.get_count("verbose"), 3)
 
 
-fn test_count_long_repeated() raises:
+def test_count_long_repeated() raises:
     """Tests that --verbose --verbose sets count to 2."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -379,7 +379,7 @@ fn test_count_long_repeated() raises:
     assert_equal(result.get_count("verbose"), 2)
 
 
-fn test_count_mixed_short_long() raises:
+def test_count_mixed_short_long() raises:
     """Tests that -vv --verbose sets count to 3."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -394,7 +394,7 @@ fn test_count_mixed_short_long() raises:
     assert_equal(result.get_count("verbose"), 3)
 
 
-fn test_count_default_zero() raises:
+def test_count_default_zero() raises:
     """Tests that an unprovided count arg returns 0."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -412,7 +412,7 @@ fn test_count_default_zero() raises:
 # ── Count ceiling (.max()) ───────────────────────────────────────────────────────
 
 
-fn test_count_max_caps_merged_short() raises:
+def test_count_max_caps_merged_short() raises:
     """Tests that .count().max[3]() caps -vvvvv at 3."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -432,7 +432,7 @@ fn test_count_max_caps_merged_short() raises:
     )
 
 
-fn test_count_max_caps_repeated_long() raises:
+def test_count_max_caps_repeated_long() raises:
     """Tests that .max[2]() caps repeated --verbose at 2."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -458,7 +458,7 @@ fn test_count_max_caps_repeated_long() raises:
     )
 
 
-fn test_count_max_caps_mixed() raises:
+def test_count_max_caps_mixed() raises:
     """Tests that .max[3]() caps mixed -vv --verbose --verbose at 3."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -478,7 +478,7 @@ fn test_count_max_caps_mixed() raises:
     )
 
 
-fn test_count_max_below_ceiling() raises:
+def test_count_max_below_ceiling() raises:
     """Tests that .max[5]() does not affect -vv (below ceiling)."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -498,7 +498,7 @@ fn test_count_max_below_ceiling() raises:
     )
 
 
-fn test_count_max_exact_ceiling() raises:
+def test_count_max_exact_ceiling() raises:
     """Tests that -vvv with .max[3]() returns exactly 3."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -518,7 +518,7 @@ fn test_count_max_exact_ceiling() raises:
     )
 
 
-fn test_count_max_single_short() raises:
+def test_count_max_single_short() raises:
     """Tests that .max[2]() caps -v -v -v via separate short flags at 2."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -538,7 +538,7 @@ fn test_count_max_single_short() raises:
     )
 
 
-fn test_count_without_max_no_ceiling() raises:
+def test_count_without_max_no_ceiling() raises:
     """Tests that .count() without .max() has no ceiling."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -557,7 +557,7 @@ fn test_count_without_max_no_ceiling() raises:
     )
 
 
-fn test_count_max_one() raises:
+def test_count_max_one() raises:
     """Tests that .max[1]() caps any number of flags at 1 (boolean-like)."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -580,7 +580,7 @@ fn test_count_max_one() raises:
 # ── Positional arg count validation ──────────────────────────────────────────────
 
 
-fn test_too_many_positionals() raises:
+def test_too_many_positionals() raises:
     """Tests that extra positional args raise an error."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -603,7 +603,7 @@ fn test_too_many_positionals() raises:
     )
 
 
-fn test_exact_positionals_ok() raises:
+def test_exact_positionals_ok() raises:
     """Tests that the exact number of positional args is accepted."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -622,7 +622,7 @@ fn test_exact_positionals_ok() raises:
 # ── Negatable flags (--no-X) ─────────────────────────────────────────────────────
 
 
-fn test_negatable_positive() raises:
+def test_negatable_positive() raises:
     """Test that --color sets a negatable flag to True."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -637,7 +637,7 @@ fn test_negatable_positive() raises:
     assert_true(result.get_flag("color"), msg="--color should be True")
 
 
-fn test_negatable_negative() raises:
+def test_negatable_negative() raises:
     """Test that --no-color sets a negatable flag to False."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -655,7 +655,7 @@ fn test_negatable_negative() raises:
     )
 
 
-fn test_negatable_default() raises:
+def test_negatable_default() raises:
     """Test that an unset negatable flag defaults to False (not present)."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -675,7 +675,7 @@ fn test_negatable_default() raises:
     )
 
 
-fn test_non_negatable_rejects_no_prefix() raises:
+def test_non_negatable_rejects_no_prefix() raises:
     """Test that --no-X fails for a non-negatable flag."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -698,7 +698,7 @@ fn test_non_negatable_rejects_no_prefix() raises:
     )
 
 
-fn test_prefix_match_unambiguous() raises:
+def test_prefix_match_unambiguous() raises:
     """Test that --verb resolves to --verbose when unambiguous."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -718,7 +718,7 @@ fn test_prefix_match_unambiguous() raises:
     )
 
 
-fn test_prefix_match_value() raises:
+def test_prefix_match_value() raises:
     """Test that prefix matching works for value-taking options."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -730,7 +730,7 @@ fn test_prefix_match_value() raises:
     assert_equal(result.get_string("output"), "file.txt")
 
 
-fn test_prefix_match_equals() raises:
+def test_prefix_match_equals() raises:
     """Test that prefix matching works with --key=value syntax."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -742,7 +742,7 @@ fn test_prefix_match_equals() raises:
     assert_equal(result.get_string("output"), "file.txt")
 
 
-fn test_prefix_match_ambiguous() raises:
+def test_prefix_match_ambiguous() raises:
     """Test that ambiguous prefix raises an error."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -768,7 +768,7 @@ fn test_prefix_match_ambiguous() raises:
     assert_true(caught, msg="Should have raised error for ambiguous prefix")
 
 
-fn test_prefix_match_exact_preferred() raises:
+def test_prefix_match_exact_preferred() raises:
     """Test that exact match is preferred over prefix match."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -791,7 +791,7 @@ fn test_prefix_match_exact_preferred() raises:
     )
 
 
-fn test_prefix_match_negatable() raises:
+def test_prefix_match_negatable() raises:
     """Test that --no-col resolves to --no-color when unambiguous."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -809,5 +809,5 @@ fn test_prefix_match_negatable() raises:
     )
 
 
-fn main() raises:
+def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_parse.mojo
+++ b/tests/test_parse.mojo
@@ -1,6 +1,6 @@
 """Tests for argmojo — core parsing (flags, values, positionals, shorts, count, negatable, prefix)."""
 
-from testing import assert_true, assert_false, assert_equal, TestSuite
+from std.testing import assert_true, assert_false, assert_equal, TestSuite
 import argmojo
 from argmojo import Argument, Command, ParseResult
 

--- a/tests/test_password.mojo
+++ b/tests/test_password.mojo
@@ -68,7 +68,7 @@ def test_password_default_fields() raises:
 
 
 def test_password_copy_preserves_field() raises:
-    """Tests that __copyinit__ preserves _hide_input."""
+    """Tests that Argument.copy() preserves _hide_input and _prompt."""
     var original = Argument("pass", help="Password").long["pass"]().password()
     var copy = original.copy()
     assert_true(copy._hide_input, msg="copy should preserve _hide_input")

--- a/tests/test_password.mojo
+++ b/tests/test_password.mojo
@@ -17,14 +17,14 @@ from argmojo import Argument, Command, ParseResult
 # ── Builder method tests ─────────────────────────────────────────────────────
 
 
-fn test_password_builder_basic() raises:
+def test_password_builder_basic() raises:
     """Tests that .password() sets _hide_input and implies _prompt."""
     var arg = Argument("token", help="API token").long["token"]().password()
     assert_true(arg._hide_input, msg=".password() should set _hide_input")
     assert_true(arg._prompt, msg=".password() should imply .prompt()")
 
 
-fn test_password_builder_with_explicit_prompt() raises:
+def test_password_builder_with_explicit_prompt() raises:
     """Tests that .password() works alongside .prompt["text"]()."""
     var arg = (
         Argument("pass", help="Password")
@@ -41,7 +41,7 @@ fn test_password_builder_with_explicit_prompt() raises:
     )
 
 
-fn test_password_before_prompt() raises:
+def test_password_before_prompt() raises:
     """Tests that .password() before .prompt["text"]() works."""
     var arg = (
         Argument("secret", help="Secret key")
@@ -58,7 +58,7 @@ fn test_password_before_prompt() raises:
     )
 
 
-fn test_password_default_fields() raises:
+def test_password_default_fields() raises:
     """Tests that _hide_input is False by default."""
     var arg = Argument("name", help="Name").long["name"]()
     assert_false(arg._hide_input, msg="_hide_input should be False by default")
@@ -67,7 +67,7 @@ fn test_password_default_fields() raises:
 # ── Copy and move propagation ────────────────────────────────────────────────
 
 
-fn test_password_copy_preserves_field() raises:
+def test_password_copy_preserves_field() raises:
     """Tests that __copyinit__ preserves _hide_input."""
     var original = Argument("pass", help="Password").long["pass"]().password()
     var copy = original.copy()
@@ -78,7 +78,7 @@ fn test_password_copy_preserves_field() raises:
 # ── Validation guards ────────────────────────────────────────────────────────
 
 
-fn test_password_rejected_on_flag() raises:
+def test_password_rejected_on_flag() raises:
     """Tests that .password() on a flag raises at add_argument time."""
     var cmd = Command("test", "Test app")
     var caught = False
@@ -98,7 +98,7 @@ fn test_password_rejected_on_flag() raises:
     assert_true(caught, msg="add_argument should reject .password() on flag")
 
 
-fn test_password_rejected_on_count() raises:
+def test_password_rejected_on_count() raises:
     """Tests that .password() on a count arg raises at add_argument time."""
     var cmd = Command("test", "Test app")
     var caught = False
@@ -121,7 +121,7 @@ fn test_password_rejected_on_count() raises:
 # ── Prompting skipped when value provided on command line ─────────────────────
 
 
-fn test_password_skipped_when_value_provided() raises:
+def test_password_skipped_when_value_provided() raises:
     """Tests that password prompt is skipped when value is on command line."""
     var cmd = Command("test", "Test app")
     cmd.add_argument(
@@ -137,7 +137,7 @@ fn test_password_skipped_when_value_provided() raises:
     )
 
 
-fn test_password_with_default() raises:
+def test_password_with_default() raises:
     """Tests password arg with a default value."""
     var cmd = Command("test", "Test app")
     cmd.add_argument(
@@ -158,7 +158,7 @@ fn test_password_with_default() raises:
     )
 
 
-fn test_password_with_choices() raises:
+def test_password_with_choices() raises:
     """Tests password arg with choices (unusual but valid)."""
     var cmd = Command("test", "Test app")
     cmd.add_argument(
@@ -181,7 +181,7 @@ fn test_password_with_choices() raises:
 # ── Integration with other features ──────────────────────────────────────────
 
 
-fn test_password_with_required() raises:
+def test_password_with_required() raises:
     """Tests that required + password arg errors on missing value.
 
     When stdin is /dev/null, prompting stops → the required arg is
@@ -205,7 +205,7 @@ fn test_password_with_required() raises:
     assert_true(caught, msg="missing required password arg should error")
 
 
-fn test_password_arg_with_parent() raises:
+def test_password_arg_with_parent() raises:
     """Tests that password fields are inherited via add_parent."""
     var parent = Command("_shared")
     parent.add_argument(
@@ -232,7 +232,7 @@ fn test_password_arg_with_parent() raises:
     assert_true(found, msg="token should be inherited from parent")
 
 
-fn test_password_with_subcommand() raises:
+def test_password_with_subcommand() raises:
     """Tests password arg on a subcommand."""
     var app = Command("app", "My app")
     var login = Command("login", "Login to service")
@@ -255,7 +255,7 @@ fn test_password_with_subcommand() raises:
     )
 
 
-fn test_password_not_set_on_normal_prompt() raises:
+def test_password_not_set_on_normal_prompt() raises:
     """Tests that a normal .prompt() arg does NOT have _hide_input."""
     var arg = Argument("name", help="Name").long["name"]().prompt()
     assert_false(
@@ -264,7 +264,7 @@ fn test_password_not_set_on_normal_prompt() raises:
     )
 
 
-fn test_password_positional() raises:
+def test_password_positional() raises:
     """Tests password on a positional argument."""
     var cmd = Command("test", "Test app")
     cmd.add_argument(
@@ -280,7 +280,7 @@ fn test_password_positional() raises:
     )
 
 
-fn test_password_graceful_on_non_interactive_stdin() raises:
+def test_password_graceful_on_non_interactive_stdin() raises:
     """Tests that password prompting stops gracefully on non-interactive stdin.
 
     When the test runs with stdin redirected from /dev/null, input()
@@ -308,5 +308,5 @@ fn test_password_graceful_on_non_interactive_stdin() raises:
 # ── Test runner ──────────────────────────────────────────────────────────────
 
 
-fn main() raises:
+def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_password.mojo
+++ b/tests/test_password.mojo
@@ -10,7 +10,7 @@ tests focus on:
    stdin from `/dev/null`, so prompting stops without blocking)
 """
 
-from testing import assert_true, assert_false, assert_equal, TestSuite
+from std.testing import assert_true, assert_false, assert_equal, TestSuite
 import argmojo
 from argmojo import Argument, Command, ParseResult
 

--- a/tests/test_persistent.mojo
+++ b/tests/test_persistent.mojo
@@ -25,7 +25,7 @@ from argmojo import Argument, Command, ParseResult
 # ── Persistent flag on root without any subcommand ─────────────────────────
 
 
-fn test_persistent_flag_on_root_no_subcommand() raises:
+def test_persistent_flag_on_root_no_subcommand() raises:
     """A persistent flag still works as a plain root flag when no subcommand
     is involved."""
     var command = Command("app", "")
@@ -40,7 +40,7 @@ fn test_persistent_flag_on_root_no_subcommand() raises:
     assert_true(r.get_flag("verbose"), msg="root verbose should be True")
 
 
-fn test_persistent_flag_absent_on_root() raises:
+def test_persistent_flag_absent_on_root() raises:
     """Absent persistent flag defaults to False on root."""
     var command = Command("app", "")
     command.add_argument(
@@ -57,7 +57,7 @@ fn test_persistent_flag_absent_on_root() raises:
 # ── Persistent flag BEFORE the subcommand token ────────────────────────────
 
 
-fn test_persistent_flag_before_subcommand_in_root_result() raises:
+def test_persistent_flag_before_subcommand_in_root_result() raises:
     """Persistent flag placed before the subcommand token is stored in the root
     result."""
     var app = Command("app", "")
@@ -77,7 +77,7 @@ fn test_persistent_flag_before_subcommand_in_root_result() raises:
     assert_equal(r.subcommand, "search")
 
 
-fn test_persistent_flag_before_subcommand_pushed_to_child() raises:
+def test_persistent_flag_before_subcommand_pushed_to_child() raises:
     """Persistent flag placed before the subcommand token is pushed down into
     the child result so sub_result.get_flag() also works."""
     var app = Command("app", "")
@@ -103,7 +103,7 @@ fn test_persistent_flag_before_subcommand_pushed_to_child() raises:
 # ── Persistent flag AFTER the subcommand token ─────────────────────────────
 
 
-fn test_persistent_flag_after_subcommand_in_child_result() raises:
+def test_persistent_flag_after_subcommand_in_child_result() raises:
     """Persistent flag placed after the subcommand token is parsed by the child
     (injected) and stored in the child result."""
     var app = Command("app", "")
@@ -125,7 +125,7 @@ fn test_persistent_flag_after_subcommand_in_child_result() raises:
     )
 
 
-fn test_persistent_flag_after_subcommand_bubbles_to_root() raises:
+def test_persistent_flag_after_subcommand_bubbles_to_root() raises:
     """Persistent flag placed after the subcommand token is also bubbled up to
     the root result so root_result.get_flag() always works."""
     var app = Command("app", "")
@@ -147,7 +147,7 @@ fn test_persistent_flag_after_subcommand_bubbles_to_root() raises:
     )
 
 
-fn test_persistent_short_flag_after_subcommand() raises:
+def test_persistent_short_flag_after_subcommand() raises:
     """The short form of a persistent flag also bubbles up from after-subcommand
     position."""
     var app = Command("app", "")
@@ -175,7 +175,7 @@ fn test_persistent_short_flag_after_subcommand() raises:
 # ── Persistent value-taking option ─────────────────────────────────────────
 
 
-fn test_persistent_value_option_after_subcommand() raises:
+def test_persistent_value_option_after_subcommand() raises:
     """A persistent value-taking option placed after the subcommand token is
     injected into the child, parsed, and synced both ways."""
     var app = Command("app", "")
@@ -193,7 +193,7 @@ fn test_persistent_value_option_after_subcommand() raises:
     assert_equal(r.get_subcommand_result().get_string("output"), "json")
 
 
-fn test_persistent_flag_absent_defaults_false_in_both() raises:
+def test_persistent_flag_absent_defaults_false_in_both() raises:
     """When a persistent flag is not provided at all, both root and child
     results return False."""
     var app = Command("app", "")
@@ -221,7 +221,7 @@ fn test_persistent_flag_absent_defaults_false_in_both() raises:
 # ── Non-persistent flag isolation ──────────────────────────────────────────
 
 
-fn test_non_persistent_root_flag_not_injected_into_child() raises:
+def test_non_persistent_root_flag_not_injected_into_child() raises:
     """A non-persistent root flag placed after the subcommand token is NOT
     recognised by the child and causes an unknown-option error."""
     var app = Command("app", "")
@@ -246,7 +246,7 @@ fn test_non_persistent_root_flag_not_injected_into_child() raises:
 # ── Conflict detection ──────────────────────────────────────────────────────
 
 
-fn test_persistent_conflict_long_name_raises() raises:
+def test_persistent_conflict_long_name_raises() raises:
     """Tests add_subcommand() raises when a persistent parent long_name conflicts
     with a child long_name."""
     var app = Command("app", "")
@@ -269,7 +269,7 @@ fn test_persistent_conflict_long_name_raises() raises:
     )
 
 
-fn test_persistent_conflict_short_name_raises() raises:
+def test_persistent_conflict_short_name_raises() raises:
     """Tests add_subcommand() raises when a persistent parent short_name conflicts
     with a child short_name."""
     var app = Command("app", "")
@@ -298,7 +298,7 @@ fn test_persistent_conflict_short_name_raises() raises:
     )
 
 
-fn test_no_conflict_for_non_persistent_same_name() raises:
+def test_no_conflict_for_non_persistent_same_name() raises:
     """No conflict is raised when a non-persistent root arg shares a name with
     a child arg (only persistent args are checked)."""
     var app = Command("app", "")
@@ -319,5 +319,5 @@ fn test_no_conflict_for_non_persistent_same_name() raises:
 # ── Main ───────────────────────────────────────────────────────────────────
 
 
-fn main() raises:
+def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_persistent.mojo
+++ b/tests/test_persistent.mojo
@@ -17,7 +17,7 @@ Covers:
   - Absent persistent flag defaults to False / raises as usual.
 """
 
-from testing import assert_true, assert_false, assert_equal, TestSuite
+from std.testing import assert_true, assert_false, assert_equal, TestSuite
 import argmojo
 from argmojo import Argument, Command, ParseResult
 

--- a/tests/test_prompt.mojo
+++ b/tests/test_prompt.mojo
@@ -7,7 +7,7 @@ Since interactive prompting reads from stdin, these tests focus on:
 4. Choices/defaults appear in the prompt (tested via field inspection)
 """
 
-from testing import assert_true, assert_false, assert_equal, TestSuite
+from std.testing import assert_true, assert_false, assert_equal, TestSuite
 import argmojo
 from argmojo import Argument, Command, ParseResult
 

--- a/tests/test_prompt.mojo
+++ b/tests/test_prompt.mojo
@@ -14,7 +14,7 @@ from argmojo import Argument, Command, ParseResult
 # ── Builder method tests ─────────────────────────────────────────────────────
 
 
-fn test_prompt_builder_default() raises:
+def test_prompt_builder_default() raises:
     """Tests that .prompt() enables prompting."""
     var arg = Argument("name", help="Your name").long["name"]().prompt()
     assert_true(arg._prompt, msg=".prompt() should enable prompting")
@@ -23,7 +23,7 @@ fn test_prompt_builder_default() raises:
     )
 
 
-fn test_prompt_builder_with_text() raises:
+def test_prompt_builder_with_text() raises:
     """Tests that .prompt["..."]() sets custom text and enables prompting."""
     var arg = (
         Argument("name", help="Your name")
@@ -38,7 +38,7 @@ fn test_prompt_builder_with_text() raises:
     )
 
 
-fn test_prompt_with_custom_text_standalone() raises:
+def test_prompt_with_custom_text_standalone() raises:
     """Tests that .prompt["..."]() works as a standalone builder."""
     var arg = (
         Argument("email", help="Email address")
@@ -56,7 +56,7 @@ fn test_prompt_with_custom_text_standalone() raises:
 # ── Prompting skipped when value provided ────────────────────────────────────
 
 
-fn test_prompt_skipped_when_value_provided() raises:
+def test_prompt_skipped_when_value_provided() raises:
     """Tests that prompting is skipped when the argument is on the command line.
     """
     var command = Command("test", "Test app")
@@ -74,7 +74,7 @@ fn test_prompt_skipped_when_value_provided() raises:
     )
 
 
-fn test_prompt_skipped_for_flag_provided() raises:
+def test_prompt_skipped_for_flag_provided() raises:
     """Tests that a prompt-enabled flag is skipped when provided."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -92,7 +92,7 @@ fn test_prompt_skipped_for_flag_provided() raises:
     )
 
 
-fn test_prompt_skipped_for_positional_provided() raises:
+def test_prompt_skipped_for_positional_provided() raises:
     """Tests that a prompt-enabled positional is skipped when provided."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -108,7 +108,7 @@ fn test_prompt_skipped_for_positional_provided() raises:
     )
 
 
-fn test_prompt_skipped_when_short_used() raises:
+def test_prompt_skipped_when_short_used() raises:
     """Tests that prompting is skipped when the short option is used."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -127,7 +127,7 @@ fn test_prompt_skipped_when_short_used() raises:
     )
 
 
-fn test_prompt_skipped_when_equals_used() raises:
+def test_prompt_skipped_when_equals_used() raises:
     """Tests that prompting is skipped when --key=value syntax is used."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -146,7 +146,7 @@ fn test_prompt_skipped_when_equals_used() raises:
 # ── Prompt with choices and defaults ─────────────────────────────────────────
 
 
-fn test_prompt_with_choices_skipped_when_provided() raises:
+def test_prompt_with_choices_skipped_when_provided() raises:
     """Tests that a prompt arg with choices works when value is on CLI."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -167,7 +167,7 @@ fn test_prompt_with_choices_skipped_when_provided() raises:
     )
 
 
-fn test_prompt_with_default_skipped_when_provided() raises:
+def test_prompt_with_default_skipped_when_provided() raises:
     """Tests that a prompt arg with default uses CLI value over default."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -186,7 +186,7 @@ fn test_prompt_with_default_skipped_when_provided() raises:
     )
 
 
-fn test_prompt_default_applied_when_no_prompt_input() raises:
+def test_prompt_default_applied_when_no_prompt_input() raises:
     """Tests that defaults still apply for prompt args when stdin is not a TTY.
 
     When stdin is not a TTY (piped/closed), prompting is skipped entirely
@@ -214,7 +214,7 @@ fn test_prompt_default_applied_when_no_prompt_input() raises:
 # ── Prompt field propagation through copy/move ───────────────────────────────
 
 
-fn test_prompt_field_copy() raises:
+def test_prompt_field_copy() raises:
     """Tests that prompt fields survive Argument copy."""
     var original = (
         Argument("name", help="Your name").long["name"]().prompt["Enter name"]()
@@ -231,7 +231,7 @@ fn test_prompt_field_copy() raises:
 # ── Combined features ───────────────────────────────────────────────────────
 
 
-fn test_prompt_combined_with_required() raises:
+def test_prompt_combined_with_required() raises:
     """Tests that prompt works alongside .required() when value is given."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -247,7 +247,7 @@ fn test_prompt_combined_with_required() raises:
     )
 
 
-fn test_prompt_combined_with_group() raises:
+def test_prompt_combined_with_group() raises:
     """Tests that prompt works alongside .group[]()."""
     var arg = (
         Argument("user", help="Username")
@@ -259,7 +259,7 @@ fn test_prompt_combined_with_group() raises:
     assert_equal(arg._group, "Auth", msg="group should be set")
 
 
-fn test_prompt_on_optional_arg_with_default() raises:
+def test_prompt_on_optional_arg_with_default() raises:
     """Tests that prompt works on non-required args (no .required())."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -279,7 +279,7 @@ fn test_prompt_on_optional_arg_with_default() raises:
     )
 
 
-fn test_prompt_on_optional_arg_default_applied() raises:
+def test_prompt_on_optional_arg_default_applied() raises:
     """Tests that non-required prompt arg falls back to default when
     stdin is not interactive (piped/closed)."""
     var command = Command("test", "Test app")
@@ -300,7 +300,7 @@ fn test_prompt_on_optional_arg_default_applied() raises:
     )
 
 
-fn test_multiple_prompt_args_all_provided() raises:
+def test_multiple_prompt_args_all_provided() raises:
     """Tests that multiple prompt-enabled args work when all provided."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -329,5 +329,5 @@ fn test_multiple_prompt_args_all_provided() raises:
 # ── Test runner ──────────────────────────────────────────────────────────────
 
 
-fn main() raises:
+def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_remainder_known.mojo
+++ b/tests/test_remainder_known.mojo
@@ -10,7 +10,7 @@ from argmojo import Argument, Command, ParseResult
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
-fn test_value_name_basic() raises:
+def test_value_name_basic() raises:
     """Tests that .value_name() sets the display name for help."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -25,7 +25,7 @@ fn test_value_name_basic() raises:
     assert_equal(result.get_string("output"), "data.csv")
 
 
-fn test_value_name_in_help() raises:
+def test_value_name_in_help() raises:
     """Tests that value_name appears in help output."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -46,7 +46,7 @@ fn test_value_name_in_help() raises:
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
-fn test_remainder_basic() raises:
+def test_remainder_basic() raises:
     """Tests that remainder consumes all remaining tokens."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -66,7 +66,7 @@ fn test_remainder_basic() raises:
     assert_equal(rest[2], "main.c")
 
 
-fn test_remainder_empty() raises:
+def test_remainder_empty() raises:
     """Tests remainder with no trailing arguments."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -83,7 +83,7 @@ fn test_remainder_empty() raises:
     assert_equal(len(rest), 0)
 
 
-fn test_remainder_only() raises:
+def test_remainder_only() raises:
     """Tests remainder as the only positional."""
     var command = Command("test", "Test app")
     command.add_argument(Argument("rest", help="All arguments").remainder())
@@ -97,7 +97,7 @@ fn test_remainder_only() raises:
     assert_equal(rest[2], "file.txt")
 
 
-fn test_remainder_with_options_before() raises:
+def test_remainder_with_options_before() raises:
     """Tests that options before the remainder positional slot are parsed normally.
     """
     var command = Command("test", "Test app")
@@ -122,7 +122,7 @@ fn test_remainder_with_options_before() raises:
     assert_equal(rest[1], "main.c")
 
 
-fn test_remainder_captures_double_dash_tokens() raises:
+def test_remainder_captures_double_dash_tokens() raises:
     """Tests that remainder captures -- and tokens after it."""
     var command = Command("test", "Test app")
     command.add_argument(Argument("rest", help="All args").remainder())
@@ -137,7 +137,7 @@ fn test_remainder_captures_double_dash_tokens() raises:
     assert_equal(rest[1], "--help")
 
 
-fn test_remainder_guard_no_long_short() raises:
+def test_remainder_guard_no_long_short() raises:
     """Tests that remainder rejects .long() or .short()."""
     var command = Command("test", "Test app")
     var failed = False
@@ -150,7 +150,7 @@ fn test_remainder_guard_no_long_short() raises:
     assert_true(failed, msg="remainder with .long() should be rejected")
 
 
-fn test_remainder_guard_only_one() raises:
+def test_remainder_guard_only_one() raises:
     """Tests that only one remainder positional is allowed."""
     var command = Command("test", "Test app")
     command.add_argument(Argument("rest1", help="Rest 1").remainder())
@@ -162,7 +162,7 @@ fn test_remainder_guard_only_one() raises:
     assert_true(failed, msg="second remainder should be rejected")
 
 
-fn test_remainder_with_dashes_in_values() raises:
+def test_remainder_with_dashes_in_values() raises:
     """Tests that remainder captures tokens like --unknown and -x."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -191,7 +191,7 @@ fn test_remainder_with_dashes_in_values() raises:
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
-fn test_parse_known_basic() raises:
+def test_parse_known_basic() raises:
     """Tests that unknown options are collected instead of erroring."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -210,7 +210,7 @@ fn test_parse_known_basic() raises:
     assert_equal(unknown[1], "-x")
 
 
-fn test_parse_known_no_unknowns() raises:
+def test_parse_known_no_unknowns() raises:
     """Tests parse_known_arguments with all args recognized."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -228,7 +228,7 @@ fn test_parse_known_no_unknowns() raises:
     assert_equal(len(unknown), 0)
 
 
-fn test_parse_known_mixed_with_positionals() raises:
+def test_parse_known_mixed_with_positionals() raises:
     """Tests parse_known_arguments with positionals and unknown options."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -252,7 +252,7 @@ fn test_parse_known_mixed_with_positionals() raises:
     assert_equal(unknown[0], "--unknown-flag")
 
 
-fn test_parse_known_unknown_with_value() raises:
+def test_parse_known_unknown_with_value() raises:
     """Tests that unknown long options with = syntax are collected."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -267,7 +267,7 @@ fn test_parse_known_unknown_with_value() raises:
     assert_equal(unknown[0], "--color=auto")
 
 
-fn test_parse_known_preserves_validation() raises:
+def test_parse_known_preserves_validation() raises:
     """Tests that parse_known_arguments still validates required args."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -288,7 +288,7 @@ fn test_parse_known_preserves_validation() raises:
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
-fn test_hyphen_value_positional() raises:
+def test_hyphen_value_positional() raises:
     """Tests that '-' is accepted as a positional value."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -305,7 +305,7 @@ fn test_hyphen_value_positional() raises:
     assert_equal(result.get_string("input"), "-")
 
 
-fn test_hyphen_value_multi_char_short() raises:
+def test_hyphen_value_multi_char_short() raises:
     """Tests that '-x' is consumed as a positional when allow_hyphen_values
     is set and '-x' is NOT a known option.  Without the flag, '-x' would
     be treated as an unknown short option and error."""
@@ -322,7 +322,7 @@ fn test_hyphen_value_multi_char_short() raises:
     assert_equal(result.get_string("pattern"), "-foo")
 
 
-fn test_hyphen_value_long_token() raises:
+def test_hyphen_value_long_token() raises:
     """Tests that '--unknown-thing' is consumed as a positional when
     allow_hyphen_values is set and it is not a known long option."""
     var command = Command("test", "Test app")
@@ -338,7 +338,7 @@ fn test_hyphen_value_long_token() raises:
     assert_equal(result.get_string("expr"), "--not-an-option")
 
 
-fn test_hyphen_value_known_option_still_parsed() raises:
+def test_hyphen_value_known_option_still_parsed() raises:
     """Tests that a known option is still parsed normally even when the
     current positional has allow_hyphen_values."""
     var command = Command("test", "Test app")
@@ -362,7 +362,7 @@ fn test_hyphen_value_known_option_still_parsed() raises:
     assert_equal(result.get_string("pattern"), "-foo")
 
 
-fn test_hyphen_value_without_flag_errors() raises:
+def test_hyphen_value_without_flag_errors() raises:
     """Tests that without allow_hyphen_values, '-x' raises an error."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -378,7 +378,7 @@ fn test_hyphen_value_without_flag_errors() raises:
     assert_true(failed, msg="'-x' without allow_hyphen_values should error")
 
 
-fn test_hyphen_value_with_other_positional() raises:
+def test_hyphen_value_with_other_positional() raises:
     """Tests '-' alongside a regular positional."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -397,7 +397,7 @@ fn test_hyphen_value_with_other_positional() raises:
     assert_equal(result.get_string("output"), "result.csv")
 
 
-fn test_hyphen_value_with_option() raises:
+def test_hyphen_value_with_option() raises:
     """Tests that '-' works as a value for a named option."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -413,7 +413,7 @@ fn test_hyphen_value_with_option() raises:
     assert_equal(result.get_string("file"), "-")
 
 
-fn test_hyphen_value_in_parse_known() raises:
+def test_hyphen_value_in_parse_known() raises:
     """Tests allow_hyphen_values with parse_known_arguments: unknown
     dash tokens go to positional instead of unknown_args."""
     var command = Command("test", "Test app")
@@ -434,7 +434,7 @@ fn test_hyphen_value_in_parse_known() raises:
     assert_equal(len(result.get_unknown_args()), 0)
 
 
-fn test_remainder_guard_positional_after() raises:
+def test_remainder_guard_positional_after() raises:
     """Tests that adding a positional after a remainder is rejected."""
     var command = Command("test", "Test app")
     command.add_argument(Argument("rest", help="Rest").remainder())
@@ -451,5 +451,5 @@ fn test_remainder_guard_positional_after() raises:
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
-fn main() raises:
+def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_remainder_known.mojo
+++ b/tests/test_remainder_known.mojo
@@ -1,7 +1,7 @@
 """Tests for argmojo — remainder nargs, parse_known_arguments, 
 value_name rename, allow_hyphen_values."""
 
-from testing import assert_true, assert_false, assert_equal, TestSuite
+from std.testing import assert_true, assert_false, assert_equal, TestSuite
 import argmojo
 from argmojo import Argument, Command, ParseResult
 

--- a/tests/test_response_file.mojo
+++ b/tests/test_response_file.mojo
@@ -8,8 +8,8 @@ still present in command.mojo and the tests here remain intact for when
 the compiler bug is fixed.
 """
 
-from testing import assert_true, assert_false, assert_equal, TestSuite
-from os import remove
+from std.testing import assert_true, assert_false, assert_equal, TestSuite
+from std.os import remove
 import argmojo
 from argmojo import Argument, Command, ParseResult
 

--- a/tests/test_response_file.mojo
+++ b/tests/test_response_file.mojo
@@ -17,13 +17,13 @@ from argmojo import Argument, Command, ParseResult
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 
-fn _write_file(path: String, content: String) raises:
+def _write_file(path: String, content: String) raises:
     """Write a string to a file (overwrite)."""
     with open(path, "w") as f:
         f.write(content)
 
 
-fn _remove_file(path: String):
+def _remove_file(path: String):
     """Remove a file, ignoring errors."""
     try:
         remove(path)
@@ -31,7 +31,7 @@ fn _remove_file(path: String):
         pass
 
 
-fn _make_command() -> Command:
+def _make_command() -> Command:
     """Create a simple command with response_file_prefix enabled."""
     var command = Command("test", "Test app")
     command.response_file_prefix()  # default '@'
@@ -41,7 +41,7 @@ fn _make_command() -> Command:
 # ── Basic expansion ──────────────────────────────────────────────────────────
 
 
-fn test_response_file_basic() raises:
+def test_response_file_basic() raises:
     """@args.txt expands file lines as arguments."""
     var path = "/tmp/_argmojo_test_rf_basic.txt"
     _write_file(path, "--verbose\n--output=file.txt\n")
@@ -59,7 +59,7 @@ fn test_response_file_basic() raises:
     _remove_file(path)
 
 
-fn test_response_file_mixed_with_direct_args() raises:
+def test_response_file_mixed_with_direct_args() raises:
     """Response file args are mixed with direct CLI args."""
     var path = "/tmp/_argmojo_test_rf_mixed.txt"
     _write_file(path, "--output=file.txt\n")
@@ -77,7 +77,7 @@ fn test_response_file_mixed_with_direct_args() raises:
     _remove_file(path)
 
 
-fn test_response_file_positional_args() raises:
+def test_response_file_positional_args() raises:
     """Response file can contain positional arguments."""
     var path = "/tmp/_argmojo_test_rf_pos.txt"
     _write_file(path, "hello\nworld\n")
@@ -96,7 +96,7 @@ fn test_response_file_positional_args() raises:
 # ── Comments and blank lines ────────────────────────────────────────────────
 
 
-fn test_response_file_comments_and_blanks() raises:
+def test_response_file_comments_and_blanks() raises:
     """Lines starting with # and blank lines are skipped."""
     var path = "/tmp/_argmojo_test_rf_comments.txt"
     _write_file(
@@ -122,7 +122,7 @@ fn test_response_file_comments_and_blanks() raises:
     _remove_file(path)
 
 
-fn test_response_file_whitespace_stripped() raises:
+def test_response_file_whitespace_stripped() raises:
     """Leading/trailing whitespace per line is stripped."""
     var path = "/tmp/_argmojo_test_rf_ws.txt"
     _write_file(path, "  --verbose  \n  --output=file.txt  \n")
@@ -143,7 +143,7 @@ fn test_response_file_whitespace_stripped() raises:
 # ── Escape doubled prefix ───────────────────────────────────────────────────
 
 
-fn test_response_file_escape_cli() raises:
+def test_response_file_escape_cli() raises:
     """@@literal on the CLI is treated as @literal (not a file)."""
     var command = _make_command()
     command.add_argument(Argument("user", help="User").positional())
@@ -153,7 +153,7 @@ fn test_response_file_escape_cli() raises:
     assert_equal(result.get_string("user"), "@admin")
 
 
-fn test_response_file_escape_in_file() raises:
+def test_response_file_escape_in_file() raises:
     """@@literal inside a response file is treated as @literal."""
     var path = "/tmp/_argmojo_test_rf_escape.txt"
     _write_file(path, "@@admin\n")
@@ -170,7 +170,7 @@ fn test_response_file_escape_in_file() raises:
 # ── Recursive (nested) response files ───────────────────────────────────────
 
 
-fn test_response_file_recursive() raises:
+def test_response_file_recursive() raises:
     """Response files can reference other response files."""
     var path1 = "/tmp/_argmojo_test_rf_r1.txt"
     var path2 = "/tmp/_argmojo_test_rf_r2.txt"
@@ -194,7 +194,7 @@ fn test_response_file_recursive() raises:
 # ── Error cases ──────────────────────────────────────────────────────────────
 
 
-fn test_response_file_not_found() raises:
+def test_response_file_not_found() raises:
     """Error when response file does not exist."""
     var command = _make_command()
 
@@ -212,7 +212,7 @@ fn test_response_file_not_found() raises:
     assert_true(caught, msg="Should have raised for missing response file")
 
 
-fn test_response_file_max_depth() raises:
+def test_response_file_max_depth() raises:
     """Error when nesting depth exceeds the limit."""
     var path = "/tmp/_argmojo_test_rf_loop.txt"
     # File references itself — would loop forever without depth limit.
@@ -239,7 +239,7 @@ fn test_response_file_max_depth() raises:
 # ── Disabled by default ─────────────────────────────────────────────────────
 
 
-fn test_response_file_disabled_by_default() raises:
+def test_response_file_disabled_by_default() raises:
     """Without response_file_prefix(), @token is treated as a regular positional.
     """
     var command = Command("test", "Test app")
@@ -253,7 +253,7 @@ fn test_response_file_disabled_by_default() raises:
 # ── Custom prefix ────────────────────────────────────────────────────────────
 
 
-fn test_response_file_custom_prefix() raises:
+def test_response_file_custom_prefix() raises:
     """A custom prefix (e.g. '+') can be used instead of '@'."""
     var path = "/tmp/_argmojo_test_rf_custom.txt"
     _write_file(path, "--verbose\n")
@@ -273,7 +273,7 @@ fn test_response_file_custom_prefix() raises:
 # ── Multiple response files ─────────────────────────────────────────────────
 
 
-fn test_response_file_multiple() raises:
+def test_response_file_multiple() raises:
     """Multiple @file arguments are all expanded."""
     var path1 = "/tmp/_argmojo_test_rf_m1.txt"
     var path2 = "/tmp/_argmojo_test_rf_m2.txt"
@@ -297,7 +297,7 @@ fn test_response_file_multiple() raises:
 # ── Response file with short options ─────────────────────────────────────────
 
 
-fn test_response_file_short_options() raises:
+def test_response_file_short_options() raises:
     """Response file can contain short options."""
     var path = "/tmp/_argmojo_test_rf_short.txt"
     _write_file(path, "-v\n-o\nfile.txt\n")
@@ -323,7 +323,7 @@ fn test_response_file_short_options() raises:
 # ── Response file with values containing spaces ─────────────────────────────
 
 
-fn test_response_file_value_one_per_line() raises:
+def test_response_file_value_one_per_line() raises:
     """Each line becomes one argument, allowing values with spaces within the line.
     """
     var path = "/tmp/_argmojo_test_rf_oneline.txt"
@@ -341,7 +341,7 @@ fn test_response_file_value_one_per_line() raises:
 # ── Empty response file ─────────────────────────────────────────────────────
 
 
-fn test_response_file_empty() raises:
+def test_response_file_empty() raises:
     """Empty response file contributes no arguments."""
     var path = "/tmp/_argmojo_test_rf_empty.txt"
     _write_file(path, "")
@@ -360,7 +360,7 @@ fn test_response_file_empty() raises:
 # ── Response file preserves argv[0] ─────────────────────────────────────────
 
 
-fn test_response_file_preserves_argv0() raises:
+def test_response_file_preserves_argv0() raises:
     """Tests argv[0] (program name) is never expanded even if it starts with @.
     """
     var path = "/tmp/_argmojo_test_rf_argv0.txt"
@@ -383,5 +383,5 @@ fn test_response_file_preserves_argv0() raises:
     _remove_file(path)
 
 
-fn main() raises:
+def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_subcommands.mojo
+++ b/tests/test_subcommands.mojo
@@ -41,7 +41,7 @@ from argmojo import Argument, Command, ParseResult
 # ── Step 0: _apply_defaults() behavior ───────────────────────────────────────
 
 
-fn test_defaults_named_arg() raises:
+def test_defaults_named_arg() raises:
     """Tests that a named arg with a default gets filled when not provided."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -55,7 +55,7 @@ fn test_defaults_named_arg() raises:
     assert_equal(result.get_string("format"), "json")
 
 
-fn test_defaults_positional_arg() raises:
+def test_defaults_positional_arg() raises:
     """Tests that a positional arg with a default gets filled when not provided.
     """
     var command = Command("test", "Test app")
@@ -72,7 +72,7 @@ fn test_defaults_positional_arg() raises:
     assert_equal(result.get_string("path"), ".")
 
 
-fn test_defaults_not_applied_when_provided() raises:
+def test_defaults_not_applied_when_provided() raises:
     """Tests that defaults do not overwrite explicitly provided values."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -86,7 +86,7 @@ fn test_defaults_not_applied_when_provided() raises:
     assert_equal(result.get_string("format"), "csv")
 
 
-fn test_defaults_multiple_positional() raises:
+def test_defaults_multiple_positional() raises:
     """Tests defaults with multiple positional args where some are provided."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -106,7 +106,7 @@ fn test_defaults_multiple_positional() raises:
 # ── Step 0: _validate() — required args ──────────────────────────────────────
 
 
-fn test_validate_required_missing() raises:
+def test_validate_required_missing() raises:
     """Tests that a missing required arg raises an error."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -128,7 +128,7 @@ fn test_validate_required_missing() raises:
     assert_true(caught, msg="Should have raised for missing required arg")
 
 
-fn test_validate_required_provided() raises:
+def test_validate_required_provided() raises:
     """Tests that providing a required arg passes validation."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -143,7 +143,7 @@ fn test_validate_required_provided() raises:
 # ── Step 0: _validate() — positional count ───────────────────────────────────
 
 
-fn test_validate_too_many_positionals() raises:
+def test_validate_too_many_positionals() raises:
     """Tests that too many positional args fails validation."""
     var command = Command("test", "Test app")
     command.add_argument(Argument("name", help="Name").positional())
@@ -165,7 +165,7 @@ fn test_validate_too_many_positionals() raises:
 # ── Step 0: _validate() — mutually exclusive ─────────────────────────────────
 
 
-fn test_validate_exclusive_conflict() raises:
+def test_validate_exclusive_conflict() raises:
     """Tests that mutually exclusive args in conflict raise an error."""
     var command = Command("test", "Test app")
     command.add_argument(Argument("json", help="JSON").long["json"]().flag())
@@ -186,7 +186,7 @@ fn test_validate_exclusive_conflict() raises:
     assert_true(caught, msg="Should have raised for exclusive conflict")
 
 
-fn test_validate_exclusive_ok() raises:
+def test_validate_exclusive_ok() raises:
     """Tests that providing only one from exclusive group is fine."""
     var command = Command("test", "Test app")
     command.add_argument(Argument("json", help="JSON").long["json"]().flag())
@@ -202,7 +202,7 @@ fn test_validate_exclusive_ok() raises:
 # ── Step 0: _validate() — required-together ──────────────────────────────────
 
 
-fn test_validate_together_partial() raises:
+def test_validate_together_partial() raises:
     """Tests that providing only some of a required-together group fails."""
     var command = Command("test", "Test app")
     command.add_argument(Argument("user", help="User").long["user"]())
@@ -227,7 +227,7 @@ fn test_validate_together_partial() raises:
 # ── Step 0: _validate() — one-required ───────────────────────────────────────
 
 
-fn test_validate_one_required_none() raises:
+def test_validate_one_required_none() raises:
     """Tests that providing none from a one-required group fails."""
     var command = Command("test", "Test app")
     command.add_argument(Argument("json", help="JSON").long["json"]().flag())
@@ -251,7 +251,7 @@ fn test_validate_one_required_none() raises:
 # ── Step 0: _validate() — conditional requirements ───────────────────────────
 
 
-fn test_validate_conditional_triggered() raises:
+def test_validate_conditional_triggered() raises:
     """Tests that conditional requirement fires when condition is present."""
     var command = Command("test", "Test app")
     command.add_argument(Argument("save", help="Save").long["save"]().flag())
@@ -271,7 +271,7 @@ fn test_validate_conditional_triggered() raises:
     assert_true(caught, msg="Should have raised for conditional requirement")
 
 
-fn test_validate_conditional_satisfied() raises:
+def test_validate_conditional_satisfied() raises:
     """Tests that conditional requirement passes when both are provided."""
     var command = Command("test", "Test app")
     command.add_argument(Argument("save", help="Save").long["save"]().flag())
@@ -287,7 +287,7 @@ fn test_validate_conditional_satisfied() raises:
 # ── Step 0: _validate() — numeric range ──────────────────────────────────────
 
 
-fn test_validate_range_out_of_bounds() raises:
+def test_validate_range_out_of_bounds() raises:
     """Tests that a value outside numeric range fails validation."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -307,7 +307,7 @@ fn test_validate_range_out_of_bounds() raises:
     assert_true(caught, msg="Should have raised for out-of-range value")
 
 
-fn test_validate_range_in_bounds() raises:
+def test_validate_range_in_bounds() raises:
     """Tests that a value within numeric range passes validation."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -322,7 +322,7 @@ fn test_validate_range_in_bounds() raises:
 # ── Step 0: full round-trip (defaults + validation combined) ─────────────────
 
 
-fn test_defaults_then_validation_combined() raises:
+def test_defaults_then_validation_combined() raises:
     """Tests that defaults are applied BEFORE validation runs.
 
     A required-together group where one arg has a default: providing
@@ -342,7 +342,7 @@ fn test_defaults_then_validation_combined() raises:
     assert_false(result.has("pass"))
 
 
-fn test_full_parse_with_defaults_and_range() raises:
+def test_full_parse_with_defaults_and_range() raises:
     """Tests that default values also pass range validation."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -361,13 +361,13 @@ fn test_full_parse_with_defaults_and_range() raises:
 # ── Step 1: Data model — Command.subcommands field ───────────────────────────
 
 
-fn test_command_subcommands_empty_initially() raises:
+def test_command_subcommands_empty_initially() raises:
     """Tests that a fresh Command has no subcommands registered."""
     var app = Command("app", "My app")
     assert_equal(len(app.subcommands), 0)
 
 
-fn test_add_subcommand_single() raises:
+def test_add_subcommand_single() raises:
     """Tests that add_subcommand() appends one subcommand to the list.
 
     After the first add_subcommand() call the auto-added 'help' subcommand
@@ -384,7 +384,7 @@ fn test_add_subcommand_single() raises:
     assert_equal(app.subcommands[idx].description, "Search for patterns")
 
 
-fn test_add_subcommand_multiple() raises:
+def test_add_subcommand_multiple() raises:
     """Tests that multiple subcommands can be registered and are ordered.
 
     'help' is auto-inserted at index 0; user subcommands follow in
@@ -405,7 +405,7 @@ fn test_add_subcommand_multiple() raises:
     assert_equal(app.subcommands[3].name, "build")
 
 
-fn test_add_subcommand_preserves_child_args() raises:
+def test_add_subcommand_preserves_child_args() raises:
     """Tests that a subcommand's own arg definitions survive transfer.
 
     Total count is 2 (help at [0] + search at [1]).
@@ -426,7 +426,7 @@ fn test_add_subcommand_preserves_child_args() raises:
     assert_equal(app.subcommands[idx].args[1].name, "max-depth")
 
 
-fn test_subcommand_has_own_version() raises:
+def test_subcommand_has_own_version() raises:
     """Tests that a subcommand can have its own version string."""
     var app = Command("app", "My app", version="1.0.0")
     var sub = Command("serve", "Start server", version="2.0.0-beta")
@@ -439,27 +439,27 @@ fn test_subcommand_has_own_version() raises:
 # ── Step 1: Data model — ParseResult.subcommand field ────────────────────────
 
 
-fn test_parseresult_subcommand_defaults_empty() raises:
+def test_parseresult_subcommand_defaults_empty() raises:
     """Tests that ParseResult.subcommand defaults to empty string."""
     var result = ParseResult()
     assert_equal(result.subcommand, "")
 
 
-fn test_parseresult_subcommand_can_be_set() raises:
+def test_parseresult_subcommand_can_be_set() raises:
     """Tests that ParseResult.subcommand can be assigned a name."""
     var result = ParseResult()
     result.subcommand = "search"
     assert_equal(result.subcommand, "search")
 
 
-fn test_parseresult_no_subcommand_result_initially() raises:
+def test_parseresult_no_subcommand_result_initially() raises:
     """Tests that has_subcommand_result() returns False on a fresh ParseResult.
     """
     var result = ParseResult()
     assert_false(result.has_subcommand_result())
 
 
-fn test_parseresult_get_subcommand_result_raises_when_empty() raises:
+def test_parseresult_get_subcommand_result_raises_when_empty() raises:
     """Tests that get_subcommand_result() raises when no child result exists."""
     var result = ParseResult()
     var caught = False
@@ -474,7 +474,7 @@ fn test_parseresult_get_subcommand_result_raises_when_empty() raises:
     assert_true(caught, msg="Should have raised for empty subcommand result")
 
 
-fn test_parseresult_subcommand_result_stored_and_retrieved() raises:
+def test_parseresult_subcommand_result_stored_and_retrieved() raises:
     """Tests that a child ParseResult can be stored and retrieved."""
     var parent = ParseResult()
     var child = ParseResult()
@@ -486,7 +486,7 @@ fn test_parseresult_subcommand_result_stored_and_retrieved() raises:
     assert_equal(retrieved.get_string("pattern"), "hello")
 
 
-fn test_parseresult_str_includes_subcommand() raises:
+def test_parseresult_str_includes_subcommand() raises:
     """Tests that __str__ includes the subcommand name when set."""
     var result = ParseResult()
     result.subcommand = "build"
@@ -494,7 +494,7 @@ fn test_parseresult_str_includes_subcommand() raises:
     assert_true("build" in s, msg="__str__ should include the subcommand name")
 
 
-fn test_parseresult_str_no_subcommand_section_when_empty() raises:
+def test_parseresult_str_no_subcommand_section_when_empty() raises:
     """Tests that __str__ omits the subcommand when it is empty."""
     var result = ParseResult()
     var s = String(result)
@@ -504,7 +504,7 @@ fn test_parseresult_str_no_subcommand_section_when_empty() raises:
     )
 
 
-fn test_parseresult_copy_preserves_subcommand() raises:
+def test_parseresult_copy_preserves_subcommand() raises:
     """Tests that copying a ParseResult preserves subcommand and child result.
     """
     var original = ParseResult()
@@ -519,7 +519,7 @@ fn test_parseresult_copy_preserves_subcommand() raises:
     assert_equal(copy.get_subcommand_result().get_string("name"), "myproject")
 
 
-fn test_parse_without_subcommands_unaffected() raises:
+def test_parse_without_subcommands_unaffected() raises:
     """Tests that parse_arguments() results are unchanged when no subcommands exist.
     """
     var command = Command("app", "My app")
@@ -539,7 +539,7 @@ fn test_parse_without_subcommands_unaffected() raises:
 # ── Step 2: Parse routing ─────────────────────────────────────────────────────
 
 
-fn test_dispatch_basic() raises:
+def test_dispatch_basic() raises:
     """Tests basic subcommand dispatch: app search pattern."""
     var app = Command("app", "My app")
     var search = Command("search", "Search")
@@ -556,7 +556,7 @@ fn test_dispatch_basic() raises:
     assert_equal(sub.get_string("pattern"), "hello")
 
 
-fn test_dispatch_root_flag_before_subcommand() raises:
+def test_dispatch_root_flag_before_subcommand() raises:
     """Tests that root flags before subcommand are parsed by root."""
     var app = Command("app", "My app")
     app.add_argument(
@@ -579,7 +579,7 @@ fn test_dispatch_root_flag_before_subcommand() raises:
     assert_equal(sub.get_string("pattern"), "hello")
 
 
-fn test_dispatch_root_short_flag_before_subcommand() raises:
+def test_dispatch_root_short_flag_before_subcommand() raises:
     """Tests that root short flags before subcommand are parsed by root."""
     var app = Command("app", "My app")
     app.add_argument(
@@ -602,7 +602,7 @@ fn test_dispatch_root_short_flag_before_subcommand() raises:
     assert_equal(sub.get_string("pattern"), "hello")
 
 
-fn test_dispatch_child_flag() raises:
+def test_dispatch_child_flag() raises:
     """Tests that child flags are parsed by the child command."""
     var app = Command("app", "My app")
     var search = Command("search", "Search")
@@ -622,7 +622,7 @@ fn test_dispatch_child_flag() raises:
     assert_equal(sub.get_string("pattern"), "hello")
 
 
-fn test_dispatch_child_flag_short() raises:
+def test_dispatch_child_flag_short() raises:
     """Tests that child short flags are parsed by the child command."""
     var app = Command("app", "My app")
     var search = Command("search", "Search")
@@ -642,7 +642,7 @@ fn test_dispatch_child_flag_short() raises:
     assert_equal(sub.get_string("pattern"), "hello")
 
 
-fn test_dispatch_double_dash_stops_dispatch() raises:
+def test_dispatch_double_dash_stops_dispatch() raises:
     """Tests that -- before subcommand name prevents dispatch."""
     var app = Command("app", "My app")
     app.allow_positional_with_subcommands()
@@ -659,7 +659,7 @@ fn test_dispatch_double_dash_stops_dispatch() raises:
     assert_equal(result.get_string("arg1"), "search")
 
 
-fn test_dispatch_unknown_token_is_positional() raises:
+def test_dispatch_unknown_token_is_positional() raises:
     """Tests that an unknown token (no subcommand match) is treated as positional.
     """
     var app = Command("app", "My app")
@@ -674,7 +674,7 @@ fn test_dispatch_unknown_token_is_positional() raises:
     assert_equal(result.get_string("name"), "hello")
 
 
-fn test_dispatch_two_subcommands_route_first() raises:
+def test_dispatch_two_subcommands_route_first() raises:
     """Tests routing to the first of two registered subcommands."""
     var app = Command("app", "My app")
     var search = Command("search", "Search")
@@ -692,7 +692,7 @@ fn test_dispatch_two_subcommands_route_first() raises:
     assert_equal(result.get_subcommand_result().get_string("pattern"), "foo")
 
 
-fn test_dispatch_two_subcommands_route_second() raises:
+def test_dispatch_two_subcommands_route_second() raises:
     """Tests routing to the second of two registered subcommands."""
     var app = Command("app", "My app")
     var search = Command("search", "Search")
@@ -710,7 +710,7 @@ fn test_dispatch_two_subcommands_route_second() raises:
     assert_equal(result.get_subcommand_result().get_string("name"), "myproject")
 
 
-fn test_dispatch_child_validation_error() raises:
+def test_dispatch_child_validation_error() raises:
     """Tests that missing required child arg raises an error."""
     var app = Command("app", "My app")
     var search = Command("search", "Search")
@@ -732,7 +732,7 @@ fn test_dispatch_child_validation_error() raises:
     assert_true(caught, msg="Should have raised for missing child required arg")
 
 
-fn test_dispatch_child_default_value() raises:
+def test_dispatch_child_default_value() raises:
     """Tests that child defaults are applied during child parse.
 
     Required positionals are declared first so the single token fills
@@ -755,7 +755,7 @@ fn test_dispatch_child_default_value() raises:
     assert_equal(sub.get_string("path"), ".")
 
 
-fn test_dispatch_no_subcommand_when_none_match() raises:
+def test_dispatch_no_subcommand_when_none_match() raises:
     """Tests that subcommand field stays empty when no token matches."""
     var app = Command("app", "My app")
     app.allow_positional_with_subcommands()
@@ -769,7 +769,7 @@ fn test_dispatch_no_subcommand_when_none_match() raises:
     assert_false(result.has_subcommand_result())
 
 
-fn test_dispatch_root_still_validates_own_required() raises:
+def test_dispatch_root_still_validates_own_required() raises:
     """Tests that root still validates its own required args after dispatch."""
     var app = Command("app", "My app")
     app.add_argument(
@@ -792,7 +792,7 @@ fn test_dispatch_root_still_validates_own_required() raises:
     assert_true(caught, msg="Root required arg should still be validated")
 
 
-fn test_dispatch_child_receives_no_root_tokens() raises:
+def test_dispatch_child_receives_no_root_tokens() raises:
     """Tests tokens before subcommand are NOT forwarded to the child."""
     var app = Command("app", "My app")
     app.add_argument(
@@ -819,7 +819,7 @@ fn test_dispatch_child_receives_no_root_tokens() raises:
 # ── Step 2b: auto-registered 'help' subcommand ───────────────────────────────
 
 
-fn test_help_sub_auto_added() raises:
+def test_help_sub_auto_added() raises:
     """Tests that add_subcommand() automatically inserts a 'help' subcommand."""
     var app = Command("app", "My app")
     var search = Command("search", "Search")
@@ -832,7 +832,7 @@ fn test_help_sub_auto_added() raises:
     assert_true(app.subcommands[help_idx]._is_help_subcommand)
 
 
-fn test_help_sub_added_only_once() raises:
+def test_help_sub_added_only_once() raises:
     """Tests that 'help' is not duplicated on multiple add_subcommand() calls.
     """
     var app = Command("app", "My app")
@@ -849,7 +849,7 @@ fn test_help_sub_added_only_once() raises:
     assert_equal(count, 1)
 
 
-fn test_help_sub_appears_after_user_subs() raises:
+def test_help_sub_appears_after_user_subs() raises:
     """Tests that 'help' is at index 0 and user subs follow in order."""
     var app = Command("app", "My app")
     app.add_subcommand(Command("search", "Search"))
@@ -861,7 +861,7 @@ fn test_help_sub_appears_after_user_subs() raises:
     assert_equal(app.subcommands[2].name, "init")
 
 
-fn test_help_sub_flag_on_user_subs() raises:
+def test_help_sub_flag_on_user_subs() raises:
     """Tests that user-registered subcommands do NOT have the flag set."""
     var app = Command("app", "My app")
     app.add_subcommand(Command("search", "Search"))
@@ -871,7 +871,7 @@ fn test_help_sub_flag_on_user_subs() raises:
     assert_false(app.subcommands[search_idx]._is_help_subcommand)
 
 
-fn test_disable_help_sub_before_add() raises:
+def test_disable_help_sub_before_add() raises:
     """Tests that disable_help_subcommand() before add_subcommand() prevents insertion.
     """
     var app = Command("app", "My app")
@@ -883,7 +883,7 @@ fn test_disable_help_sub_before_add() raises:
     assert_equal(app._find_subcommand("help"), -1)
 
 
-fn test_disable_help_sub_after_add() raises:
+def test_disable_help_sub_after_add() raises:
     """Tests that disable_help_subcommand() after add_subcommand() removes it.
     """
     var app = Command("app", "My app")
@@ -898,7 +898,7 @@ fn test_disable_help_sub_after_add() raises:
     assert_equal(app._find_subcommand("help"), -1)
 
 
-fn test_dispatch_unaffected_by_help_sub() raises:
+def test_dispatch_unaffected_by_help_sub() raises:
     """Tests that normal dispatch still works when 'help' sub is auto-added."""
     var app = Command("app", "My app")
     var search = Command("search", "Search")
@@ -914,7 +914,7 @@ fn test_dispatch_unaffected_by_help_sub() raises:
     assert_equal(child.get_string("pattern"), "TODO")
 
 
-fn test_help_sub_disabled_unknown_word_becomes_positional() raises:
+def test_help_sub_disabled_unknown_word_becomes_positional() raises:
     """Tests that with help disabled, 'help' token is treated as a positional.
     """
     var app = Command("app", "My app")
@@ -933,7 +933,7 @@ fn test_help_sub_disabled_unknown_word_becomes_positional() raises:
 # ── Error handling ───────────────────────────────────────────────────────────
 
 
-fn test_unknown_subcommand_error_no_positionals() raises:
+def test_unknown_subcommand_error_no_positionals() raises:
     """Tests that an unknown subcommand name gives an error when no positional args are defined.
     """
     var app = Command("app", "My app")
@@ -957,7 +957,7 @@ fn test_unknown_subcommand_error_no_positionals() raises:
     assert_true(caught, msg="Should have raised for unknown subcommand")
 
 
-fn test_unknown_token_becomes_positional_when_positionals_defined() raises:
+def test_unknown_token_becomes_positional_when_positionals_defined() raises:
     """Tests that unknown token becomes positional when root has positional args.
     """
     var app = Command("app", "My app")
@@ -972,7 +972,7 @@ fn test_unknown_token_becomes_positional_when_positionals_defined() raises:
     assert_equal(result.get_string("query"), "foo")
 
 
-fn test_child_error_includes_command_path() raises:
+def test_child_error_includes_command_path() raises:
     """Tests that child parse errors include the full command path in stderr."""
     var app = Command("app", "My app")
     var search = Command("search", "Search")
@@ -997,7 +997,7 @@ fn test_child_error_includes_command_path() raises:
     assert_true(caught, msg="Should have raised for missing required in child")
 
 
-fn test_unknown_subcommand_error_excludes_help_sub() raises:
+def test_unknown_subcommand_error_excludes_help_sub() raises:
     """Tests that the error message for unknown subcommand does not list 'help'.
     """
     var app = Command("app", "My app")
@@ -1031,7 +1031,7 @@ fn test_unknown_subcommand_error_excludes_help_sub() raises:
 # ── Positional + subcommand guard ────────────────────────────────────────────
 
 
-fn test_add_positional_after_subcommand_raises() raises:
+def test_add_positional_after_subcommand_raises() raises:
     """Tests that adding a positional after a subcommand raises without opt-in.
     """
     var app = Command("app", "My app")
@@ -1054,7 +1054,7 @@ fn test_add_positional_after_subcommand_raises() raises:
     assert_true(caught, msg="Should have raised")
 
 
-fn test_add_subcommand_after_positional_raises() raises:
+def test_add_subcommand_after_positional_raises() raises:
     """Tests that adding a subcommand after a positional raises without opt-in.
     """
     var app = Command("app", "My app")
@@ -1077,7 +1077,7 @@ fn test_add_subcommand_after_positional_raises() raises:
     assert_true(caught, msg="Should have raised")
 
 
-fn test_allow_positional_with_subcommands_opt_in() raises:
+def test_allow_positional_with_subcommands_opt_in() raises:
     """Tests that with opt-in, both directions work without error."""
     # Direction 1: positional first, then subcommand.
     var app1 = Command("app", "My app")
@@ -1099,7 +1099,7 @@ fn test_allow_positional_with_subcommands_opt_in() raises:
     assert_equal(result.get_string("query"), "hello")
 
 
-fn test_non_positional_args_unaffected_by_guard() raises:
+def test_non_positional_args_unaffected_by_guard() raises:
     """Tests that adding non-positional (flags/options) with subcommands
     does not trigger the guard, even without opt-in."""
     var app = Command("app", "My app")
@@ -1115,13 +1115,13 @@ fn test_non_positional_args_unaffected_by_guard() raises:
 # ── Step 5: Subcommand aliases ───────────────────────────────────────────────
 
 
-fn test_command_aliases_empty_by_default() raises:
+def test_command_aliases_empty_by_default() raises:
     """Tests that a fresh Command has no aliases registered."""
     var sub = Command("clone", "Clone a repo")
     assert_equal(len(sub._command_aliases), 0)
 
 
-fn test_command_aliases_builder() raises:
+def test_command_aliases_builder() raises:
     """Tests that command_aliases() stores the provided names."""
     var sub = Command("clone", "Clone a repo")
     var names: List[String] = ["cl", "cln"]
@@ -1131,7 +1131,7 @@ fn test_command_aliases_builder() raises:
     assert_equal(sub._command_aliases[1], "cln")
 
 
-fn test_alias_dispatch_basic() raises:
+def test_alias_dispatch_basic() raises:
     """Tests that typing an alias dispatches to the correct subcommand."""
     var app = Command("app", "My app")
     var clone = Command("clone", "Clone a repo")
@@ -1149,7 +1149,7 @@ fn test_alias_dispatch_basic() raises:
     assert_equal(sub_result.get_string("url"), "https://example.com/repo.git")
 
 
-fn test_alias_stores_canonical_name() raises:
+def test_alias_stores_canonical_name() raises:
     """Tests that result.subcommand holds the canonical name, not the alias."""
     var app = Command("app", "My app")
     var commit = Command("commit", "Record changes")
@@ -1163,7 +1163,7 @@ fn test_alias_stores_canonical_name() raises:
     assert_equal(result.subcommand, "commit")
 
 
-fn test_alias_dispatch_with_child_flags() raises:
+def test_alias_dispatch_with_child_flags() raises:
     """Tests that child flags parse correctly when dispatched via alias."""
     var app = Command("app", "My app")
     var commit = Command("commit", "Record changes")
@@ -1183,7 +1183,7 @@ fn test_alias_dispatch_with_child_flags() raises:
     assert_true(sub.get_flag("amend"))
 
 
-fn test_alias_primary_name_still_works() raises:
+def test_alias_primary_name_still_works() raises:
     """Tests that the primary name still dispatches correctly alongside aliases.
     """
     var app = Command("app", "My app")
@@ -1197,7 +1197,7 @@ fn test_alias_primary_name_still_works() raises:
     assert_equal(result.subcommand, "clone")
 
 
-fn test_alias_find_subcommand() raises:
+def test_alias_find_subcommand() raises:
     """Tests that _find_subcommand() returns the correct index for aliases."""
     var app = Command("app", "My app")
     var search = Command("search", "Search")
@@ -1216,7 +1216,7 @@ fn test_alias_find_subcommand() raises:
     assert_equal(idx_none, -1)
 
 
-fn test_alias_copy_init() raises:
+def test_alias_copy_init() raises:
     """Tests that aliases survive Command copy."""
     var sub = Command("clone", "Clone")
     var aliases: List[String] = ["cl"]
@@ -1226,7 +1226,7 @@ fn test_alias_copy_init() raises:
     assert_equal(sub2._command_aliases[0], "cl")
 
 
-fn test_alias_multiple_subcommands() raises:
+def test_alias_multiple_subcommands() raises:
     """Tests aliases with multiple subcommands don't interfere."""
     var app = Command("app", "My app")
     var clone = Command("clone", "Clone")
@@ -1265,7 +1265,7 @@ fn test_alias_multiple_subcommands() raises:
 # ── Hidden subcommands — dispatch ─────────────────────────────────────────────
 
 
-fn test_hidden_subcommand_still_dispatchable() raises:
+def test_hidden_subcommand_still_dispatchable() raises:
     """Tests that a hidden subcommand can still be dispatched by exact name."""
     var app = Command("app", "Test app")
     var visible = Command("clone", "Clone")
@@ -1285,7 +1285,7 @@ fn test_hidden_subcommand_still_dispatchable() raises:
     assert_equal(sub.get_string("level"), "trace")
 
 
-fn test_hidden_subcommand_alias_dispatchable() raises:
+def test_hidden_subcommand_alias_dispatchable() raises:
     """Tests that a hidden subcommand can be dispatched via its alias."""
     var app = Command("app", "Test app")
     var debug = Command("debug", "Debug")
@@ -1302,7 +1302,7 @@ fn test_hidden_subcommand_alias_dispatchable() raises:
     assert_equal(result.subcommand, "debug")
 
 
-fn test_hidden_is_hidden_field() raises:
+def test_hidden_is_hidden_field() raises:
     """Tests that _is_hidden is False by default and True after hidden()."""
     var cmd = Command("test", "Test")
     assert_false(cmd._is_hidden, msg="_is_hidden should default to False")
@@ -1310,7 +1310,7 @@ fn test_hidden_is_hidden_field() raises:
     assert_true(cmd._is_hidden, msg="hidden() should set _is_hidden to True")
 
 
-fn test_hidden_subcommand_copy() raises:
+def test_hidden_subcommand_copy() raises:
     """Tests that _is_hidden survives Command copy."""
     var cmd = Command("debug", "Debug")
     cmd.hidden()
@@ -1318,5 +1318,5 @@ fn test_hidden_subcommand_copy() raises:
     assert_true(copy._is_hidden, msg="_is_hidden should survive copy")
 
 
-fn main() raises:
+def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_subcommands.mojo
+++ b/tests/test_subcommands.mojo
@@ -9,7 +9,7 @@ Step 1: Validates the data model & API surface for subcommand support:
   - Command.subcommands field (List[Command]) and add_subcommand()
   - ParseResult.subcommand field (String, defaults to "")
   - ParseResult.has_subcommand_result() / get_subcommand_result()
-  - ParseResult.__copyinit__ preserves subcommand data
+  - ParseResult copy initializer preserves subcommand data
   - parse_arguments() unchanged when no subcommands are registered
 
 Step 2: Validates parse-time subcommand routing:
@@ -512,7 +512,7 @@ def test_parseresult_copy_preserves_subcommand() raises:
     var child = ParseResult()
     child._values["name"] = "myproject"
     original._subcommand_results.append(child^)
-    # Copy explicitly (triggers __copyinit__).
+    # Copy explicitly (triggers copy initializer).
     var copy = original.copy()
     assert_equal(copy.subcommand, "init")
     assert_true(copy.has_subcommand_result())

--- a/tests/test_subcommands.mojo
+++ b/tests/test_subcommands.mojo
@@ -34,7 +34,7 @@ Step 2b: Validates the auto-registered 'help' subcommand:
   - Normal dispatch is unaffected by the presence of help subcommand
 """
 
-from testing import assert_true, assert_false, assert_equal, TestSuite
+from std.testing import assert_true, assert_false, assert_equal, TestSuite
 import argmojo
 from argmojo import Argument, Command, ParseResult
 
@@ -1020,7 +1020,7 @@ fn test_unknown_subcommand_error_excludes_help_sub() raises:
         # Check the "Available commands:" part specifically.
         var avail_start = msg.find("Available commands: ")
         if avail_start >= 0:
-            var avail_part = String(msg[avail_start:])
+            var avail_part = String(msg[byte=avail_start:])
             assert_false(
                 "help" in avail_part,
                 msg="'help' sub should not appear in available commands",

--- a/tests/test_typo_suggestions.mojo
+++ b/tests/test_typo_suggestions.mojo
@@ -1,6 +1,6 @@
 """Tests for argmojo — typo suggestions (Levenshtein distance)."""
 
-from testing import assert_true, assert_false, assert_equal, TestSuite
+from std.testing import assert_true, assert_false, assert_equal, TestSuite
 import argmojo
 from argmojo import Argument, Command, ParseResult
 

--- a/tests/test_typo_suggestions.mojo
+++ b/tests/test_typo_suggestions.mojo
@@ -7,7 +7,7 @@ from argmojo import Argument, Command, ParseResult
 # ── Long option typo suggestions ─────────────────────────────────────────────
 
 
-fn test_typo_long_option_suggests() raises:
+def test_typo_long_option_suggests() raises:
     """Tests that a typo like --verbos suggests --verbose."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -38,7 +38,7 @@ fn test_typo_long_option_suggests() raises:
     assert_true(caught, msg="Should have raised error for --vrebose")
 
 
-fn test_typo_long_option_no_suggestion() raises:
+def test_typo_long_option_no_suggestion() raises:
     """Tests that a completely unrelated option doesn't produce a suggestion."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -59,7 +59,7 @@ fn test_typo_long_option_no_suggestion() raises:
     assert_true(caught, msg="Should have raised error for --zzzzzzz")
 
 
-fn test_typo_long_option_single_char_diff() raises:
+def test_typo_long_option_single_char_diff() raises:
     """Tests that a single character difference triggers a suggestion."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -87,7 +87,7 @@ fn test_typo_long_option_single_char_diff() raises:
 # ── Subcommand typo suggestions ──────────────────────────────────────────────
 
 
-fn test_typo_subcommand_suggests() raises:
+def test_typo_subcommand_suggests() raises:
     """Tests that a typo subcommand like 'serach' suggests 'search'."""
     var root = Command("app", "Test app")
     var search = Command("search", "Search items")
@@ -113,7 +113,7 @@ fn test_typo_subcommand_suggests() raises:
     assert_true(caught, msg="Should have raised error for 'serach'")
 
 
-fn test_typo_subcommand_no_suggestion() raises:
+def test_typo_subcommand_no_suggestion() raises:
     """Tests that a completely unrelated subcommand doesn't produce a suggestion.
     """
     var root = Command("app", "Test app")
@@ -137,7 +137,7 @@ fn test_typo_subcommand_no_suggestion() raises:
 # ── Alias typo suggestions ──────────────────────────────────────────────────
 
 
-fn test_typo_alias_suggests() raises:
+def test_typo_alias_suggests() raises:
     """Tests that a typo close to an alias triggers a suggestion."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -161,7 +161,7 @@ fn test_typo_alias_suggests() raises:
     assert_true(caught, msg="Should have raised error for --colro")
 
 
-fn test_typo_subcommand_alias_suggests() raises:
+def test_typo_subcommand_alias_suggests() raises:
     """Tests that a typo near a subcommand alias triggers a suggestion."""
     var root = Command("app", "Test app")
     var clone = Command("clone", "Clone a repo")
@@ -188,7 +188,7 @@ fn test_typo_subcommand_alias_suggests() raises:
     assert_true(caught, msg="Should have raised error for 'clon'")
 
 
-fn test_typo_hidden_subcommand_not_suggested() raises:
+def test_typo_hidden_subcommand_not_suggested() raises:
     """Tests that hidden subcommands are NOT included in typo suggestions."""
     var app = Command("app", "Test app")
     var clone = Command("clone", "Clone a repository")
@@ -218,5 +218,5 @@ fn test_typo_hidden_subcommand_not_suggested() raises:
     )
 
 
-fn main() raises:
+def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_usage.mojo
+++ b/tests/test_usage.mojo
@@ -1,6 +1,6 @@
 """Tests for argmojo — custom usage line."""
 
-from testing import assert_true, assert_false, assert_equal, TestSuite
+from std.testing import assert_true, assert_false, assert_equal, TestSuite
 import argmojo
 from argmojo import Argument, Command, ParseResult
 

--- a/tests/test_usage.mojo
+++ b/tests/test_usage.mojo
@@ -7,7 +7,7 @@ from argmojo import Argument, Command, ParseResult
 # ── Custom usage in help ─────────────────────────────────────────────────────────
 
 
-fn test_custom_usage_in_plain_help() raises:
+def test_custom_usage_in_plain_help() raises:
     """Tests that custom usage appears in plain help output."""
     var cmd = Command("git", "The stupid content tracker")
     cmd.usage("git [-v | --version] [-C <path>] <command> [<args>]")
@@ -19,7 +19,7 @@ fn test_custom_usage_in_plain_help() raises:
     )
 
 
-fn test_custom_usage_in_colored_help() raises:
+def test_custom_usage_in_colored_help() raises:
     """Tests that custom usage appears in colored help output."""
     var cmd = Command("git", "The stupid content tracker")
     cmd.usage("git [-v | --version] [-C <path>] <command> [<args>]")
@@ -32,7 +32,7 @@ fn test_custom_usage_in_colored_help() raises:
     )
 
 
-fn test_custom_usage_replaces_auto_generated() raises:
+def test_custom_usage_replaces_auto_generated() raises:
     """Tests that custom usage replaces the auto-generated positionals."""
     var cmd = Command("myapp", "My app")
     cmd.add_argument(
@@ -60,7 +60,7 @@ fn test_custom_usage_replaces_auto_generated() raises:
 # ── Default usage still works ────────────────────────────────────────────────────
 
 
-fn test_default_usage_when_no_custom() raises:
+def test_default_usage_when_no_custom() raises:
     """Tests that auto-generated usage is used when no custom is set."""
     var cmd = Command("test", "Test app")
     cmd.add_argument(
@@ -74,7 +74,7 @@ fn test_default_usage_when_no_custom() raises:
     )
 
 
-fn test_default_usage_with_optional_positional() raises:
+def test_default_usage_with_optional_positional() raises:
     """Tests auto-generated usage for optional positional."""
     var cmd = Command("test", "Test app")
     cmd.add_argument(
@@ -88,7 +88,7 @@ fn test_default_usage_with_optional_positional() raises:
     )
 
 
-fn test_default_usage_with_subcommands() raises:
+def test_default_usage_with_subcommands() raises:
     """Tests auto-generated usage with subcommands."""
     var app = Command("app", "My app")
     var sub = Command("deploy", "Deploy something")
@@ -104,7 +104,7 @@ fn test_default_usage_with_subcommands() raises:
 # ── Custom usage preserved in copy ───────────────────────────────────────────────
 
 
-fn test_custom_usage_preserved_in_copy() raises:
+def test_custom_usage_preserved_in_copy() raises:
     """Tests that custom usage is preserved when copying a Command."""
     var original = Command("git", "Git")
     original.usage("git [options] <command> [<args>]")
@@ -120,7 +120,7 @@ fn test_custom_usage_preserved_in_copy() raises:
 # ── Custom usage with other features ─────────────────────────────────────────────
 
 
-fn test_custom_usage_with_subcommands() raises:
+def test_custom_usage_with_subcommands() raises:
     """Tests custom usage with subcommands registered."""
     var app = Command("app", "My app")
     app.usage("app [-v] <command>")
@@ -139,7 +139,7 @@ fn test_custom_usage_with_subcommands() raises:
     )
 
 
-fn test_custom_usage_description_still_shown() raises:
+def test_custom_usage_description_still_shown() raises:
     """Tests that description is still shown above custom usage."""
     var cmd = Command("myapp", "A great application")
     cmd.usage("myapp [options]")
@@ -155,7 +155,7 @@ fn test_custom_usage_description_still_shown() raises:
     )
 
 
-fn test_custom_usage_parsing_still_works() raises:
+def test_custom_usage_parsing_still_works() raises:
     """Tests that custom usage doesn't affect parsing behavior."""
     var cmd = Command("test", "Test app")
     cmd.add_argument(
@@ -172,7 +172,7 @@ fn test_custom_usage_parsing_still_works() raises:
     assert_true(result.get_flag("verbose"), msg="--verbose should work")
 
 
-fn test_custom_usage_in_plain_usage_hint() raises:
+def test_custom_usage_in_plain_usage_hint() raises:
     """Tests that custom usage appears in the plain usage hint (_plain_usage).
     """
     var cmd = Command("git", "The stupid content tracker")
@@ -186,5 +186,5 @@ fn test_custom_usage_in_plain_usage_hint() raises:
     )
 
 
-fn main() raises:
+def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
This PR updates ArgMojo’s codebase to compile and run against Mojo v0.26.2, primarily by adapting to stdlib namespace changes and updated language semantics around string slicing and compile-time validation.

**Changes:**
- Bump pixi environment Mojo dependency/lockfile to v0.26.2.
- Migrate imports to `std.*` (e.g., `std.testing`, `std.os`, `std.sys`, `std.ffi`) and adjust string slicing to use `byte=...` where required.
- Replace `constrained[]` / `@parameter` compile-time patterns with `comptime assert` / `comptime if`, and update move/copy initializers to the new `__init__` forms.