### PR TITLE
[core] Enable asterisk-masked password input

### DIFF
--- a/examples/demo.mojo
+++ b/examples/demo.mojo
@@ -101,9 +101,9 @@ Try these (build first with: pixi run package && mojo build -I src -o demo examp
   ./demo run myapp                            # no extra args → empty remainder
 
   # ── Subcommand: login (interactive prompting) ────────────────────────
-  ./demo login                                # prompts for user and token interactively
-  ./demo login --user alice --token secret    # no prompts needed
-  ./demo login --user alice                   # prompts only for token
+  ./demo login                                # prompts for user, token, and pin
+  ./demo login --user alice --token s --pin 1 # no prompts needed
+  ./demo login --user alice                   # prompts for token (hidden) and pin (****)
 """
 
 from argmojo import Argument, Command
@@ -352,9 +352,11 @@ def main() raises:
     app.add_subcommand(run^)
 
     # ── Subcommand: login (interactive prompting + password) ─────────────
-    # Demonstrates .prompt(), .prompt["..."](), and .password() for
-    # interactive input.  Missing arguments are prompted for
-    # interactively; the token is masked with asterisks (sudo-rs style).
+    # Demonstrates .prompt(), .prompt["..."](), and .password() /
+    # .password[True]() for interactive input.  Missing arguments are
+    # prompted for interactively.
+    #   token    → fully hidden  (.password())       — no echo at all
+    #   pin      → asterisk mode (.password[True]()) — echoes * per key
     var login = Command("login", "Authenticate with the service")
     login.add_argument(
         Argument("user", help="Username")
@@ -369,15 +371,15 @@ def main() raises:
         .short["t"]()
         .required()
         .prompt["Enter your API token"]()
-        .password[asterisk=False]()  # standard password mode: no echo at all
+        .password()  # fully hidden: no echo at all
     )
     login.add_argument(
-        Argument("birthdate", help="Birthdate")
-        .long["birthdate"]()
-        .short["b"]()
+        Argument("pin", help="Security PIN")
+        .long["pin"]()
+        .short["p"]()
         .required()
-        .prompt["Enter your birthdate"]()
-        .password[asterisk=True]()  # asterisk mode: echoes * for each keystroke
+        .prompt["Enter your security PIN"]()
+        .password[True]()  # asterisk mode: echoes * for each keystroke
     )
     login.add_argument(
         Argument("region", help="Server region")

--- a/examples/demo.mojo
+++ b/examples/demo.mojo
@@ -354,7 +354,7 @@ def main() raises:
     # ── Subcommand: login (interactive prompting + password) ─────────────
     # Demonstrates .prompt(), .prompt["..."](), and .password() for
     # interactive input.  Missing arguments are prompted for
-    # interactively; the token is masked (hidden input).
+    # interactively; the token is masked with asterisks (sudo-rs style).
     var login = Command("login", "Authenticate with the service")
     login.add_argument(
         Argument("user", help="Username")
@@ -369,7 +369,15 @@ def main() raises:
         .short["t"]()
         .required()
         .prompt["Enter your API token"]()
-        .password()
+        .password[asterisk=False]()  # standard password mode: no echo at all
+    )
+    login.add_argument(
+        Argument("birthdate", help="Birthdate")
+        .long["birthdate"]()
+        .short["b"]()
+        .required()
+        .prompt["Enter your birthdate"]()
+        .password[asterisk=True]()  # asterisk mode: echoes * for each keystroke
     )
     login.add_argument(
         Argument("region", help="Server region")

--- a/src/argmojo/argument.mojo
+++ b/src/argmojo/argument.mojo
@@ -151,6 +151,10 @@ struct Argument(Copyable, Movable, Writable):
     """If True, the user's input is hidden (not echoed) when prompted.
     Useful for passwords and other sensitive values.  Requires a
     terminal; falls back to normal input on non-interactive stdin."""
+    var _show_asterisk: Bool
+    """If True, each keystroke is echoed as ``*`` instead of being
+    completely hidden.  Inspired by sudo-rs.  Only meaningful when
+    ``_hide_input`` is also True."""
 
     # ===------------------------------------------------------------------=== #
     # Life cycle methods
@@ -200,6 +204,7 @@ struct Argument(Copyable, Movable, Writable):
         self._prompt = False
         self._prompt_text = ""
         self._hide_input = False
+        self._show_asterisk = False
 
     def __init__(out self, *, copy: Self):
         """Creates a copy of this argument.
@@ -248,6 +253,7 @@ struct Argument(Copyable, Movable, Writable):
         self._prompt = copy._prompt
         self._prompt_text = copy._prompt_text
         self._hide_input = copy._hide_input
+        self._show_asterisk = copy._show_asterisk
 
     def __init__(out self, *, deinit take: Self):
         """Moves the value from another Argument.
@@ -292,6 +298,7 @@ struct Argument(Copyable, Movable, Writable):
         self._prompt = take._prompt
         self._prompt_text = take._prompt_text^
         self._hide_input = take._hide_input
+        self._show_asterisk = take._show_asterisk
 
     # ===------------------------------------------------------------------=== #
     # Builder methods for configuring the argument
@@ -949,6 +956,41 @@ struct Argument(Copyable, Movable, Writable):
         ```
         """
         self._hide_input = True
+        if not self._prompt:
+            self._prompt = True
+        return self^
+
+    def password[asterisk: Bool](var self) -> Self:
+        """Marks this argument as a password with configurable echo style.
+
+        When ``asterisk`` is True, each keystroke is echoed as ``*``
+        (like sudo-rs) instead of being completely hidden.  This gives
+        the user visual feedback on how many characters have been typed
+        while still concealing the actual value.
+
+        When ``asterisk`` is False, behaves identically to the
+        parameterless ``.password()`` (input fully hidden).
+
+        Implies ``.prompt()`` if not already set.
+
+        Parameters:
+            asterisk: If True, echo ``*`` for each character.
+
+        Returns:
+            Self with hidden/asterisk input enabled.
+
+        Examples:
+
+        ```mojo
+        from argmojo import Argument
+        # Asterisk feedback (sudo-rs style):
+        _ = Argument("pass", help="Password").long["pass"]().password[True]()
+        # Fully hidden (same as .password()):
+        _ = Argument("pass", help="Password").long["pass"]().password[False]()
+        ```
+        """
+        self._hide_input = True
+        self._show_asterisk = asterisk
         if not self._prompt:
             self._prompt = True
         return self^

--- a/src/argmojo/argument.mojo
+++ b/src/argmojo/argument.mojo
@@ -956,6 +956,7 @@ struct Argument(Copyable, Movable, Writable):
         ```
         """
         self._hide_input = True
+        self._show_asterisk = False
         if not self._prompt:
             self._prompt = True
         return self^

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -2811,6 +2811,11 @@ struct Command(Copyable, Movable, Writable):
                 if a._show_asterisk:
                     # Asterisk mode: echo '*' for each keystroke.
                     value = _read_password_asterisk(msg)
+                    # Empty result means cancel (Ctrl-C) or EOF —
+                    # stop prompting, consistent with the input()
+                    # exception path in the non-asterisk branch.
+                    if len(value) == 0:
+                        return
                 else:
                     # Password mode: disable echo, read, re-enable echo,
                     # then print a newline (since the user's Enter is not

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -2810,11 +2810,9 @@ struct Command(Copyable, Movable, Writable):
             if a._hide_input:
                 if a._show_asterisk:
                     # Asterisk mode: echo '*' for each keystroke.
-                    value = _read_password_asterisk(msg)
-                    # Empty result means cancel (Ctrl-C) or EOF —
-                    # stop prompting, consistent with the input()
-                    # exception path in the non-asterisk branch.
-                    if len(value) == 0:
+                    try:
+                        value = _read_password_asterisk(msg)
+                    except e:
                         return
                 else:
                     # Password mode: disable echo, read, re-enable echo,

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -16,6 +16,7 @@ from .utils import (
     _correct_cjk_punctuation,
     _disable_echo,
     _display_width,
+    _read_password_asterisk,
     _restore_echo,
     _fullwidth_to_halfwidth,
     _has_fullwidth_chars,
@@ -2807,22 +2808,26 @@ struct Command(Copyable, Movable, Writable):
             # ── Read input ───────────────────────────────────────────
             var value: String
             if a._hide_input:
-                # Password mode: disable echo, read, re-enable echo,
-                # then print a newline (since the user's Enter is not
-                # echoed either on some terminals).
-                var saved = _disable_echo()
-                var echo_disabled = len(saved) > 0
-                try:
-                    value = input(msg)
-                except e:
+                if a._show_asterisk:
+                    # Asterisk mode: echo '*' for each keystroke.
+                    value = _read_password_asterisk(msg)
+                else:
+                    # Password mode: disable echo, read, re-enable echo,
+                    # then print a newline (since the user's Enter is not
+                    # echoed either on some terminals).
+                    var saved = _disable_echo()
+                    var echo_disabled = len(saved) > 0
+                    try:
+                        value = input(msg)
+                    except e:
+                        _ = _restore_echo(saved^)
+                        return
                     _ = _restore_echo(saved^)
-                    return
-                _ = _restore_echo(saved^)
-                # Print a newline so the cursor moves to the next line
-                # (the user's Enter was not echoed) — only if echo was
-                # actually disabled.
-                if echo_disabled:
-                    print()
+                    # Print a newline so the cursor moves to the next line
+                    # (the user's Enter was not echoed) — only if echo was
+                    # actually disabled.
+                    if echo_disabled:
+                        print()
             else:
                 try:
                     value = input(msg)

--- a/src/argmojo/utils.mojo
+++ b/src/argmojo/utils.mojo
@@ -562,21 +562,31 @@ def _restore_echo(var saved: List[UInt32]) -> Bool:
 comptime _ICANON_MACOS: UInt32 = 0x00000100
 comptime _ICANON_LINUX: UInt32 = 0x00000002
 
+# ── ISIG bitmask (platform-dependent) ───────────────────────────────────────
+# macOS: ISIG = 0x080 (bit 7 of c_lflag)
+# Linux: ISIG = 0x001 (bit 0 of c_lflag)
+comptime _ISIG_MACOS: UInt32 = 0x00000080
+comptime _ISIG_LINUX: UInt32 = 0x00000001
 
-def _read_password_asterisk(msg: String) -> String:
+
+def _read_password_asterisk(msg: String) raises -> String:
     """Reads a password interactively, echoing ``*`` for each keystroke.
 
-    Disables ECHO and ICANON in terminal settings so that each byte
-    is delivered immediately and without echo.  For every printable
-    byte, a ``*`` is written to stderr.  Backspace erases the last
-    ``*``.  Enter (LF/CR) finishes input.
+    Disables ECHO, ICANON, and ISIG in terminal settings so that each
+    byte is delivered immediately and without echo, and interrupt
+    signals (such as Ctrl-C) are read as raw bytes rather than
+    generating signals.  For every printable byte, a ``*`` is written
+    to stderr.  Backspace erases the last ``*``.  Enter (LF/CR)
+    finishes input.
 
     Prompt and feedback are written to stderr (unbuffered), following
     the convention used by ``sudo``, ``ssh``, and similar tools.
 
     Falls back to plain ``input()`` (visible) when stdin is not a
     terminal or the termios layout cannot be determined.
-    Returns an empty string on Ctrl-C or read error.
+
+    Raises on Ctrl-C, Ctrl-D (EOF), or read error after restoring
+    the terminal to its original settings.
     """
     from std.sys import stderr
 
@@ -589,44 +599,41 @@ def _read_password_asterisk(msg: String) -> String:
     var rc = external_call["tcgetattr", Int, Int, Int](0, Int(ptr))
     if rc != 0:
         # Not a terminal — fall back to regular input.
-        try:
-            return input()
-        except:
-            return ""
+        # Let input() raise on EOF so the caller can stop prompting.
+        return input()
 
     var saved = buf.copy()
     var offset = _lflag_offset(buf)
     if offset < 0:
-        try:
-            return input()
-        except:
-            return ""
+        return input()
 
-    # ── Disable ECHO + ICANON ────────────────────────────────────
+    # ── Disable ECHO + ICANON + ISIG ─────────────────────────────
     var icanon: UInt32
+    var isig: UInt32
     if offset == 6:  # macOS
         icanon = _ICANON_MACOS
+        isig = _ISIG_MACOS
     else:  # Linux
         icanon = _ICANON_LINUX
-    buf[offset] = buf[offset] & ~_ECHO & ~icanon
+        isig = _ISIG_LINUX
+    buf[offset] = buf[offset] & ~_ECHO & ~icanon & ~isig
     ptr = buf.unsafe_ptr()
     rc = external_call["tcsetattr", Int, Int, Int, Int](0, _TCSANOW, Int(ptr))
     _ = buf^
     if rc != 0:
         _ = _restore_echo(saved^)
-        try:
-            return input()
-        except:
-            return ""
+        return input()
 
     # ── Read one byte at a time ──────────────────────────────────
     var password = List[UInt8]()
     var one = List[UInt8](length=1, fill=0)
+    var cancelled = False
 
     while True:
         var one_ptr = one.unsafe_ptr()
         var n = external_call["read", Int, Int, Int, Int](0, Int(one_ptr), 1)
         if n <= 0:
+            cancelled = True
             break  # EOF or error
         var ch = one[0]
         if ch == 10 or ch == 13:  # Enter (LF / CR)
@@ -637,18 +644,21 @@ def _read_password_asterisk(msg: String) -> String:
                 # Erase one asterisk: cursor back, overwrite space, cursor back.
                 print("\x08 \x08", end="", file=stderr)
         elif ch == 3:  # Ctrl-C — cancel
-            print(file=stderr)
-            _ = _restore_echo(saved^)
-            return ""
+            cancelled = True
+            break
         elif ch == 4:  # Ctrl-D — EOF
+            cancelled = True
             break
         elif ch >= 32:  # Printable byte
             password.append(ch)
             print("*", end="", file=stderr)
 
-    # ── Restore terminal and build result ────────────────────────
+    # ── Always restore terminal before returning or raising ──────
     print(file=stderr)
     _ = _restore_echo(saved^)
+
+    if cancelled:
+        raise "password input cancelled"
 
     var result = String()
     for i in range(len(password)):

--- a/src/argmojo/utils.mojo
+++ b/src/argmojo/utils.mojo
@@ -552,3 +552,105 @@ def _restore_echo(var saved: List[UInt32]) -> Bool:
     # Keep saved alive — see _disable_echo comment.
     _ = saved^
     return rc == 0
+
+
+# ── ICANON bitmask (platform-dependent) ─────────────────────────────────────
+# macOS: ICANON = 0x100 (bit 8 of c_lflag)
+# Linux: ICANON = 0x002 (bit 1 of c_lflag)
+# We pick the right constant at runtime based on the c_lflag offset
+# detected by _lflag_offset().
+comptime _ICANON_MACOS: UInt32 = 0x00000100
+comptime _ICANON_LINUX: UInt32 = 0x00000002
+
+
+def _read_password_asterisk(msg: String) -> String:
+    """Reads a password interactively, echoing ``*`` for each keystroke.
+
+    Disables ECHO and ICANON in terminal settings so that each byte
+    is delivered immediately and without echo.  For every printable
+    byte, a ``*`` is written to stderr.  Backspace erases the last
+    ``*``.  Enter (LF/CR) finishes input.
+
+    Prompt and feedback are written to stderr (unbuffered), following
+    the convention used by ``sudo``, ``ssh``, and similar tools.
+
+    Falls back to plain ``input()`` (visible) when stdin is not a
+    terminal or the termios layout cannot be determined.
+    Returns an empty string on Ctrl-C or read error.
+    """
+    from std.sys import stderr
+
+    # ── Print prompt ─────────────────────────────────────────────
+    print(msg, end="", file=stderr)
+
+    # ── tcgetattr — save original terminal settings ──────────────
+    var buf = List[UInt32](length=_TERMIOS_BUF_LEN, fill=0)
+    var ptr = buf.unsafe_ptr()
+    var rc = external_call["tcgetattr", Int, Int, Int](0, Int(ptr))
+    if rc != 0:
+        # Not a terminal — fall back to regular input.
+        try:
+            return input()
+        except:
+            return ""
+
+    var saved = buf.copy()
+    var offset = _lflag_offset(buf)
+    if offset < 0:
+        try:
+            return input()
+        except:
+            return ""
+
+    # ── Disable ECHO + ICANON ────────────────────────────────────
+    var icanon: UInt32
+    if offset == 6:  # macOS
+        icanon = _ICANON_MACOS
+    else:  # Linux
+        icanon = _ICANON_LINUX
+    buf[offset] = buf[offset] & ~_ECHO & ~icanon
+    ptr = buf.unsafe_ptr()
+    rc = external_call["tcsetattr", Int, Int, Int, Int](0, _TCSANOW, Int(ptr))
+    _ = buf^
+    if rc != 0:
+        _ = _restore_echo(saved^)
+        try:
+            return input()
+        except:
+            return ""
+
+    # ── Read one byte at a time ──────────────────────────────────
+    var password = List[UInt8]()
+    var one = List[UInt8](length=1, fill=0)
+
+    while True:
+        var one_ptr = one.unsafe_ptr()
+        var n = external_call["read", Int, Int, Int, Int](0, Int(one_ptr), 1)
+        if n <= 0:
+            break  # EOF or error
+        var ch = one[0]
+        if ch == 10 or ch == 13:  # Enter (LF / CR)
+            break
+        elif ch == 127 or ch == 8:  # Backspace / Delete
+            if len(password) > 0:
+                _ = password.pop()
+                # Erase one asterisk: cursor back, overwrite space, cursor back.
+                print("\x08 \x08", end="", file=stderr)
+        elif ch == 3:  # Ctrl-C — cancel
+            print(file=stderr)
+            _ = _restore_echo(saved^)
+            return ""
+        elif ch == 4:  # Ctrl-D — EOF
+            break
+        elif ch >= 32:  # Printable byte
+            password.append(ch)
+            print("*", end="", file=stderr)
+
+    # ── Restore terminal and build result ────────────────────────
+    print(file=stderr)
+    _ = _restore_echo(saved^)
+
+    var result = String()
+    for i in range(len(password)):
+        result += chr(Int(password[i]))
+    return result^

--- a/src/argmojo/utils.mojo
+++ b/src/argmojo/utils.mojo
@@ -586,7 +586,18 @@ def _read_password_asterisk(msg: String) raises -> String:
     terminal or the termios layout cannot be determined.
 
     Raises on Ctrl-C, Ctrl-D (EOF), or read error after restoring
-    the terminal to its original settings.
+    the terminal to its original settings.  The exception message
+    distinguishes the cause:
+    - ``"password input cancelled"`` for Ctrl-C
+    - ``"password input EOF"`` for Ctrl-D / EOF
+    - ``"password input read error"`` for a read(2) failure
+
+    Note: passwords are assumed to be ASCII (the overwhelmingly common
+    case).  Non-ASCII / UTF-8 multi-byte input will produce one ``*``
+    per byte rather than per character, and backspace operates on bytes.
+    The plain ``.password()`` mode (using ``input()``) handles UTF-8
+    correctly and should be preferred when Unicode passphrases are
+    expected.
     """
     from std.sys import stderr
 
@@ -628,12 +639,14 @@ def _read_password_asterisk(msg: String) raises -> String:
     var password = List[UInt8]()
     var one = List[UInt8](length=1, fill=0)
     var cancelled = False
+    var cancel_reason = String()
 
     while True:
         var one_ptr = one.unsafe_ptr()
         var n = external_call["read", Int, Int, Int, Int](0, Int(one_ptr), 1)
         if n <= 0:
             cancelled = True
+            cancel_reason = "password input read error"
             break  # EOF or error
         var ch = one[0]
         if ch == 10 or ch == 13:  # Enter (LF / CR)
@@ -645,10 +658,30 @@ def _read_password_asterisk(msg: String) raises -> String:
                 print("\x08 \x08", end="", file=stderr)
         elif ch == 3:  # Ctrl-C — cancel
             cancelled = True
+            cancel_reason = "password input cancelled"
             break
         elif ch == 4:  # Ctrl-D — EOF
             cancelled = True
+            cancel_reason = "password input EOF"
             break
+        elif ch == 27:  # ESC — start of escape sequence (e.g. arrow keys)
+            # Consume remaining bytes of the sequence so they don't
+            # pollute the password buffer.  Typical sequences are
+            # 2-3 bytes (e.g. ESC [ A), but we read up to 8 to be safe.
+            var discard_count = 0
+            while discard_count < 8:
+                var esc_ptr = one.unsafe_ptr()
+                var n2 = external_call["read", Int, Int, Int, Int](
+                    0, Int(esc_ptr), 1
+                )
+                if n2 <= 0:
+                    break
+                # Stop after the terminating letter of a CSI sequence.
+                var esc_ch = one[0]
+                discard_count += 1
+                if esc_ch >= 64 and esc_ch <= 126:  # '@' .. '~'
+                    break
+            continue
         elif ch >= 32:  # Printable byte
             password.append(ch)
             print("*", end="", file=stderr)
@@ -658,7 +691,7 @@ def _read_password_asterisk(msg: String) raises -> String:
     _ = _restore_echo(saved^)
 
     if cancelled:
-        raise "password input cancelled"
+        raise cancel_reason
 
     var result = String()
     for i in range(len(password)):

--- a/tests/test_interactive.mojo
+++ b/tests/test_interactive.mojo
@@ -583,6 +583,95 @@ def test_password_not_set_on_normal_prompt() raises:
     )
 
 
+# ── password[asterisk] builder tests ─────────────────────────────────────────
+
+
+def test_password_asterisk_true_sets_fields() raises:
+    """Tests that .password[True]() sets both _hide_input and _show_asterisk."""
+    var arg = Argument("pin", help="PIN").long["pin"]().password[True]()
+    assert_true(arg._hide_input, msg="_hide_input should be True")
+    assert_true(arg._show_asterisk, msg="_show_asterisk should be True")
+    assert_true(arg._prompt, msg="_prompt should be implied")
+
+
+def test_password_asterisk_false_sets_fields() raises:
+    """Tests that .password[False]() sets _hide_input but not _show_asterisk."""
+    var arg = Argument("pass", help="Password").long["pass"]().password[False]()
+    assert_true(arg._hide_input, msg="_hide_input should be True")
+    assert_false(arg._show_asterisk, msg="_show_asterisk should be False")
+    assert_true(arg._prompt, msg="_prompt should be implied")
+
+
+def test_password_plain_resets_asterisk() raises:
+    """Tests that .password() after .password[True]() resets _show_asterisk.
+
+    The last builder call should win — .password() means fully hidden.
+    """
+    var arg = (
+        Argument("pass", help="Password")
+        .long["pass"]()
+        .password[True]()
+        .password()
+    )
+    assert_true(arg._hide_input, msg="_hide_input should be True")
+    assert_false(
+        arg._show_asterisk,
+        msg="_show_asterisk should be reset by .password()",
+    )
+
+
+def test_password_asterisk_copy_preserves() raises:
+    """Tests that copy preserves _show_asterisk."""
+    var original = Argument("pin", help="PIN").long["pin"]().password[True]()
+    var copy = original.copy()
+    assert_true(copy._show_asterisk, msg="copy should preserve _show_asterisk")
+    assert_true(copy._hide_input, msg="copy should preserve _hide_input")
+
+
+def test_password_asterisk_default_is_false() raises:
+    """Tests that _show_asterisk is False by default."""
+    var arg = Argument("name", help="Name").long["name"]()
+    assert_false(
+        arg._show_asterisk, msg="_show_asterisk should be False by default"
+    )
+
+
+def test_password_asterisk_skipped_when_value_provided() raises:
+    """Tests that asterisk password prompt is skipped when value is on CLI."""
+    var cmd = Command("test", "Test app")
+    cmd.add_argument(Argument("pin", help="PIN").long["pin"]().password[True]())
+
+    var args: List[String] = ["test", "--pin", "1234"]
+    var result = cmd.parse_arguments(args)
+    assert_equal(
+        result.get_string("pin"),
+        "1234",
+        msg="provided value should be used",
+    )
+
+
+def test_password_asterisk_with_default() raises:
+    """Tests asterisk password arg with a default.
+
+    When stdin is /dev/null, prompting stops and default is applied.
+    """
+    var cmd = Command("test", "Test app")
+    cmd.add_argument(
+        Argument("pin", help="PIN")
+        .long["pin"]()
+        .default["0000"]()
+        .password[True]()
+    )
+
+    var args: List[String] = ["test"]
+    var result = cmd.parse_arguments(args)
+    assert_equal(
+        result.get_string("pin"),
+        "0000",
+        msg="default should be used when stdin is not interactive",
+    )
+
+
 def test_password_positional() raises:
     """Tests password on a positional argument."""
     var cmd = Command("test", "Test app")


### PR DESCRIPTION
This PR adds support for “asterisk-masked” interactive password entry (echoing `*` per keystroke) as an alternative to fully-hidden password input, integrated into ArgMojo’s prompting flow.

**Changes:**
- Introduces a POSIX terminal raw-input helper to read passwords while printing `*` feedback.
- Extends `Argument` with `_show_asterisk` and a new `password[asterisk: Bool]()` builder variant.
- Updates `Command` interactive prompting to use the new asterisk mode and updates the demo.