### PR TITLE
[doc] Update documents for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A command-line argument parser library for [Mojo](https://www.modular.com/mojo),
  -->
 
 [![Version](https://img.shields.io/github/v/tag/forfudan/argmojo?label=version&color=blue)](https://github.com/forfudan/argmojo/releases)
-[![Mojo](https://img.shields.io/badge/mojo-0.26.1-orange)](https://docs.modular.com/mojo/manual/)
+[![Mojo](https://img.shields.io/badge/mojo-0.26.2-orange)](https://docs.modular.com/mojo/manual/)
 [![pixi](https://img.shields.io/badge/pixi%20add-argmojo-brightgreen)](https://prefix.dev/channels/modular-community/packages/argmojo)
 [![User manual](https://img.shields.io/badge/user-manual-purple)](https://github.com/forfudan/argmojo/wiki)
 
@@ -51,8 +51,34 @@ ArgMojo provides a builder-pattern API for defining and parsing command-line arg
 - **Append / collect action**: `--tag x --tag y` collects repeated options into a list with `.append()`
 - **One-required groups**: require at least one argument from a group (e.g., must provide `--json` or `--yaml`)
 - **Value delimiter**: `--env dev,staging,prod` splits by delimiter into a list with `.delimiter[","]()`
-- **Multi-value options (nargs)**: `--point 10 20` consumes N consecutive values with `.nargs(N)`
+- **Multi-value options (nargs)**: `--point 10 20` consumes N consecutive values with `.number_of_values[N]()`
+- **Key-value map options**: `--define CC=gcc --define CXX=g++` collects key=value pairs with `.map_option()`
+- **Numeric range validation**: `--level 5` checked against `[min, max]` bounds with `.range[1, 10]()`; optional clamping with `.clamp()`
+- **Conditional requirements**: `--output` required when `--save` is present
+- **Aliases**: alternative long names (e.g., `--colour` and `--color`) with `.alias_name["color"]()`
+- **Deprecated arguments**: emit a warning but continue parsing
+- **Custom tips**: add tip lines below the help message
+- **Mutual implication**: `--debug` automatically sets `--verbose` with `.implies()`
+- **Subcommands**: hierarchical commands (`app search`, `app init`), nested subcommands (`app remote add`), persistent (global) flags, subcommand aliases, hidden subcommands
 - **Shell completion script generation**: `generate_completion("bash"|"zsh"|"fish")` produces a complete tab-completion script for your CLI
+- **Typo suggestions**: Levenshtein-distance "did you mean …?" for misspelled options and subcommands
+- **Interactive prompting**: `.prompt()` to interactively ask for missing values
+- **Password / masked input**: `.password()` to hide typed input during prompts
+- **Confirmation option**: `confirmation_option()` to add a `--yes`/`-y` skip-confirmation flag
+- **Argument parents**: `add_parent()` to share argument definitions across commands
+- **Custom usage line**: `usage()` to override the auto-generated usage string
+- **Response files**: `@args.txt` expansion (temporarily disabled due to a Mojo compiler bug)
+- **CJK-aware help alignment**: CJK characters treated as 2-column-wide
+- **CJK full-width auto-correction**: fullwidth `－－ｖｅｒｂｏｓｅ` → `--verbose` with a warning
+- **CJK punctuation detection**: em-dash `——verbose` → `--verbose`
+- **Argument groups**: `.group["Network"]()` to group arguments under dedicated help sections
+- **Default-if-no-value**: `--compress` uses a fallback; `--compress=bzip2` overrides
+- **Require equals syntax**: `--key=value` required, `--key value` rejected
+- **Remainder positional**: `.remainder()` consumes all remaining tokens
+- **Allow hyphen values**: `.allow_hyphen_values()` accepts `-` as a regular value (stdin convention)
+- **Partial parsing**: `parse_known_arguments()` collects unrecognised options instead of erroring
+- **Compile-time validation**: builder parameters validated at `mojo build` time via `comptime assert`
+- **Registration-time validation**: group constraint typos caught when the program starts, not when the user runs it
 
 ---
 
@@ -61,6 +87,8 @@ I created this project to support my experiments with a CLI-based Chinese charac
 My goal is to provide a Mojo-idiomatic argument parsing library that can be easily adopted by the growing Mojo community for their CLI applications. **Before Mojo v1.0** (which means it is not yet stable), my focus is on building core features and ensuring correctness. "Core features" refer to those who appear in `argparse`/`clap`/`cobra` and are commonly used in CLI apps. "Correctness" means that the library should handle edge cases properly, provide clear error messages, and have good test coverage. Some fancy features will depend on my time and interest.
 
 ## Installation
+
+### Package Manager
 
 ArgMojo is available in the modular-community `https://repo.prefix.dev/modular-community` package repository. To access this repository, add it to your `channels` list in your `pixi.toml` file:
 
@@ -75,17 +103,14 @@ Then, you can install ArgMojo using any of these methods:
 1. In the `mojoproject.toml` file of your project, add the following dependency:
 
     ```toml
-    argmojo = "==0.3.0"
+    argmojo = "*"
     ```
 
     Then run `pixi install` to download and install the package.
 
-The following table summarizes the package versions and their corresponding Mojo versions:
+### Using mojopkg
 
-| `argmojo` version | `mojo` version | package manager |
-| ----------------- | -------------- | --------------- |
-| 0.1.0             | ==0.26.1       | pixi            |
-| 0.3.0             | ==0.26.1       | pixi            |
+The package manager may not be up to date with the latest ArgMojo release. If you want to use the latest version, you can download the `mojopkg` file from the [latest release](https://github.com/forfudan/argmojo/releases) and include it in your project directory.
 
 ## Quick Start
 
@@ -95,7 +120,7 @@ Here is a simple example of how to use ArgMojo in a Mojo program. See `examples/
 from argmojo import Argument, Command
 
 
-fn main() raises:
+def main() raises:
     var app = Command("mgrep", "Search for PATTERN in each FILE.", version="1.0.0")
 
     # Positional arguments
@@ -144,10 +169,12 @@ For detailed explanations and more examples of every feature, see the **[User Ma
 
 ArgMojo ships with two complete example CLIs:
 
-| Example                  | File                  | Features                                                                                                                                                                                                                                                                                                                          |
-| ------------------------ | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `mgrep` — simulated grep | `examples/mgrep.mojo` | Positional args, flags, count flags, negatable flags, choices, value_name, append/collect, value delimiter, nargs, mutually exclusive groups, required-together groups, conditional requirements, numeric range, key-value map, aliases, deprecated args, hidden args, negative-number passthrough, `--` stop marker, custom tips |
-| `mgit` — simulated git   | `examples/mgit.mojo`  | Subcommands (clone/init/add/commit/push/pull/log/remote/branch/diff/tag/stash), nested subcommands (remote add/remove/rename/show), persistent (global) flags, per-command args, mutually exclusive groups, choices, aliases, deprecated args, custom tips, shell completion script generation                                    |
+| Example                   | File                  | Features                                                                                                                                                                                                                                                                                                                          |
+| ------------------------- | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mgrep` — simulated grep  | `examples/mgrep.mojo` | Positional args, flags, count flags, negatable flags, choices, value_name, append/collect, value delimiter, nargs, mutually exclusive groups, required-together groups, conditional requirements, numeric range, key-value map, aliases, deprecated args, hidden args, negative-number passthrough, `--` stop marker, custom tips |
+| `mgit` — simulated git    | `examples/mgit.mojo`  | Subcommands (clone/init/add/commit/push/pull/log/remote/branch/diff/tag/stash), nested subcommands (remote add/remove/rename/show), persistent (global) flags, per-command args, mutually exclusive groups, choices, aliases, deprecated args, custom tips, shell completion script generation                                    |
+| `demo` — feature showcase | `examples/demo.mojo`  | Comprehensive showcase of all ArgMojo features in a single CLI                                                                                                                                                                                                                                                                    |
+| `yu` — Chinese CLI        | `examples/yu.mojo`    | CJK-aware help formatting, full-width auto-correction, CJK punctuation detection                                                                                                                                                                                                                                                  |
 
 Build both example binaries:
 
@@ -232,10 +259,14 @@ pixi run clean
 ```txt
 argmojo/
 ├── docs/                              # Documentation
+│   ├── argmojo_overall_planning.md    # Planning document and feature matrix
+│   ├── changelog.md                   # Release changelog
 │   └── user_manual.md                 # User manual with detailed examples
 ├── examples/
+│   ├── demo.mojo                      # Comprehensive feature showcase
 │   ├── mgrep.mojo                     # grep-like CLI (no subcommands)
-│   └── mgit.mojo                      # git-like CLI (with subcommands)
+│   ├── mgit.mojo                      # git-like CLI (with subcommands)
+│   └── yu.mojo                        # Chinese-language CLI (CJK features)
 ├── src/
 │   └── argmojo/                       # Main package
 │       ├── __init__.mojo              # Package exports

--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -10,7 +10,7 @@ At the moment, Mojo does not have a mature command-line argument parsing library
 
 ## 2. Cross-Language Research Summary
 
-This section summarises the key design patterns and features from well-known arg parsers across multiple languages. The goal is to extract **universally useful ideas** that are feasible in Mojo 0.26.1, and to exclude features that depend on language-specific capabilities (macros, decorators, reflection, closures-as-first-class) that Mojo does not yet provide.
+This section summarises the key design patterns and features from well-known arg parsers across multiple languages. The goal is to extract **universally useful ideas** that are feasible in Mojo 0.26.2, and to exclude features that depend on language-specific capabilities (macros, decorators, reflection, closures-as-first-class) that Mojo does not yet provide.
 
 ### 2.1 Libraries Surveyed
 
@@ -109,9 +109,9 @@ These features appear across multiple libraries and depend only on string operat
 Mojo provides `sys.argv()` to access command-line arguments:
 
 ```mojo
-from sys import argv
+from std.sys import argv
 
-fn main():
+def main():
     var args = argv()
     for i in range(len(args)):
         print("arg[", i, "] =", args[i])

--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -239,7 +239,7 @@ examples/
 ```mojo
 from argmojo import Command, Argument
 
-fn main() raises:
+def main() raises:
     var command = Command("demo", "A CJK-aware text search tool which supports pinyin and Yuhao IME")
 
     # Positional arguments

--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -55,7 +55,7 @@ These features appear across multiple libraries and depend only on string operat
 | Key-value map (`-Dkey=val`)        | —        | —     | —     | —    | Java `-D`, Docker `-e`       | **Done**      |
 | Aliases for long names             | —        | —     | ✓     | ✓    |                              | **Done**      |
 | Deprecated arguments               | ✓ (3.13) | —     | ✓     | —    |                              | **Done**      |
-| Negative number passthrough        | ✓        | —     | —     | ✓    | Essential for `decimo`       | **Done**      |
+| Negative number / stdin `−`        | ✓        | —     | ✓     | ✓    | `allow_hyphen_values()`      | **Done**      |
 | Subcommands                        | ✓        | ✓     | ✓     | ✓    |                              | **Done**      |
 | Auto-added `help` subcommand       | —        | —     | ✓     | ✓    | git, cargo, kubectl          | **Done**      |
 | Persistent (global) flags          | —        | —     | ✓     | ✓    | git `--no-pager` etc.        | **Done**      |
@@ -70,13 +70,11 @@ These features appear across multiple libraries and depend only on string operat
 | Interactive prompting              | —        | ✓     | —     | —    |                              | **Done**      |
 | Password / masked input            | —        | ✓     | —     | —    |                              | **Done**      |
 | Confirmation (`--yes` / `-y`)      | —        | ✓     | —     | —    |                              | **Done**      |
-| Pre/Post run hooks                 | —        | —     | ✓     | —    |                              | Phase 5       |
 | REMAINDER number_of_values         | ✓        | —     | —     | —    |                              | **Done**      |
 | Partial parsing (known args)       | ✓        | —     | —     | ✓    |                              | **Done**      |
 | Require equals syntax              | —        | —     | —     | ✓    |                              | **Done**      |
 | Default-if-no-value                | ✓        | —     | —     | ✓    |                              | **Done**      |
 | Mutual implication (`implies`)     | —        | —     | —     | —    | ArgMojo unique feature       | **Done**      |
-| Stdin value (`-` convention)       | —        | —     | ✓     | —    | Unix convention              | Phase 5       |
 | Shell completion script generation | —        | ✓     | ✓     | ✓    | bash / zsh / fish            | **Done**      |
 | Argument groups in help            | ✓        | —     | ✓     | ✓    |                              | **Done**      |
 | Value-name wrapping control        | —        | —     | —     | ✓    | clap, cargo, pixi, git       | **Done**      |
@@ -86,6 +84,7 @@ These features appear across multiple libraries and depend only on string operat
 | Typed retrieval (`get_int()` etc.) | ✓        | ✓     | ✓     | ✓    |                              | **Done**      |
 | Comptime `StringLiteral` params    | —        | —     | —     | ✓    | clap derive macros           | **Done**      |
 | Registration-time name validation  | —        | —     | —     | ✓    | clap panic on unknown ID     | **Done**      |
+| Pre/Post run hooks                 | —        | —     | ✓     | —    |                              | Phase unknown |
 | `Parseable` trait for type params  | —        | —     | —     | ✓    |                              | Phase unknown |
 | Derive / struct-based schema       | —        | —     | —     | ✓    | Requires Mojo macros         | Phase unknown |
 | Enum → type mapping (real enums)   | —        | —     | —     | ✓    | Requires reflection          | Phase unknown |
@@ -151,27 +150,14 @@ src/argmojo/
 ├── parse_result.mojo               # ParseResult struct — parsed values
 └── utils.mojo                      # Internal utilities — ANSI colours, display helpers
 tests/
-├── test_parse.mojo                 # Core parsing tests (flags, values, shorts, etc.)
-├── test_groups.mojo                # Group constraint tests (exclusive, conditional, etc.)
-├── test_collect.mojo               # Collection feature tests (append, delimiter, number_of_values)
-├── test_help.mojo                  # Help output tests (formatting, colours, alignment)
-├── test_extras.mojo                # Range, map, alias, deprecated tests
-├── test_subcommands.mojo           # Subcommand tests (dispatch, help sub, unknown sub, etc.)
-├── test_negative_numbers.mojo      # Negative number passthrough tests
-├── test_persistent.mojo            # Persistent (global) flag tests
-├── test_typo_suggestions.mojo      # Levenshtein typo suggestion tests
-├── test_completion.mojo            # Shell completion script generation tests
-├── test_implies.mojo               # Mutual implication and cycle detection tests
-├── test_const_require_equals.mojo  # default_if_no_value and require_equals tests
-├── test_response_file.mojo         # response file (@args.txt) expansion tests
-├── test_remainder_known.mojo       # remainder, parse_known_arguments, allow_hyphen_values tests
-├── test_fullwidth.mojo             # full-width → half-width auto-correction tests
-├── test_groups_help.mojo           # argument groups in help + value_name wrapping tests
-├── test_prompt.mojo                # interactive prompting tests
-├── test_parents.mojo               # argument parents (shared definitions) tests
-├── test_confirmation.mojo          # confirmation option (--yes / -y) tests
-├── test_password.mojo              # password / masked input tests
-└── test_usage.mojo                 # usage line customisation tests
+├── test_parse.mojo                 # Core parsing + negative number passthrough tests
+├── test_options.mojo               # default_if_no_value, require_equals, range, clamp, map, aliases, deprecated, remainder, parse_known, collection tests
+├── test_groups.mojo                # Mutually exclusive, required-together, one-required, conditional, implies, argument groups in help, value_name wrapping tests
+├── test_help.mojo                  # Help formatting, ANSI colours, CJK alignment, NO_COLOR, custom usage, fullwidth correction tests
+├── test_subcommands.mojo           # Subcommand dispatch, persistent/global flags, argument parents tests
+├── test_completion.mojo            # Shell completion (bash/zsh/fish) + Levenshtein typo suggestion tests
+├── test_interactive.mojo           # Interactive prompting, password/masked input, confirmation tests
+└── test_response_file.mojo         # Response file (@args.txt) expansion tests (⚠ disabled due to compiler bug)
 examples/
 ├── demo.mojo                       # comprehensive showcase of all ArgMojo features
 ├── mgrep.mojo                      # grep-like CLI example (no subcommands)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,81 +6,63 @@ This document tracks all notable changes to ArgMojo, including new features, API
 Comment out unreleased changes here. This file will be edited just before each release to reflect the final changelog for that version.
 -->
 
-## Unreleased (v0.4.0)
+## 20260321 (v0.4.0)
+
+ArgMojo v0.4.0 adds interactive prompting, password input, confirmation, argument parents, custom usage lines, response files, CJK-aware help formatting, and full-width auto-correction. The builder API is fully parameterised with compile-time `StringLiteral` parameters. The codebase is migrated to Mojo v0.26.2 and the test suite consolidated from 20 files into 8 modules.
 
 ArgMojo v0.4.0 targets Mojo v0.26.2.
 
-### ⭐️ New features in v0.4.0
+### ⭐️ New in v0.4.0
 
-1. Add `.default_if_no_value["value"]()` builder method for default-if-no-value semantics. When an option has a default-if-no-value, it may appear without an explicit value: `--compress` uses the default-if-no-value, while `--compress=bzip2` uses the explicit value. For long options, `.default_if_no_value()` implies `.require_equals()`. For short options, `-c` uses the default-if-no-value while `-cbzip2` uses the attached value (PR #12).
-2. Add `.require_equals()` builder method. When set, long options reject space-separated syntax (`--key value`) and require `--key=value`. Can be used standalone (the value is mandatory via `=`) or combined with `.default_if_no_value()` (the value is optional; omitting it uses default-if-no-value) (PR #12).
-3. Help output adapts to the new modifiers: `--key=<value>` for require_equals, `--key[=<value>]` for default_if_no_value (PR #12).
-4. ~~Add `response_file_prefix()` builder method on `Command` for response-file support. When enabled, tokens starting with the prefix (default `@`) are expanded by reading the referenced file — each non-empty, non-comment line becomes a separate argument. Supports comments (`#`), escape (`@@literal`), recursive nesting (configurable depth), and custom prefix characters (PR #12).~~ *(Temporarily disabled — triggers a Mojo compiler deadlock under `-D ASSERT=all`. The implementation is preserved as module-level functions and will be re-enabled when the Mojo compiler bug is fixed.)*
-5. Add `.remainder()` builder method on `Argument`. A remainder positional consumes **all** remaining tokens (including ones starting with `-`), similar to argparse `nargs=REMAINDER` or clap `trailing_var_arg`. At most one remainder positional is allowed per command and it must be the last positional (PR #13).
-6. Add `parse_known_arguments()` method on `Command`. Like `parse_arguments()`, but unrecognised options are collected into the result instead of raising an error. Access them via `result.get_unknown_args()`. Useful for forwarding unknown flags to another program (PR #13).
-7. Add `.allow_hyphen_values()` builder method on `Argument`. When set on a positional, values starting with `-` are accepted without requiring `--` (e.g., `-` for stdin). Remainder positionals have this enabled automatically (PR #13).
-8. **CJK-aware help alignment.** Help output now computes column padding using terminal display width instead of byte length. CJK ideographs and fullwidth characters are correctly treated as 2-column-wide, so help descriptions stay aligned when option names, positional names, or subcommand names contain Chinese, Japanese, or Korean characters. ANSI escape sequences are skipped during width calculation. No API changes — this is automatic (PR #14).
-9. **Full-width → half-width auto-correction.** When CJK users forget to switch input methods and type fullwidth ASCII (e.g., `－－ｖｅｒｂｏｓｅ` instead of `--verbose`, or `＝` instead of `=`), ArgMojo auto-detects and corrects these characters with a coloured warning. Fullwidth spaces (`U+3000`) embedded in a token cause it to be split into multiple arguments. All tokens containing fullwidth ASCII are normalized; only option tokens (starting with `-` after correction) trigger a warning. Disabled via `disable_fullwidth_correction()` (PR #15).
-10. **CJK punctuation auto-correction.** Common CJK punctuation outside the fullwidth ASCII range is also corrected — for example, em-dash (`——verbose`) is converted to `--verbose`. This runs as a separate pass after fullwidth correction. Disabled via `disable_punctuation_correction()` (PR #16).
-11. **Argument groups in help.** Add `.group["name"]()` builder method on `Argument`. Arguments assigned to the same group are displayed under a dedicated heading in `--help` output, in first-appearance order. Ungrouped arguments remain under the default "Options:" heading. Persistent arguments are collected under "Global Options:" as before (PR #17).
-12. **Value-name wrapping control.** Change `.value_name()` to accept compile-time parameters: `.value_name["NAME"]()` or `.value_name["NAME", False]()`. When `wrapped` is `True` (the default), the custom value name is displayed in angle brackets (`<NAME>`) in help output — matching the convention used by clap, cargo, pixi, and git. When `wrapped` is `False`, the value name is displayed bare (`NAME`). The auto-generated default placeholder (`<arg_name>`) is not affected (PR #17).
-13. **Registration-time validation for group constraints.** `mutually_exclusive()`, `required_together()`, `one_required()`, and `required_if()` now validate argument names against `self.args` at the moment they are called. An `Error` is raised immediately if any name is unknown, empty lists are rejected, and duplicates are silently deduplicated. `required_if()` additionally rejects self-referential rules (`target == condition`). This catches developer typos on the very first `mojo run`, without waiting for end-user input (PR #22).
-14. **Interactive prompting.** Add `.prompt()` and `.prompt["text"]()` builder methods on `Argument`. When an argument marked with `.prompt()` is not provided on the command line, the user is interactively prompted for its value before validation runs. Use `.prompt()` to prompt with the argument's help text, or `.prompt["Custom text"]()` to set a custom message. Works on both required and optional arguments. Prompts show valid choices for `.choice[]()` arguments and show default values in parentheses. For flag arguments, `y`/`n` input is accepted. When stdin is not a terminal (e.g., piped input, CI environments, `/dev/null`), or when `input()` otherwise raises, the exception is caught, prompting stops gracefully, and any values collected so far are preserved (PR #23).
-15. **Argument parents.** Add `add_parent(parent)` method on `Command`. Copies all argument definitions and group constraints (mutually exclusive, required together, one-required, conditional requirements, implications) from a parent `Command` into the current command. This lets you share a common set of arguments across multiple commands without repeating them — equivalent to Python argparse's `parents` parameter. The parent is not modified. All registration-time validation guards run on each inherited argument as usual (PR #25).
-16. **Confirmation option.** Add `confirmation_option()` and `confirmation_option["prompt"]()` builder methods on `Command`. When enabled, the command automatically registers a `--yes` / `-y` flag and prompts the user for confirmation after parsing (and after interactive prompting, if any). If the user does not confirm (`y`/`yes`), the command aborts with an error. Passing `--yes` or `-y` on the command line skips the prompt entirely. When stdin is not interactive (piped input, `/dev/null`), the command aborts gracefully. This is equivalent to Click's `confirmation_option` decorator (PR #26).
-17. **Usage line customisation.** Add `usage(text)` method on `Command`. When set, the given text replaces the auto-generated `Usage: myapp [OPTIONS] ...` line in both `--help` output and error messages. This lets you write git-style usage strings like `git [-v | --version] [-h | --help] [-C <path>] <command> [<args>]`. When not set, the default auto-generated usage line is used (PR #29).
-18. **Password / masked input.** Add `.password()` builder method on `Argument`. When combined with `.prompt()` (implied automatically), the user's typed input is hidden — terminal echo is disabled via POSIX `tcsetattr(3)` while the user types, then re-enabled afterwards. This is equivalent to Click's `hide_input=True` / Python's `getpass.getpass()`. If stdin is not a terminal (piped input, CI, `/dev/null`), the call falls back gracefully — prompting stops and defaults are applied as usual. `.password()` cannot be used on flag or count arguments (rejected at `add_argument()` time) (PR #28).
+1. Add `.default_if_no_value["value"]()` — option appears without a value to use the fallback; with `=value` to override. For long options, implies `.require_equals()` (PR #12).
+2. Add `.require_equals()` — long options reject space-separated values and require `--key=value` syntax. Help output adapts: `--key=<value>` for require-equals, `--key[=<value>]` for default-if-no-value (PR #12).
+3. Add `response_file_prefix()` on `Command` for `@args.txt` expansion with comments, escaping, and recursive nesting. *(Temporarily disabled due to a Mojo compiler deadlock under `-D ASSERT=all`.)* (PR #12).
+4. Add `.remainder()` on `Argument` — consume all remaining tokens (including dash-prefixed) as a single positional, similar to argparse `nargs=REMAINDER` (PR #13).
+5. Add `parse_known_arguments()` on `Command` — unrecognised options are collected via `result.get_unknown_args()` instead of raising an error (PR #13).
+6. Add `.allow_hyphen_values()` on `Argument` — accept tokens starting with `-` as values without requiring `--` first; covers the stdin `-` convention (PR #13).
+7. CJK-aware help alignment using terminal display width; CJK characters treated as 2-column-wide. No API changes — automatic (PR #14).
+8. Full-width → half-width auto-correction with a coloured warning when CJK users type fullwidth ASCII (e.g., `－－ｖｅｒｂｏｓｅ` → `--verbose`). Disabled via `disable_fullwidth_correction()` (PR #15).
+9. CJK punctuation auto-correction — em-dash `——verbose` corrected to `--verbose`. Disabled via `disable_punctuation_correction()` (PR #16).
+10. Add `.group["name"]()` on `Argument` — group arguments under dedicated headings in `--help` output (PR #17).
+11. Value-name wrapping control: `.value_name["NAME"]()` renders as `<NAME>` by default; `.value_name["NAME", False]()` renders bare (PR #17).
+12. Add runtime `generate_completion("shell")` overload alongside the existing compile-time `generate_completion["shell"]()` (PR #19).
+13. Registration-time validation for `mutually_exclusive()`, `required_together()`, `one_required()`, and `required_if()` — catches typos, empty lists, and self-referential rules immediately at `add_argument()` time (PR #22).
+14. Add `.prompt()` / `.prompt["text"]()` on `Argument` — interactively prompt for missing values before validation. Shows choices and defaults; handles non-interactive stdin gracefully (PR #23).
+15. Add `add_parent(parent)` on `Command` — share argument definitions and group constraints across commands, equivalent to argparse `parents` (PR #25).
+16. Add `confirmation_option()` on `Command` — register `--yes`/`-y` and prompt for confirmation after parsing; `--yes` skips the prompt (PR #26).
+17. Add `usage(text)` on `Command` — replace the auto-generated usage line with a custom string (PR #27).
+18. Add `.password()` on `Argument` — hide typed input via POSIX `tcsetattr(3)` during prompts, equivalent to Click `hide_input=True` (PR #28).
 
-### 🔄 Mojo v0.26.2 migration in v0.4.0
+### 🔄 Mojo v0.26.2 migration (PR #29)
 
-ArgMojo v0.4.0 targets **Mojo v0.26.2** (previously v0.26.1). The following codebase-wide changes were made to adapt to the new language semantics (PR #29):
-
-- **Bump Mojo dependency** from `==0.26.1` to `==0.26.2` in `pixi.toml` and regenerate `pixi.lock`.
-- **Migrate stdlib imports** to the new `std.*` namespace: `from sys` → `from std.sys`, `from os` → `from std.os`, `from os.path` → `from std.os.path`, `from sys.ffi` → `from std.ffi`, `from testing` → `from std.testing` (21 test files).
-- **Replace `constrained[]` with `comptime assert`** across all compile-time validation sites (argument builder methods, colour resolution, shell completion dispatch).
-- **Replace `@parameter if` with `comptime if`** in `_resolve_color[]` and `generate_completion[]`.
-- **Unify move/copy initialisers** to the new `__init__` forms: `__copyinit__` → `__init__(out self, *, copy: Self)`, `__moveinit__` → `__init__(out self, *, deinit take: Self)` for `Argument`, `Command`, and `ParseResult`.
-- **Remove `Stringable` from trait lists**: `Argument`, `Command`, and `ParseResult` now conform to `Copyable, Movable, Writable` only (`Stringable` was removed from the stdlib).
-- **Add `byte=` keyword to all string slicing** operations (`token[i:j]` → `token[byte=i:j]`) in `command.mojo`, `utils.mojo`, and `examples/yu.mojo`.
-- **Fix aliasing violation**: `em_dash + em_dash` → `chr(0x2014) + chr(0x2014)` to avoid the new same-variable borrowing alias check.
-- **Replace `fn` with `def`** across all 30 `.mojo` files (754 declarations). In Mojo v0.26.2, `def` has the same semantics as the old `fn` (non-raising by default, requires explicit `raises`), and `fn` is deprecated.
+- Bump Mojo dependency to `==0.26.2` in `pixi.toml`.
+- Migrate stdlib imports to `std.*` namespace (`from sys` → `from std.sys`, etc.).
+- Replace `constrained[]` with `comptime assert` and `@parameter if` with `comptime if`.
+- Unify `__copyinit__`/`__moveinit__` to new `__init__(out self, *, copy/take: Self)` forms.
+- Remove `Stringable` from trait lists (removed from stdlib).
+- Add `byte=` keyword to all string slicing operations.
+- Replace `fn` with `def` across all 30 files (754 declarations).
 
 ### 🦋 Changed in v0.4.0
 
-- **Rename `.metavar()` to `.value_name()`** across the entire API and documentation. The internal field is now `_value_name`. This follows clap's naming convention and better describes the purpose. There is no backward-compatible alias — all call sites must use `.value_name()` (PR #13).
-- **Value-name display now uses angle brackets by default.** Custom value names set via `.value_name["FOO"]()` are now rendered as `<FOO>` in help output. To preserve the old behaviour (bare `FOO`), use `.value_name["FOO", False]()`. This only affects custom value names — the auto-generated placeholder was already wrapped in `<>` (PR #17).
-- **Parameterise `.alias_name[]()` as a compile-time parameter.** Changed from `.aliases(["color"])` (runtime `List[String]`) to `.alias_name["color"]()` (compile-time `StringLiteral`). Alias names are validated at compile time (same rules as `.long[]`). For multiple aliases, chain calls: `.alias_name["out"]().alias_name["fmt"]()` (PR #18).
-- **Parameterise `.delimiter[]()` as a compile-time parameter.** Changed from `.delimiter(",")` (runtime `String`) to `.delimiter[","]()` (compile-time `StringLiteral`). Only `,`, `;`, `:`, `|` are accepted; validated at compile time (PR #18).
-- **Parameterise `.default[]()` as a compile-time parameter.** Changed from `.default("val")` (runtime `String`) to `.default["val"]()` (compile-time `StringLiteral`). No additional compile-time validation beyond the type change.
-- **Parameterise `.deprecated[]()` as a compile-time parameter.** Changed from `.deprecated("msg")` (runtime `String`) to `.deprecated["msg"]()` (compile-time `StringLiteral`). Message must be non-empty (validated at compile time).
-- **Parameterise `.default_if_no_value[]()` as a compile-time parameter.** Changed from `.default_if_no_value("val")` (runtime `String`) to `.default_if_no_value["val"]()` (compile-time `StringLiteral`). No additional compile-time validation beyond the type change.
-- **Parameterise `.group[]()` as a compile-time parameter.** Changed from `.group("name")` (runtime `String`) to `.group["name"]()` (compile-time `StringLiteral`). Group name must be non-empty (validated at compile time).
-- **Replace `.choices()` with chained `.choice[]()`.** Changed from `.choices(list^)` (runtime `List[String]`) to chained `.choice["a"]().choice["b"]()` (compile-time `StringLiteral`). Each choice value must be non-empty (validated at compile time). This uses the same singular-parameter + chaining pattern as `.alias_name[]()`, since Mojo's `StringLiteral` embeds its value in the type and variadic parameters require homogeneous types.
+1. Rename `.metavar()` to `.value_name()` across the entire API (PR #13).
+2. Parameterise `.long[]()` and `.short[]()` as compile-time `StringLiteral` parameters (PR #20).
+3. Parameterise `.alias_name[]()`, `.delimiter[]()`, `.default[]()`, `.deprecated[]()`, `.default_if_no_value[]()`, `.group[]()`, `.prompt[]()`, and colour setters (`header_color[]`, `arg_color[]`, `warn_color[]`, `error_color[]`) as compile-time parameters (PR #18, #21).
+4. Replace `.choices(list)` with chained `.choice["a"]().choice["b"]()` compile-time parameters (PR #18).
+5. Value-name display uses angle brackets by default; `.value_name["FOO", False]()` for bare display (PR #17).
+6. Move `print_summary()` from `Command` to `ParseResult` (PR #24).
 
 ### 🔧 Fixes in v0.4.0
 
-- Clarify documentation and docstrings: `default_if_no_value` does not "reject" `--key value`; it simply does not consume the next token as a value (PR #12, review feedback).
-- Fix cross-library comparison: click is described as "Python CLI framework" instead of incorrectly saying "built on top of argparse" (PR #12, review feedback).
-- Reject `.require_equals()` / `.default_if_no_value()` combined with `.number_of_values[N]()` at `add_argument()` time with a clear error (PR #12, review feedback).
-
-### 🛡️ Validation improvements in v0.4.0
-
-- **Compile-time `StringLiteral` parameters.** Builder methods that accept fixed, known values (`.long[]`, `.short[]`, `.choice[]`, `.default[]`, `.delimiter[]`, `.deprecated[]`, `.default_if_no_value[]`, `.group[]`, `.alias_name[]`, `.value_name[]`, `header_color[]`, `arg_color[]`, `warn_color[]`, `error_color[]`, `.max[]`, `.range[]`, `.number_of_values[]`, `response_file_max_depth[]`) now use compile-time `StringLiteral` or `Int` parameters. Invalid values are rejected by the compiler before a binary is produced (PR #18, and earlier PRs).
-- **Registration-time name validation.** `mutually_exclusive()`, `required_together()`, `one_required()`, and `required_if()` now raise an `Error` immediately if any referenced argument name is not registered. Empty lists are rejected and duplicates are deduplicated. `required_if()` rejects self-referential rules. This matches the existing pattern in `implies()` (PR #22).
+- Clarify that `default_if_no_value` does not "reject" `--key value` — it simply does not consume the next token (PR #12).
+- Fix Click description: "Python CLI framework", not "built on top of argparse" (PR #12).
+- Reject `.require_equals()` / `.default_if_no_value()` combined with `.number_of_values[N]()` at `add_argument()` time (PR #12).
 
 ### 📚 Documentation and testing in v0.4.0
 
-- Add Developer Validation section to user manual documenting the two-layer validation model (compile-time `StringLiteral` + runtime registration-time `raises`) with recommended workflow (PR #22).
-- Add `pixi run debug` task that runs all examples under `-D ASSERT=all` with `--help` to exercise registration-time validation in CI (PR #22).
-- **Consolidate test suite into 8 focused modules** (PR #30):
-  - `tests/test_parse.mojo` — core parsing (long/short flags, key-value pairs, positional args, short flag merging, choices, count, negatable flags, prefix matching, negative numbers).
-  - `tests/test_options.mojo` — option features (default_if_no_value, require_equals, range/clamp, key-value mapping, aliases, deprecated args, remainder, parse_known_arguments, value_name, allow_hyphen_values, append, delimiter splitting, number_of_values).
-  - `tests/test_help.mojo` — help and display (hidden args, value_name, padding, alignment, ANSI colours, subcommand help, CJK-aware alignment, NO_COLOR, custom usage, full-width → half-width auto-correction).
-  - `tests/test_groups.mojo` — argument groups (mutually exclusive, required together, one-required, required_if, registration-time validation, groups in help output, value_name wrapping, implies with cycle detection).
-  - `tests/test_completion.mojo` — shell completions (Fish, Zsh, Bash script generation, built-in flag, aliases, hidden subcommands) and typo suggestions (Levenshtein distance for options and subcommands).
-  - `tests/test_subcommands.mojo` — subcommand support, persistent flags, parent inheritance (data model, parse-time routing, auto-registered help, aliases, hidden dispatch, positional guards).
-  - `tests/test_interactive.mojo` — interactive prompting, password/masked input, confirmation option (builder methods, field propagation, validation guards, skip-when-provided).
-  - `tests/test_response_file.mojo` — response-file (@args.txt) expansion (currently excluded from CI due to Mojo compiler deadlock).
+- Consolidate test suite from 20 files into 8 focused modules (PR #30).
+- Add Developer Validation section to user manual with two-layer validation model (compile-time + registration-time) (PR #22).
+- Add `pixi run debug` task for `-D ASSERT=all` regression testing (PR #22).
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -42,6 +42,7 @@ ArgMojo v0.4.0 targets Mojo v0.26.2.
 - Remove `Stringable` from trait lists (removed from stdlib).
 - Add `byte=` keyword to all string slicing operations.
 - Replace `fn` with `def` across all 30 files (754 declarations).
+- Remove `__str__` methods; consolidate string output into `write_to` (Mojo v0.26.2 convention).
 
 ### 🦋 Changed in v0.4.0
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -167,7 +167,7 @@ After calling `command.parse()` or `command.parse_arguments()`, you get a `Parse
 | `result.get_list("name")`   | `List[String]`         | Returns collected values (empty list if none).        |
 | `result.get_map("name")`    | `Dict[String, String]` | Returns key-value pairs (empty dict if none).         |
 | `result.has("name")`        | `Bool`                 | Returns `True` if the argument was provided.          |
-| `result.print_summary()`    |                        | Prints a human-readable summary of all parsed values. |
+| `result.print_summary()`    | `None`                 | Prints a human-readable summary of all parsed values. |
 
 **`get_string()`** works for both named options and positional arguments — positional values are looked up by the name given in `Argument("name", ...)`.
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -135,7 +135,7 @@ from argmojo import Argument, Command
 A **Command** is the top-level object that holds argument definitions and runs the parser.
 
 ```mojo
-fn main() raises:
+def main() raises:
     var command = Command("myapp", "A short description of the program", version="1.0.0")
     # ... add arguments ...
     var result = command.parse()
@@ -158,14 +158,16 @@ fn main() raises:
 
 After calling `command.parse()` or `command.parse_arguments()`, you get a `ParseResult` with these typed accessors:
 
-| Method                      | Returns        | Description                                       |
-| --------------------------- | -------------- | ------------------------------------------------- |
-| `result.get_flag("name")`   | `Bool`         | Returns `True` if the flag was set, else `False`. |
-| `result.get_string("name")` | `String`       | Returns the string value. Raises if not found.    |
-| `result.get_int("name")`    | `Int`          | Parses the value as an integer. Raises on error.  |
-| `result.get_count("name")`  | `Int`          | Returns the count (0 if never provided).          |
-| `result.get_list("name")`   | `List[String]` | Returns collected values (empty list if none).    |
-| `result.has("name")`        | `Bool`         | Returns `True` if the argument was provided.      |
+| Method                      | Returns                | Description                                           |
+| --------------------------- | ---------------------- | ----------------------------------------------------- |
+| `result.get_flag("name")`   | `Bool`                 | Returns `True` if the flag was set, else `False`.     |
+| `result.get_string("name")` | `String`               | Returns the string value. Raises if not found.        |
+| `result.get_int("name")`    | `Int`                  | Parses the value as an integer. Raises on error.      |
+| `result.get_count("name")`  | `Int`                  | Returns the count (0 if never provided).              |
+| `result.get_list("name")`   | `List[String]`         | Returns collected values (empty list if none).        |
+| `result.get_map("name")`    | `Dict[String, String]` | Returns key-value pairs (empty dict if none).         |
+| `result.has("name")`        | `Bool`                 | Returns `True` if the argument was provided.          |
+| `result.print_summary()`    |                        | Prints a human-readable summary of all parsed values. |
 
 **`get_string()`** works for both named options and positional arguments — positional values are looked up by the name given in `Argument("name", ...)`.
 
@@ -2942,7 +2944,7 @@ The examples below use this `login` command:
 ```mojo
 from argmojo import Argument, Command
 
-fn main() raises:
+def main() raises:
     var command = Command("login", "Authenticate with the service")
     command.add_argument(
         Argument("user", help="Username")
@@ -3123,7 +3125,7 @@ When multiple commands share the same set of arguments (e.g., `--verbose`, `--fo
 ```mojo
 from argmojo import Command, Argument
 
-fn main() raises:
+def main() raises:
     # Define shared arguments in a "parent" command.
     # The name is arbitrary — it is never shown to users.
     var shared = Command("_shared")
@@ -3227,7 +3229,7 @@ For passwords, API tokens, and other sensitive values, you want to **hide the us
 ```mojo
 from argmojo import Command, Argument
 
-fn main() raises:
+def main() raises:
     var command = Command("login", "Authenticate with the server")
     command.add_argument(
         Argument("username", help="Your username").long["username"]().short["u"]().required()
@@ -3299,7 +3301,7 @@ Some commands are destructive or irreversible — dropping databases, deleting f
 ```mojo
 from argmojo import Command, Argument
 
-fn main() raises:
+def main() raises:
     var cmd = Command("drop", "Drop the database")
     cmd.add_argument(
         Argument("name", help="Database name").positional().required()
@@ -3378,7 +3380,7 @@ For some programs you may want a hand-written usage string — for example, git'
 ```mojo
 from argmojo import Command, Argument
 
-fn main() raises:
+def main() raises:
     var cmd = Command("git", "The stupid content tracker", version="2.45.0")
     cmd.usage("git [-v | --version] [-h | --help] [-C <path>] <command> [<args>]")
 
@@ -3576,7 +3578,7 @@ All `Argument` builder methods that accept fixed, known values use **compile-tim
 Argument("verbose", help="Verbose output").long["verbose"]().short["v"]().flag()
 
 # ✗ Compile error — "REED" is not a valid colour name
-command.header_color["REED"]()   # caught by constrained[] at compile time
+command.header_color["REED"]()   # caught by comptime assert at compile time
 ```
 
 Methods validated at compile time include:

--- a/pixi.lock
+++ b/pixi.lock
@@ -12,30 +12,28 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.12-py313hd8ed1ab_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.3-py314hd8ed1ab_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.4-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.2-hf4e2dac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.21-h280c20c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.52.0-hf4e2dac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.modular.com/max/noarch/mblack-26.2.0-release.conda
       - conda: https://conda.modular.com/max/linux-64/mojo-0.26.2.0-release.conda
       - conda: https://conda.modular.com/max/linux-64/mojo-compiler-0.26.2.0-release.conda
@@ -45,42 +43,42 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.0.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.12-hc97d973_100_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.3-h32b2ec7_101_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.12-h4df99d1_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.3-h4df99d1_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py313h07c4f96_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py314h5bd0f2a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h387f397_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h41580af_10.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.12-py313hd8ed1ab_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.2-h38cb7af_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.3-py314hd8ed1ab_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.9.1-pyhc90fa1f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-21.1.8-h55c6f16_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-h385eeb1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.1-h55c6f16_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.4-hf6b4638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.2-h8088a28_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.20-h99b78c6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.51.2-h1ae2325_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.21-h1a92334_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.52.0-h1ae2325_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
       - conda: https://conda.modular.com/max/noarch/mblack-26.2.0-release.conda
       - conda: https://conda.modular.com/max/osx-arm64/mojo-0.26.2.0-release.conda
       - conda: https://conda.modular.com/max/osx-arm64/mojo-compiler-0.26.2.0-release.conda
@@ -90,21 +88,22 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.1-hd24854e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pathspec-1.0.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.12-h20e6be0_100_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.3-h4c637c5_101_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.12-h4df99d1_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.3-h4df99d1_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.1.0-py312h022ad19_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.4-py313h6535dbc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.4-py314h0612a62_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h888dc83_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h4818236_10.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -148,14 +147,14 @@ packages:
   license_family: BSD
   size: 124834
   timestamp: 1771350416561
-- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
-  sha256: b5974ec9b50e3c514a382335efa81ed02b05906849827a34061c496f4defa0b2
-  md5: bddacf101bb4dd0e51811cb69c7790e2
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
+  sha256: 67cc7101b36421c5913a1687ef1b99f85b5d6868da3abbf6ec1a4181e79782fc
+  md5: 4492fd26db29495f0ba23f146cd5638d
   depends:
   - __unix
   license: ISC
-  size: 146519
-  timestamp: 1767500828366
+  size: 147413
+  timestamp: 1772006283803
 - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
   sha256: 38cfe1ee75b21a8361c8824f5544c3866f303af1762693a178266d7f198e8715
   md5: ea8a6c3256897cc31263de9f455e25d9
@@ -167,47 +166,47 @@ packages:
   license_family: BSD
   size: 97676
   timestamp: 1764518652276
-- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.13.12-py313hd8ed1ab_100.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.14.3-py314hd8ed1ab_101.conda
   noarch: generic
-  sha256: 7636809bda35add7af66cda1fee156136fcba0a1e24bbef1d591ee859df755a8
-  md5: 9a4b8a37303b933b847c14a310f0557b
+  sha256: 91b06300879df746214f7363d6c27c2489c80732e46a369eb2afc234bcafb44c
+  md5: 3bb89e4f795e5414addaa531d6b1500a
   depends:
-  - python >=3.13,<3.14.0a0
-  - python_abi * *_cp313
+  - python >=3.14,<3.15.0a0
+  - python_abi * *_cp314
   license: Python-2.0
-  size: 48648
-  timestamp: 1770270374831
-- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
-  sha256: 142a722072fa96cf16ff98eaaf641f54ab84744af81754c292cb81e0881c0329
-  md5: 186a18e3ba246eccfc7cff00cd19a870
+  size: 50078
+  timestamp: 1770674447292
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
+  sha256: fbf86c4a59c2ed05bbffb2ba25c7ed94f6185ec30ecb691615d42342baa1a16a
+  md5: c80d8a3b84358cb967fa81e7075fbc8a
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libstdcxx >=14
   license: MIT
   license_family: MIT
-  size: 12728445
-  timestamp: 1767969922681
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.2-h38cb7af_0.conda
-  sha256: d4cefbca587429d1192509edc52c88de52bc96c2447771ddc1f8bee928aed5ef
-  md5: 1e93aca311da0210e660d2247812fa02
+  size: 12723451
+  timestamp: 1773822285671
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
+  sha256: 3a7907a17e9937d3a46dfd41cffaf815abad59a569440d1e25177c15fd0684e5
+  md5: f1182c91c0de31a7abd40cedf6a5ebef
   depends:
   - __osx >=11.0
   license: MIT
   license_family: MIT
-  size: 12358010
-  timestamp: 1767970350308
-- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
-  sha256: c18ab120a0613ada4391b15981d86ff777b5690ca461ea7e9e49531e8f374745
-  md5: 63ccfdc3a3ce25b027b8767eb722fca8
+  size: 12361647
+  timestamp: 1773822915649
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.8.0-pyhcf101f3_0.conda
+  sha256: 82ab2a0d91ca1e7e63ab6a4939356667ef683905dea631bc2121aa534d347b16
+  md5: 080594bf4493e6bae2607e65390c520a
   depends:
-  - python >=3.9
+  - python >=3.10
   - zipp >=3.20
   - python
   license: Apache-2.0
   license_family: APACHE
-  size: 34641
-  timestamp: 1747934053147
+  size: 34387
+  timestamp: 1773931568510
 - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.3-pyhd8ed1ab_1.conda
   sha256: 19d8bd5bb2fde910ec59e081eeb59529491995ce0d653a5209366611023a0b3a
   md5: 4ebae00eae9705b0c3d6d1018a81d047
@@ -248,33 +247,34 @@ packages:
   license: LGPL-2.1-or-later
   size: 134088
   timestamp: 1754905959823
-- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
-  sha256: 99df692f7a8a5c27cd14b5fb1374ee55e756631b9c3d659ed3ee60830249b238
-  md5: 3f43953b7d3fb3aaa1d0d0723d91e368
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
+  sha256: 3e307628ca3527448dd1cb14ad7bb9d04d1d28c7d4c5f97ba196ae984571dd25
+  md5: fb53fb07ce46a575c5d004bbc96032c2
   depends:
-  - keyutils >=1.6.1,<2.0a0
-  - libedit >=3.1.20191231,<3.2.0a0
-  - libedit >=3.1.20191231,<4.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - openssl >=3.3.1,<4.0a0
+  - __glibc >=2.17,<3.0.a0
+  - keyutils >=1.6.3,<2.0a0
+  - libedit >=3.1.20250104,<3.2.0a0
+  - libedit >=3.1.20250104,<4.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - openssl >=3.5.5,<4.0a0
   license: MIT
   license_family: MIT
-  size: 1370023
-  timestamp: 1719463201255
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
-  sha256: 4442f957c3c77d69d9da3521268cad5d54c9033f1a73f99cde0a3658937b159b
-  md5: c6dc8a0fdec13a0565936655c33069a1
+  size: 1386730
+  timestamp: 1769769569681
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-h385eeb1_0.conda
+  sha256: c0a0bf028fe7f3defcdcaa464e536cf1b202d07451e18ad83fdd169d15bef6ed
+  md5: e446e1822f4da8e5080a9de93474184d
   depends:
   - __osx >=11.0
-  - libcxx >=16
-  - libedit >=3.1.20191231,<3.2.0a0
-  - libedit >=3.1.20191231,<4.0a0
-  - openssl >=3.3.1,<4.0a0
+  - libcxx >=19
+  - libedit >=3.1.20250104,<3.2.0a0
+  - libedit >=3.1.20250104,<4.0a0
+  - openssl >=3.5.5,<4.0a0
   license: MIT
   license_family: MIT
-  size: 1155530
-  timestamp: 1719463474401
+  size: 1160828
+  timestamp: 1769770119811
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
   sha256: 565941ac1f8b0d2f2e8f02827cbca648f4d18cd461afc31f15604cd291b5c5f3
   md5: 12bd9a3f089ee6c9266a37dab82afabd
@@ -287,15 +287,15 @@ packages:
   license_family: GPL
   size: 725507
   timestamp: 1770267139900
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-21.1.8-h55c6f16_2.conda
-  sha256: 5fbeb2fc2673f0455af6079abf93faaf27f11a92574ad51565fa1ecac9a4e2aa
-  md5: 4cb5878bdb9ebfa65b7cdff5445087c5
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.1-h55c6f16_0.conda
+  sha256: 3c8142cdd3109c250a926c492ec45bc954697b288e5d1154ada95272ffa21be8
+  md5: 7a290d944bc0c481a55baf33fa289deb
   depends:
   - __osx >=11.0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 570068
-  timestamp: 1770238262922
+  size: 570281
+  timestamp: 1773203613980
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
   sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
   md5: c277e0a4d549b03ac1e9d6cbbe3d017b
@@ -374,15 +374,6 @@ packages:
   license_family: GPL
   size: 1041788
   timestamp: 1771378212382
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_18.conda
-  sha256: e318a711400f536c81123e753d4c797a821021fb38970cebfb3f454126016893
-  md5: d5e96b1ed75ca01906b3d2469b4ce493
-  depends:
-  - libgcc 15.2.0 he0feb66_18
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 27526
-  timestamp: 1771378224552
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
   sha256: 21337ab58e5e0649d869ab168d4e609b033509de22521de1bfed0c031bfc5110
   md5: 239c5e9546c38a1e884d69effcf4c882
@@ -432,43 +423,44 @@ packages:
   license_family: BSD
   size: 73690
   timestamp: 1769482560514
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
-  sha256: 0105bd108f19ea8e6a78d2d994a6d4a8db16d19a41212070d2d1d48a63c34161
-  md5: a587892d3c13b6621a6091be690dbca2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.21-h280c20c_3.conda
+  sha256: 64e5c80cbce4680a2d25179949739a6def695d72c40ca28f010711764e372d97
+  md5: 7af961ef4aa2c1136e11dd43ded245ab
   depends:
-  - libgcc-ng >=12
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   license: ISC
-  size: 205978
-  timestamp: 1716828628198
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.20-h99b78c6_0.conda
-  sha256: fade8223e1e1004367d7101dd17261003b60aa576df6d7802191f8972f7470b1
-  md5: a7ce36e284c5faaf93c220dfc39e3abd
+  size: 277661
+  timestamp: 1772479381288
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.21-h1a92334_3.conda
+  sha256: df603472ea1ebd8e7d4fb71e4360fe48d10b11c240df51c129de1da2ff9e8227
+  md5: 7cc5247987e6d115134ebab15186bc13
   depends:
   - __osx >=11.0
   license: ISC
-  size: 164972
-  timestamp: 1716828607917
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.2-hf4e2dac_0.conda
-  sha256: 04596fcee262a870e4b7c9807224680ff48d4d0cc0dac076a602503d3dc6d217
-  md5: da5be73701eecd0e8454423fd6ffcf30
+  size: 248039
+  timestamp: 1772479570912
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.52.0-hf4e2dac_0.conda
+  sha256: d716847b7deca293d2e49ed1c8ab9e4b9e04b9d780aea49a97c26925b28a7993
+  md5: fd893f6a3002a635b5e50ceb9dd2c0f4
   depends:
   - __glibc >=2.17,<3.0.a0
   - icu >=78.2,<79.0a0
   - libgcc >=14
   - libzlib >=1.3.1,<2.0a0
   license: blessing
-  size: 942808
-  timestamp: 1768147973361
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.51.2-h1ae2325_0.conda
-  sha256: 6e9b9f269732cbc4698c7984aa5b9682c168e2a8d1e0406e1ff10091ca046167
-  md5: 4b0bf313c53c3e89692f020fb55d5f2c
+  size: 951405
+  timestamp: 1772818874251
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.52.0-h1ae2325_0.conda
+  sha256: beb0fd5594d6d7c7cd42c992b6bb4d66cbb39d6c94a8234f15956da99a04306c
+  md5: f6233a3fddc35a2ec9f617f79d6f3d71
   depends:
   - __osx >=11.0
   - icu >=78.2,<79.0a0
   - libzlib >=1.3.1,<2.0a0
   license: blessing
-  size: 909777
-  timestamp: 1768148320535
+  size: 918420
+  timestamp: 1772819478684
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
   sha256: 78668020064fdaa27e9ab65cd2997e2c837b564ab26ce3bf0e58a2ce1a525c6e
   md5: 1b08cd684f34175e4514474793d44bcb
@@ -481,15 +473,6 @@ packages:
   license_family: GPL
   size: 5852330
   timestamp: 1771378262446
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
-  sha256: 3c902ffd673cb3c6ddde624cdb80f870b6c835f8bf28384b0016e7d444dd0145
-  md5: 6235adb93d064ecdf3d44faee6f468de
-  depends:
-  - libstdcxx 15.2.0 h934c35e_18
-  license: GPL-3.0-only WITH GCC-exception-3.1
-  license_family: GPL
-  size: 27575
-  timestamp: 1771378314494
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
   sha256: 1a7539cfa7df00714e8943e18de0b06cceef6778e420a5ee3a2a145773758aee
   md5: db409b7c1720428638e7c0d509d3e1b5
@@ -500,29 +483,28 @@ packages:
   license_family: BSD
   size: 40311
   timestamp: 1766271528534
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
-  sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
-  md5: edb0dca6bc32e4f4789199455a1dbeb8
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+  sha256: 55044c403570f0dc26e6364de4dc5368e5f3fc7ff103e867c487e2b5ab2bcda9
+  md5: d87ff7921124eccd67248aa483c23fec
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
   constrains:
-  - zlib 1.3.1 *_2
+  - zlib 1.3.2 *_2
   license: Zlib
   license_family: Other
-  size: 60963
-  timestamp: 1727963148474
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
-  sha256: ce34669eadaba351cd54910743e6a2261b67009624dbc7daeeafdef93616711b
-  md5: 369964e85dc26bfe78f41399b366c435
+  size: 63629
+  timestamp: 1774072609062
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+  sha256: 361415a698514b19a852f5d1123c5da746d4642139904156ddfca7c922d23a05
+  md5: bc5a5721b6439f2f62a84f2548136082
   depends:
   - __osx >=11.0
   constrains:
-  - zlib 1.3.1 *_2
+  - zlib 1.3.2 *_2
   license: Zlib
   license_family: Other
-  size: 46438
-  timestamp: 1727963202283
+  size: 47759
+  timestamp: 1774072956767
 - conda: https://conda.modular.com/max/noarch/mblack-26.2.0-release.conda
   noarch: python
   sha256: 3c2fceb89cefca899dcd7c8f26a6202acacb2a073e4cb2ef365514a465d01dcd
@@ -651,20 +633,20 @@ packages:
   license_family: MOZILLA
   size: 53739
   timestamp: 1769677743677
-- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
-  sha256: 7f263219cecf0ba6d74c751efa60c4676ce823157ca90aa43ebba5ac615ca0fa
-  md5: 4fefefb892ce9cc1539405bec2f1a6cd
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
+  sha256: 0289f0a38337ee201d984f8f31f11f6ef076cfbbfd0ab9181d12d9d1d099bf46
+  md5: 82c1787f2a65c0155ef9652466ee98d6
   depends:
   - python >=3.10
   - python
   license: MIT
   license_family: MIT
-  size: 25643
-  timestamp: 1771233827084
-- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.12-hc97d973_100_cp313.conda
-  build_number: 100
-  sha256: 8a08fe5b7cb5a28aa44e2994d18dbf77f443956990753a4ca8173153ffb6eb56
-  md5: 4c875ed0e78c2d407ec55eadffb8cf3d
+  size: 25646
+  timestamp: 1773199142345
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.3-h32b2ec7_101_cp314.conda
+  build_number: 101
+  sha256: cb0628c5f1732f889f53a877484da98f5a0e0f47326622671396fb4f2b0cd6bd
+  md5: c014ad06e60441661737121d3eae8a60
   depends:
   - __glibc >=2.17,<3.0.a0
   - bzip2 >=1.0.8,<2.0a0
@@ -679,18 +661,19 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   - ncurses >=6.5,<7.0a0
   - openssl >=3.5.5,<4.0a0
-  - python_abi 3.13.* *_cp313
+  - python_abi 3.14.* *_cp314
   - readline >=8.3,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
+  - zstd >=1.5.7,<1.6.0a0
   license: Python-2.0
-  size: 37364553
-  timestamp: 1770272309861
-  python_site_packages_path: lib/python3.13/site-packages
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.12-h20e6be0_100_cp313.conda
-  build_number: 100
-  sha256: 9a4f16a64def0853f0a7b6a7beb40d498fd6b09bee10b90c3d6069b664156817
-  md5: 179c0f5ae4f22bc3be567298ed0b17b9
+  size: 36702440
+  timestamp: 1770675584356
+  python_site_packages_path: lib/python3.14/site-packages
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.3-h4c637c5_101_cp314.conda
+  build_number: 101
+  sha256: fccce2af62d11328d232df9f6bbf63464fd45f81f718c661757f9c628c4378ce
+  md5: 753c8d0447677acb7ddbcc6e03e82661
   depends:
   - __osx >=11.0
   - bzip2 >=1.0.8,<2.0a0
@@ -702,14 +685,15 @@ packages:
   - libzlib >=1.3.1,<2.0a0
   - ncurses >=6.5,<7.0a0
   - openssl >=3.5.5,<4.0a0
-  - python_abi 3.13.* *_cp313
+  - python_abi 3.14.* *_cp314
   - readline >=8.3,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
+  - zstd >=1.5.7,<1.6.0a0
   license: Python-2.0
-  size: 12770674
-  timestamp: 1770272314517
-  python_site_packages_path: lib/python3.13/site-packages
+  size: 13522698
+  timestamp: 1770675365241
+  python_site_packages_path: lib/python3.14/site-packages
 - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
   sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
   md5: 5b8d21249ff20967101ffa321cab24e8
@@ -721,25 +705,25 @@ packages:
   license_family: APACHE
   size: 233310
   timestamp: 1751104122689
-- conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.13.12-h4df99d1_100.conda
-  sha256: f306304235197434494355351ac56020a65b7c5c56ff10ca1ed53356d575557a
-  md5: 3d92938d5b83c49162ade038aab58a59
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.14.3-h4df99d1_101.conda
+  sha256: 233aebd94c704ac112afefbb29cf4170b7bc606e22958906f2672081bc50638a
+  md5: 235765e4ea0d0301c75965985163b5a1
   depends:
-  - cpython 3.13.12.*
-  - python_abi * *_cp313
+  - cpython 3.14.3.*
+  - python_abi * *_cp314
   license: Python-2.0
-  size: 48618
-  timestamp: 1770270436560
-- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
+  size: 50062
+  timestamp: 1770674497152
+- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
   build_number: 8
-  sha256: 210bffe7b121e651419cb196a2a63687b087497595c9be9d20ebe97dd06060a7
-  md5: 94305520c52a4aa3f6c2b1ff6008d9f8
+  sha256: ad6d2e9ac39751cc0529dd1566a26751a0bf2542adb0c232533d32e176e21db5
+  md5: 0539938c55b6b1a59b560e843ad864a4
   constrains:
-  - python 3.13.* *_cp313
+  - python 3.14.* *_cp314
   license: BSD-3-Clause
   license_family: BSD
-  size: 7002
-  timestamp: 1752805902938
+  size: 6989
+  timestamp: 1752805904792
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.1.0-py312hda471dd_2.conda
   noarch: python
   sha256: be66c1f85c3b48137200d62c12d918f4f8ad329423daef04fed292818efd3c28
@@ -835,30 +819,30 @@ packages:
   license_family: MIT
   size: 21453
   timestamp: 1768146676791
-- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py313h07c4f96_0.conda
-  sha256: 6006d4e5a6ff99be052c939e43adee844a38f2dc148f44a7c11aa0011fd3d811
-  md5: 82da2dcf1ea3e298f2557b50459809e0
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.3-py314h5bd0f2a_0.conda
+  sha256: b8f9f9ae508d79c9c697eb01b6a8d2ed4bc1899370f44aa6497c8abbd15988ea
+  md5: e35f08043f54d26a1be93fdbf90d30c3
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - python >=3.13,<3.14.0a0
-  - python_abi 3.13.* *_cp313
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
   license: Apache-2.0
   license_family: Apache
-  size: 878109
-  timestamp: 1765458900582
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.4-py313h6535dbc_0.conda
-  sha256: a8130a361b7bc21190836ba8889276cc263fcb09f52bf22efcaed1de98179948
-  md5: 67a85c1b5c17124eaf9194206afd5159
+  size: 905436
+  timestamp: 1765458949518
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.4-py314h0612a62_0.conda
+  sha256: affbc6300e1baef5848f6e69569733a3e7a118aa642487c853f53d6f2bd23b89
+  md5: 83e1a2d7b0c1352870bbe9d9406135cf
   depends:
   - __osx >=11.0
-  - python >=3.13,<3.14.0a0
-  - python >=3.13,<3.14.0a0 *_cp313
-  - python_abi 3.13.* *_cp313
+  - python >=3.14,<3.15.0a0
+  - python >=3.14,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
   license: Apache-2.0
   license_family: Apache
-  size: 877647
-  timestamp: 1765836696426
+  size: 909298
+  timestamp: 1765836779269
 - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
   sha256: f39a5620c6e8e9e98357507262a7869de2ae8cc07da8b7f84e517c9fd6c2b959
   md5: 019a7385be9af33791c989871317e1ed
@@ -874,32 +858,31 @@ packages:
   license: LicenseRef-Public-Domain
   size: 119135
   timestamp: 1767016325805
-- conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h387f397_9.conda
-  sha256: 47cfe31255b91b4a6fa0e9dbaf26baa60ac97e033402dbc8b90ba5fee5ffe184
-  md5: 8035e5b54c08429354d5d64027041cad
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h41580af_10.conda
+  sha256: 325d370b28e2b9cc1f765c5b4cdb394c91a5d958fbd15da1a14607a28fee09f6
+  md5: 755b096086851e1193f3b10347415d7c
   depends:
-  - libstdcxx >=14
   - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=14
-  - libsodium >=1.0.20,<1.0.21.0a0
-  - krb5 >=1.21.3,<1.22.0a0
+  - libstdcxx >=14
+  - krb5 >=1.22.2,<1.23.0a0
+  - libsodium >=1.0.21,<1.0.22.0a0
   license: MPL-2.0
   license_family: MOZILLA
-  size: 310648
-  timestamp: 1757370847287
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h888dc83_9.conda
-  sha256: b6f9c130646e5971f6cad708e1eee278f5c7eea3ca97ec2fdd36e7abb764a7b8
-  md5: 26f39dfe38a2a65437c29d69906a0f68
+  size: 311150
+  timestamp: 1772476812121
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h4818236_10.conda
+  sha256: 2705360c72d4db8de34291493379ffd13b09fd594d0af20c9eefa8a3f060d868
+  md5: e85dcd3bde2b10081cdcaeae15797506
   depends:
   - __osx >=11.0
   - libcxx >=19
-  - libsodium >=1.0.20,<1.0.21.0a0
-  - krb5 >=1.21.3,<1.22.0a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libsodium >=1.0.21,<1.0.22.0a0
   license: MPL-2.0
   license_family: MOZILLA
-  size: 244772
-  timestamp: 1757371008525
+  size: 245246
+  timestamp: 1772476886668
 - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
   sha256: b4533f7d9efc976511a73ef7d4a2473406d7f4c750884be8e8620b0ce70f4dae
   md5: 30cd29cb87d819caead4d55184c1d115
@@ -920,3 +903,13 @@ packages:
   license_family: BSD
   size: 601375
   timestamp: 1764777111296
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+  sha256: 9485ba49e8f47d2b597dd399e88f4802e100851b27c21d7525625b0b4025a5d9
+  md5: ab136e4c34e97f34fb621d2592a393d8
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 433413
+  timestamp: 1764777166076

--- a/pixi.toml
+++ b/pixi.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 version = "0.3.0"
 
 [dependencies]
-mojo = "==0.26.2"
+mojo = "==0.26.2.0"
 
 [tasks]
 # format the code

--- a/pixi.toml
+++ b/pixi.toml
@@ -23,7 +23,7 @@ format = "mojo format ./src ./tests ./examples"
 package = "mojo package src/argmojo -o argmojo.mojopkg"
 
 # doc
-doc = """pixi run mojo doc \
+doc = """mojo doc \
 --diagnose-missing-doc-strings --Werror src/argmojo"""
 
 # run tests
@@ -95,8 +95,10 @@ d = """pixi run package && bash -c '\
 clean = "rm -f argmojo.mojopkg mgrep mgit demo yu"
 
 # Run all
-all = """pixi run package \
-&&pixi run doc \
-&&pixi run t \
-&&pixi run d \
-&&pixi run clean"""
+all = """
+pixi run format \
+&& pixi run package \
+&& pixi run doc \
+&& pixi run t \
+&& pixi run d \
+&& pixi run clean"""

--- a/pixi.toml
+++ b/pixi.toml
@@ -93,3 +93,10 @@ d = """pixi run package && bash -c '\
 
 # clean build artifacts
 clean = "rm -f argmojo.mojopkg mgrep mgit demo yu"
+
+# Run all
+all = """pixi run package \
+&&pixi run doc \
+&&pixi run t \
+&&pixi run d \
+&&pixi run clean"""

--- a/pixi.toml
+++ b/pixi.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 name = "argmojo"
 platforms = ["osx-arm64", "linux-64"]
 readme = "README.md"
-version = "0.3.0"
+version = "0.4.0"
 
 [dependencies]
 mojo = "==0.26.2.0"
@@ -21,6 +21,10 @@ format = "mojo format ./src ./tests ./examples"
 
 # compile the package
 package = "mojo package src/argmojo -o argmojo.mojopkg"
+
+# doc
+doc = """pixi run mojo doc \
+--diagnose-missing-doc-strings --Werror src/argmojo"""
 
 # run tests
 test = """\

--- a/src/argmojo/argument.mojo
+++ b/src/argmojo/argument.mojo
@@ -957,26 +957,6 @@ struct Argument(Copyable, Movable, Writable):
     # String representation methods
     # ===------------------------------------------------------------------=== #
 
-    def __str__(self) -> String:
-        """Returns a string representation of this argument definition.
-
-        Returns:
-            A human-readable string describing the argument.
-        """
-        var s = String("Argument(name='") + self.name + "'"
-        if self._long_name:
-            s += ", long='--" + self._long_name + "'"
-        if self._short_name:
-            s += ", short='-" + self._short_name + "'"
-        if self._is_flag:
-            s += ", flag"
-        if self._is_positional:
-            s += ", positional"
-        if self._is_required:
-            s += ", required"
-        s += ")"
-        return s
-
     def write_to[W: Writer](self, mut writer: W):
         """Writes the string representation to a writer.
 

--- a/src/argmojo/argument.mojo
+++ b/src/argmojo/argument.mojo
@@ -958,7 +958,11 @@ struct Argument(Copyable, Movable, Writable):
     # ===------------------------------------------------------------------=== #
 
     def __str__(self) -> String:
-        """Returns a string representation of this argument definition."""
+        """Returns a string representation of this argument definition.
+
+        Returns:
+            A human-readable string describing the argument.
+        """
         var s = String("Argument(name='") + self.name + "'"
         if self._long_name:
             s += ", long='--" + self._long_name + "'"

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -4959,20 +4959,6 @@ struct Command(Copyable, Movable, Writable):
         s += indent + "esac\n"
         return s
 
-    def __str__(self) -> String:
-        """Returns a string representation of this command.
-
-        Returns:
-            A human-readable string describing the command.
-        """
-        return (
-            "Command(name='"
-            + self.name
-            + "', args="
-            + String(len(self.args))
-            + ")"
-        )
-
     def write_to[W: Writer](self, mut writer: W):
         """Writes the string representation to a writer.
 

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -4960,7 +4960,11 @@ struct Command(Copyable, Movable, Writable):
         return s
 
     def __str__(self) -> String:
-        """Returns a string representation of this command."""
+        """Returns a string representation of this command.
+
+        Returns:
+            A human-readable string describing the command.
+        """
         return (
             "Command(name='"
             + self.name

--- a/src/argmojo/parse_result.mojo
+++ b/src/argmojo/parse_result.mojo
@@ -380,7 +380,11 @@ struct ParseResult(Copyable, Movable, Writable):
             sub._print_summary_impl(indent + 2, self.subcommand)
 
     def __str__(self) -> String:
-        """Return a string representation of the parse result."""
+        """Return a string representation of the parse result.
+
+        Returns:
+            A human-readable summary string.
+        """
         var s = String("ParseResult(")
         s += "flags=" + String(len(self._flags))
         s += ", values=" + String(len(self._values))

--- a/src/argmojo/parse_result.mojo
+++ b/src/argmojo/parse_result.mojo
@@ -379,21 +379,6 @@ struct ParseResult(Copyable, Movable, Writable):
             var sub = self._subcommand_results[0].copy()
             sub._print_summary_impl(indent + 2, self.subcommand)
 
-    def __str__(self) -> String:
-        """Return a string representation of the parse result.
-
-        Returns:
-            A human-readable summary string.
-        """
-        var s = String("ParseResult(")
-        s += "flags=" + String(len(self._flags))
-        s += ", values=" + String(len(self._values))
-        s += ", positionals=" + String(len(self._positionals))
-        if self.subcommand != "":
-            s += ", subcommand='" + self.subcommand + "'"
-        s += ")"
-        return s
-
     def write_to[W: Writer](self, mut writer: W):
         """Writes the string representation to a writer.
 
@@ -403,4 +388,15 @@ struct ParseResult(Copyable, Movable, Writable):
         Args:
             writer: The writer to write to.
         """
-        writer.write(self.__str__())
+        writer.write("ParseResult(")
+        writer.write("flags=")
+        writer.write(String(len(self._flags)))
+        writer.write(", values=")
+        writer.write(String(len(self._values)))
+        writer.write(", positionals=")
+        writer.write(String(len(self._positionals)))
+        if self.subcommand != "":
+            writer.write(", subcommand='")
+            writer.write(self.subcommand)
+            writer.write("'")
+        writer.write(")")

--- a/tests/test_subcommands.mojo
+++ b/tests/test_subcommands.mojo
@@ -476,7 +476,7 @@ def test_parseresult_subcommand_result_stored_and_retrieved() raises:
     assert_equal(retrieved.get_string("pattern"), "hello")
 
 
-def test_parseresult_str_includes_subcommand() raises:
+def test_parseresult_write_to_includes_subcommand() raises:
     """Tests that write_to includes the subcommand name when set."""
     var result = ParseResult()
     result.subcommand = "build"
@@ -484,7 +484,7 @@ def test_parseresult_str_includes_subcommand() raises:
     assert_true("build" in s, msg="write_to should include the subcommand name")
 
 
-def test_parseresult_str_no_subcommand_section_when_empty() raises:
+def test_parseresult_write_to_omits_subcommand_when_empty() raises:
     """Tests that write_to omits the subcommand when it is empty."""
     var result = ParseResult()
     var s = String(result)

--- a/tests/test_subcommands.mojo
+++ b/tests/test_subcommands.mojo
@@ -477,20 +477,20 @@ def test_parseresult_subcommand_result_stored_and_retrieved() raises:
 
 
 def test_parseresult_str_includes_subcommand() raises:
-    """Tests that __str__ includes the subcommand name when set."""
+    """Tests that write_to includes the subcommand name when set."""
     var result = ParseResult()
     result.subcommand = "build"
     var s = String(result)
-    assert_true("build" in s, msg="__str__ should include the subcommand name")
+    assert_true("build" in s, msg="write_to should include the subcommand name")
 
 
 def test_parseresult_str_no_subcommand_section_when_empty() raises:
-    """Tests that __str__ omits the subcommand when it is empty."""
+    """Tests that write_to omits the subcommand when it is empty."""
     var result = ParseResult()
     var s = String(result)
     assert_false(
         "subcommand" in s,
-        msg="__str__ should not include 'subcommand' when empty",
+        msg="write_to should not include 'subcommand' when empty",
     )
 
 


### PR DESCRIPTION
This PR prepares the repository for the v0.4.0 release by updating documentation/release notes, aligning stringification with Mojo’s `Writable` conventions, and refreshing the pixi workspace configuration/lockfiles.

**Changes:**
- Remove `__str__` implementations from core structs and rely on `write_to` (`Writable`) for string representations.
- Update docs (user manual, changelog, README, planning doc) for Mojo v0.26.2+/v0.4.0 release content.
- Bump pixi workspace version and refresh pixi tasks/lockfile to reflect the new environment.