### PR TITLE
[doc] Add a planning file for declarative API + Reorganize `Command`/`Argument` internals for clearer grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ArgMojo
 
-A command-line argument parser library for [Mojo](https://www.modular.com/mojo), inspired by Python's `argparse`, Rust's `clap`, Go's `cobra`, and other popular libraries.
+A command-line argument parser library for Mojo, inspired by Python's `argparse`, Rust's `clap`, Go's `cobra`, Swift's `swift-argument-parser`, and other popular libraries.
 
 <!-- 
 > **A**rguments **R**esolved and **G**rouped into **M**eaningful **O**ptions and **J**oined **O**bjects

--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -690,7 +690,7 @@ These features use capabilities already available in Mojo 0.26.2 and can be expe
 - **Two innovations beyond Swift**: (1) `to_command()` exposes the underlying `Command` for builder-level tweaks (groups, implications, coloured help); (2) `parse_split()` returns both typed struct + `ParseResult` for hybrid workflows.
 - **Optional** — Users who prefer the builder API are completely unaffected. Zero change to existing code.
 
-**Pre/Post run hooks** — Straightforward callback mechanism (`fn(ParseResult) raises`). No special language features needed; just needs API design and a decision on execution order with subcommands.
+**Pre/Post run hooks** — Straightforward callback mechanism (`def(ParseResult) raises`). No special language features needed; just needs API design and a decision on execution order with subcommands.
 
 #### Phase 7b: Blocked on Mojo Language Features
 

--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -14,93 +14,82 @@ This section summarises the key design patterns and features from well-known arg
 
 ### 2.1 Libraries Surveyed
 
-| Library               | Language     | Style                  | Key Insight for ArgMojo                                                                                                                                                                                                  |
-| --------------------- | ------------ | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **argparse** (stdlib) | Python       | Builder (add_argument) | Comprehensive feature set; nargs, choices, type conversion, subcommands, argument groups, mutually exclusive groups, metavar, suggest_on_error, BooleanOptionalAction                                                    |
-| **Click**             | Python       | Decorator-based        | Composable commands, lazy-loaded subcommands, context passing — decorator approach not applicable                                                                                                                        |
-| **cobra** + pflag     | Go           | Struct-based builder   | Subcommands with persistent/local flags, flag groups (mutually exclusive, required together, one required), command aliases, Levenshtein-distance suggestions, positional arg validators (ExactArgs, MinimumNArgs, etc.) |
-| **clap**              | Rust         | Builder + Derive       | Builder API is the reference model; Derive API uses macros (not available in Mojo)                                                                                                                                       |
-| **docopt**            | Python/multi | Usage-string-driven    | Generates parser from help text — elegant but too implicit for a typed language                                                                                                                                          |
+| Library                   | Language     | Style                        | Key Insight for ArgMojo                                                                                                                                                                                                  |
+| ------------------------- | ------------ | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **argparse** (stdlib)     | Python       | Builder (add_argument)       | Comprehensive feature set; nargs, choices, type conversion, subcommands, argument groups, mutually exclusive groups, metavar, suggest_on_error, BooleanOptionalAction                                                    |
+| **Click**                 | Python       | Decorator-based              | Composable commands, lazy-loaded subcommands, context passing — decorator approach not applicable                                                                                                                        |
+| **cobra** + pflag         | Go           | Struct-based builder         | Subcommands with persistent/local flags, flag groups (mutually exclusive, required together, one required), command aliases, Levenshtein-distance suggestions, positional arg validators (ExactArgs, MinimumNArgs, etc.) |
+| **clap**                  | Rust         | Builder + Derive             | Builder API is the reference model; Derive API uses macros (not available in Mojo)                                                                                                                                       |
+| **swift-argument-parser** | Swift        | Protocol + Property Wrappers | Struct-based derive via `@Argument`/`@Option`/`@Flag` property wrappers + `ParsableCommand` protocol; closest model to Mojo's parametric wrapper types                                                                   |
+| **docopt**                | Python/multi | Usage-string-driven          | Generates parser from help text — elegant but too implicit for a typed language                                                                                                                                          |
 
 ### 2.2 Universal Features Worth Adopting
 
 These features appear across multiple libraries and depend only on string operations and basic data structures.
 
-| Feature                            | argparse | Click | cobra | clap | Other                        | Planned phase |
-| ---------------------------------- | -------- | ----- | ----- | ---- | ---------------------------- | ------------- |
-| Long/short options with values     | ✓        | ✓     | ✓     | ✓    |                              | **Done**      |
-| Positional arguments               | ✓        | ✓     | ✓     | ✓    |                              | **Done**      |
-| Boolean flags                      | ✓        | ✓     | ✓     | ✓    |                              | **Done**      |
-| Default values                     | ✓        | ✓     | ✓     | ✓    |                              | **Done**      |
-| Required argument validation       | ✓        | ✓     | ✓     | ✓    |                              | **Done**      |
-| `--` stop marker                   | ✓        | ✓     | ✓     | ✓    |                              | **Done**      |
-| Auto `--help` / `-h` / `-?`        | ✓        | ✓     | ✓     | ✓    |                              | **Done**      |
-| Auto `--version` / `-V`            | ✓        | ✓     | ✓     | ✓    |                              | **Done**      |
-| Short flag merging (`-abc`)        | ✓        | —     | ✓     | ✓    |                              | **Done**      |
-| Display name for value             | ✓        | —     | —     | ✓    |                              | **Done**      |
-| Positional arg count validation    | —        | —     | ✓     | ✓    |                              | **Done**      |
-| Choices / enum validation          | ✓        | ✓     | —     | ✓    |                              | **Done**      |
-| Mutually exclusive flags           | ✓        | —     | ✓     | ✓    |                              | **Done**      |
-| Flags required together            | —        | —     | ✓     | —    |                              | **Done**      |
-| `--no-X` negation flags            | ✓ (3.9)  | —     | —     | ✓    |                              | **Done**      |
-| Long option prefix matching        | ✓        | —     | —     | —    |                              | **Done**      |
-| Append / collect action            | ✓        | ✓     | ✓     | ✓    |                              | **Done**      |
-| One-required group                 | —        | —     | ✓     | ✓    |                              | **Done**      |
-| Value delimiter (`--tag a,b,c`)    | —        | —     | ✓     | ✓    |                              | **Done**      |
-| Colored help (customisable)        | —        | ✓     | —     | ✓    | pixi                         | **Done**      |
-| Colored warning and error messages | -        | ✓     | -     | ✓    |                              | **Done**      |
-| Number of values per option        | ✓        | ✓     | —     | ✓    |                              | **Done**      |
-| Conditional requirement            | —        | —     | ✓     | ✓    |                              | **Done**      |
-| Numeric range validation           | —        | —     | —     | —    |                              | **Done**      |
-| Key-value map (`-Dkey=val`)        | —        | —     | —     | —    | Java `-D`, Docker `-e`       | **Done**      |
-| Aliases for long names             | —        | —     | ✓     | ✓    |                              | **Done**      |
-| Deprecated arguments               | ✓ (3.13) | —     | ✓     | —    |                              | **Done**      |
-| Negative number / stdin `−`        | ✓        | —     | ✓     | ✓    | `allow_hyphen_values()`      | **Done**      |
-| Subcommands                        | ✓        | ✓     | ✓     | ✓    |                              | **Done**      |
-| Auto-added `help` subcommand       | —        | —     | ✓     | ✓    | git, cargo, kubectl          | **Done**      |
-| Persistent (global) flags          | —        | —     | ✓     | ✓    | git `--no-pager` etc.        | **Done**      |
-| Suggest on typo (Levenshtein)      | ✓ (3.14) | —     | ✓     | ✓    |                              | **Done**      |
-| Subcommand aliases                 | —        | —     | ✓     | ✓    | cobra, clap                  | **Done**      |
-| Count with ceiling                 | -        | —     | —     | -    |                              | **Done**      |
-| Cap and floor (clamp) for ranges   | -        | ✓     | —     | —    | Click `IntRange(clamp=True)` | **Done**      |
-| Hidden subcommands                 | —        | —     | ✓     | ✓    |                              | **Done**      |
-| `NO_COLOR` env variable            | —        | —     | —     | —    | I need it personally         | **Done**      |
-| Response file (`@args.txt`)        | ✓        | —     | —     | —    | javac, MSBuild               | **Done**      |
-| Argument parents (shared args)     | ✓        | —     | —     | —    |                              | **Done**      |
-| Interactive prompting              | —        | ✓     | —     | —    |                              | **Done**      |
-| Password / masked input            | —        | ✓     | —     | —    |                              | **Done**      |
-| Confirmation (`--yes` / `-y`)      | —        | ✓     | —     | —    |                              | **Done**      |
-| REMAINDER number_of_values         | ✓        | —     | —     | —    |                              | **Done**      |
-| Partial parsing (known args)       | ✓        | —     | —     | ✓    |                              | **Done**      |
-| Require equals syntax              | —        | —     | —     | ✓    |                              | **Done**      |
-| Default-if-no-value                | ✓        | —     | —     | ✓    |                              | **Done**      |
-| Mutual implication (`implies`)     | —        | —     | —     | —    | ArgMojo unique feature       | **Done**      |
-| Shell completion script generation | —        | ✓     | ✓     | ✓    | bash / zsh / fish            | **Done**      |
-| Argument groups in help            | ✓        | —     | ✓     | ✓    |                              | **Done**      |
-| Value-name wrapping control        | —        | —     | —     | ✓    | clap, cargo, pixi, git       | **Done**      |
-| CJK-aware help formatting          | —        | —     | —     | —    | I need it personally         | **Done**      |
-| CJK full-to-half-width correction  | —        | —     | —     | —    | I need it personally         | **Done**      |
-| CJK punctuation detection          | —        | —     | —     | —    | I need it personally         | **Done**      |
-| Typed retrieval (`get_int()` etc.) | ✓        | ✓     | ✓     | ✓    |                              | **Done**      |
-| Comptime `StringLiteral` params    | —        | —     | —     | ✓    | clap derive macros           | **Done**      |
-| Registration-time name validation  | —        | —     | —     | ✓    | clap panic on unknown ID     | **Done**      |
-| Pre/Post run hooks                 | —        | —     | ✓     | —    |                              | Phase unknown |
-| `Parseable` trait for type params  | —        | —     | —     | ✓    |                              | Phase unknown |
-| Derive / struct-based schema       | —        | —     | —     | ✓    | Requires Mojo macros         | Phase unknown |
-| Enum → type mapping (real enums)   | —        | —     | —     | ✓    | Requires reflection          | Phase unknown |
-| Subcommand variant dispatch        | —        | —     | —     | ✓    | Requires sum types           | Phase unknown |
-
-### 2.3 Features Excluded (Infeasible or Inappropriate)
-
-| Feature                                       | Reason for Exclusion                                      |
-| --------------------------------------------- | --------------------------------------------------------- |
-| Derive / decorator API                        | Mojo has no macros or decorators                          |
-| Usage-string-driven parsing (docopt style)    | Too implicit; not a good fit for a typed systems language |
-| Type-conversion callbacks                     | Use `get_int()` / `get_string()` pattern instead          |
-| Config file reading (`fromfile_prefix_chars`) | Out of scope; users can pre-process argv                  |
-| Environment variable fallback                 | Can be done externally; not core parser responsibility    |
-| Template-customisable help (Go cobra style)   | Mojo has no template engine; help format is hardcoded     |
-| Path / URL / Duration value types             | Mojo stdlib has no `Path` / `Url` / `Duration` types yet  |
+| Feature                            | argparse | Click | cobra | clap | swift | Other                        | Planned phase |
+| ---------------------------------- | -------- | ----- | ----- | ---- | ----- | ---------------------------- | ------------- |
+| Long/short options with values     | ✓        | ✓     | ✓     | ✓    | ✓     |                              | **Done**      |
+| Positional arguments               | ✓        | ✓     | ✓     | ✓    | ✓     |                              | **Done**      |
+| Boolean flags                      | ✓        | ✓     | ✓     | ✓    | ✓     |                              | **Done**      |
+| Default values                     | ✓        | ✓     | ✓     | ✓    | ✓     |                              | **Done**      |
+| Required argument validation       | ✓        | ✓     | ✓     | ✓    | ✓     |                              | **Done**      |
+| `--` stop marker                   | ✓        | ✓     | ✓     | ✓    | ✓     |                              | **Done**      |
+| Auto `--help` / `-h` / `-?`        | ✓        | ✓     | ✓     | ✓    | ✓     |                              | **Done**      |
+| Auto `--version` / `-V`            | ✓        | ✓     | ✓     | ✓    | ✓     |                              | **Done**      |
+| Short flag merging (`-abc`)        | ✓        | —     | ✓     | ✓    | ✓     |                              | **Done**      |
+| Display name for value             | ✓        | —     | —     | ✓    | ✓     |                              | **Done**      |
+| Positional arg count validation    | —        | —     | ✓     | ✓    | ✓     |                              | **Done**      |
+| Choices / enum validation          | ✓        | ✓     | —     | ✓    | ✓     |                              | **Done**      |
+| Mutually exclusive flags           | ✓        | —     | ✓     | ✓    | ✓     |                              | **Done**      |
+| Flags required together            | —        | —     | ✓     | —    | —     |                              | **Done**      |
+| `--no-X` negation flags            | ✓ (3.9)  | —     | —     | ✓    | ✓     |                              | **Done**      |
+| Long option prefix matching        | ✓        | —     | —     | —    | —     |                              | **Done**      |
+| Append / collect action            | ✓        | ✓     | ✓     | ✓    | ✓     |                              | **Done**      |
+| One-required group                 | —        | —     | ✓     | ✓    | —     |                              | **Done**      |
+| Value delimiter (`--tag a,b,c`)    | —        | —     | ✓     | ✓    | —     |                              | **Done**      |
+| Colored help (customisable)        | —        | ✓     | —     | ✓    | —     | pixi                         | **Done**      |
+| Colored warning and error messages | -        | ✓     | -     | ✓    | —     |                              | **Done**      |
+| Number of values per option        | ✓        | ✓     | —     | ✓    | —     |                              | **Done**      |
+| Conditional requirement            | —        | —     | ✓     | ✓    | —     |                              | **Done**      |
+| Numeric range validation           | —        | —     | —     | —    | —     |                              | **Done**      |
+| Key-value map (`-Dkey=val`)        | —        | —     | —     | —    | —     | Java `-D`, Docker `-e`       | **Done**      |
+| Aliases for long names             | —        | —     | ✓     | ✓    | ✓     |                              | **Done**      |
+| Deprecated arguments               | ✓ (3.13) | —     | ✓     | —    | —     |                              | **Done**      |
+| Negative number / stdin `−`        | ✓        | —     | ✓     | ✓    | ✓     | `allow_hyphen_values()`      | **Done**      |
+| Subcommands                        | ✓        | ✓     | ✓     | ✓    | ✓     |                              | **Done**      |
+| Auto-added `help` subcommand       | —        | —     | ✓     | ✓    | ✓     | git, cargo, kubectl          | **Done**      |
+| Persistent (global) flags          | —        | —     | ✓     | ✓    | ✓     | git `--no-pager` etc.        | **Done**      |
+| Suggest on typo (Levenshtein)      | ✓ (3.14) | —     | ✓     | ✓    | ✓     |                              | **Done**      |
+| Subcommand aliases                 | —        | —     | ✓     | ✓    | ✓     | cobra, clap                  | **Done**      |
+| Count with ceiling                 | -        | —     | —     | -    | —     |                              | **Done**      |
+| Cap and floor (clamp) for ranges   | -        | ✓     | —     | —    | —     | Click `IntRange(clamp=True)` | **Done**      |
+| Hidden subcommands                 | —        | —     | ✓     | ✓    | ✓     |                              | **Done**      |
+| `NO_COLOR` env variable            | —        | —     | —     | —    | —     | I need it personally         | **Done**      |
+| Response file (`@args.txt`)        | ✓        | —     | —     | —    | —     | javac, MSBuild               | **Done**      |
+| Argument parents (shared args)     | ✓        | —     | —     | —    | ✓     |                              | **Done**      |
+| Interactive prompting              | —        | ✓     | —     | —    | —     |                              | **Done**      |
+| Password / masked input            | —        | ✓     | —     | —    | —     |                              | **Done**      |
+| Confirmation (`--yes` / `-y`)      | —        | ✓     | —     | —    | —     |                              | **Done**      |
+| REMAINDER number_of_values         | ✓        | —     | —     | —    | ✓     |                              | **Done**      |
+| Partial parsing (known args)       | ✓        | —     | —     | ✓    | —     |                              | **Done**      |
+| Require equals syntax              | —        | —     | —     | ✓    | —     |                              | **Done**      |
+| Default-if-no-value                | ✓        | —     | —     | ✓    | —     |                              | **Done**      |
+| Mutual implication (`implies`)     | —        | —     | —     | —    | —     | ArgMojo unique feature       | **Done**      |
+| Shell completion script generation | —        | ✓     | ✓     | ✓    | ✓     | bash / zsh / fish            | **Done**      |
+| Argument groups in help            | ✓        | —     | ✓     | ✓    | ✓     |                              | **Done**      |
+| Value-name wrapping control        | —        | —     | —     | ✓    | —     | clap, cargo, pixi, git       | **Done**      |
+| CJK-aware help formatting          | —        | —     | —     | —    | —     | I need it personally         | **Done**      |
+| CJK full-to-half-width correction  | —        | —     | —     | —    | —     | I need it personally         | **Done**      |
+| CJK punctuation detection          | —        | —     | —     | —    | —     | I need it personally         | **Done**      |
+| Typed retrieval (`get_int()` etc.) | ✓        | ✓     | ✓     | ✓    | ✓     |                              | **Done**      |
+| Comptime `StringLiteral` params    | —        | —     | —     | ✓    | ✓     | clap derive macros           | **Done**      |
+| Registration-time name validation  | —        | —     | —     | ✓    | ✓     | clap panic on unknown ID     | **Done**      |
+| Struct-based schema (reflection)   | —        | —     | —     | —    | ✓     | swift-argument-parser        | Phase 7a      |
+| Pre/Post run hooks                 | —        | —     | ✓     | —    | —     | Cobra                        | Phase 7a      |
+| Derive (macro/decorator-based)     | —        | —     | —     | ✓    | —     | clap `#[derive(Parser)]`     | Phase 7b      |
+| Enum → type mapping (real enums)   | —        | —     | —     | ✓    | ✓     | Requires reflection          | Phase 7b      |
+| Subcommand variant dispatch        | —        | —     | —     | ✓    | ✓     | Requires sum types           | Phase 7b      |
 
 ## 3. Technical Foundations
 
@@ -681,33 +670,37 @@ Note that the following punctuation characters are already handled by the full-w
 - [x] Rewrite `_display_width()`, `_has_fullwidth_chars()`, `_fullwidth_to_halfwidth()` using `codepoints()` API.
 - [x] Remove `_extra_whitespace_chars` field and `whitespace_characters()` API (unnecessary complexity).
 
-### Phase 7: Type-Safe API (aspirational — blocked on Mojo language features)
+### Phase 7: Nice-to-Have (Experimental)
 
-These features represent the "next generation" of CLI parser design, inspired by Rust clap's derive API. They require Mojo language features that do **not yet exist** (macros, reflection, sum types). Tracked here as aspirational goals.
+The features below are **not part of the core builder API**. They are split into sub-phases based on feasibility.
 
-> **Note on clap's success:** The claim that "clap succeeded because of strong typing" is partially misleading. clap's **builder API** (`matches.get_one::<String>("name")`) is structurally identical to ArgMojo's `result.get_string("name")` — both are runtime-typed string-keyed lookups. clap was the dominant Rust CLI library for years (v1–v3) before the derive macro was stabilised. The derive API's real value is **boilerplate reduction** (one struct definition encodes name, type, help, default), not type safety per se. Python argparse (dynamic `Namespace`), Go cobra (`GetString("name")`), and Click all use the same runtime-lookup pattern and are the most popular parsers in their ecosystems.
+#### Phase 7a: Feasible Now (Mojo 0.26.2)
 
-| Feature                                                   | What it needs                            | Status                  |
-| --------------------------------------------------------- | ---------------------------------------- | ----------------------- |
-| `Parseable` trait                                         | Mojo traits + parametric methods         | Can prototype now       |
-| `add_arg[Int]("--port")` generic registration             | `Parseable` trait + type-aware storage   | Can prototype now       |
-| `@cli struct Args` derive                                 | Mojo macros / decorators                 | Blocked — no macros     |
-| `enum Mode { Debug, Release }` → auto choices             | Mojo reflection on enum variants         | Blocked — no reflection |
-| `variant Command { Commit(CommitArgs), Push(PushArgs) }`  | Mojo sum types / enum with payloads      | Blocked — no sum types  |
-| `file: String` (required) vs `output: String?` (optional) | Derive macro to map struct fields → args | Blocked — no macros     |
-| `Path` / `Url` / `Duration` value types                   | Mojo stdlib types                        | Blocked — stdlib gaps   |
+These features use capabilities already available in Mojo 0.26.2 and can be experimented with immediately.
 
-#### What ArgMojo already provides (equivalent functionality)
+| Feature                        | Inspiration                | Status        | Planning doc                                               |
+| ------------------------------ | -------------------------- | ------------- | ---------------------------------------------------------- |
+| Declarative / struct-based API | swift-argument-parser      | Investigating | [declarative_api_planning.md](declarative_api_planning.md) |
+| Pre/Post run hooks             | cobra `PreRun` / `PostRun` | Investigating | TBD                                                        |
 
-| "Missing" feature            | ArgMojo equivalent                                                                                                                             | How                                             |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
-| Typed retrieval              | `get_flag()->Bool`, `get_int()->Int`, `get_string()->String`, `get_count()->Int`, `get_list()->List[String]`, `get_map()->Dict[String,String]` | Already typed at retrieval                      |
-| Enum validation              | `.choice["debug"]().choice["release"]()`                                                                                                       | String-level enum; help shows `{debug,release}` |
-| Required / optional          | `.required()` / `.default["..."]()`                                                                                                            | Parse-time enforcement with coloured errors     |
-| Flag counter (not just bool) | `.count()` + `get_count()`                                                                                                                     | `-vvv → 3`; `.count().max[N]()` caps at ceiling |
-| Range clamping               | `.range[min, max]().clamp()`                                                                                                                   | Adjusts out-of-range values with a warning      |
-| Subcommand dispatch          | `result.subcommand == "search"` + `get_subcommand_result()`                                                                                    | Same pattern as Go cobra                        |
-| Password / masked input      | `.password()` + `_disable_echo()`/`_restore_echo()`                                                                                            | POSIX termios echo control; Click `hide_input`  |
+**Declarative API summary** (see [full design doc](declarative_api_planning.md)):
+
+- **Layered on builder** — `declarative.mojo` is a consumer of `Command` + `Argument`; no new parsing engine.
+- **Swift-inspired** — Parametric wrapper types (`Option[T, ...]`, `Flag[...]`, `Argument[T, ...]`, `Count[...]`) mirror Swift's property wrappers (`@Option`, `@Flag`, `@Argument`). `ArgStruct` trait mirrors `ParsableCommand`.
+- **Two innovations beyond Swift**: (1) `to_command()` exposes the underlying `Command` for builder-level tweaks (groups, implications, coloured help); (2) `parse_split()` returns both typed struct + `ParseResult` for hybrid workflows.
+- **Optional** — Users who prefer the builder API are completely unaffected. Zero change to existing code.
+
+**Pre/Post run hooks** — Straightforward callback mechanism (`fn(ParseResult) raises`). No special language features needed; just needs API design and a decision on execution order with subcommands.
+
+#### Phase 7b: Blocked on Mojo Language Features
+
+These features require Mojo capabilities that do not exist yet. They will remain blocked until upstream Mojo adds them.
+
+| Feature                        | Inspiration                          | Blocked on                |
+| ------------------------------ | ------------------------------------ | ------------------------- |
+| Derive (macro/decorator-based) | clap `#[derive(Parser)]`             | Mojo proc macros          |
+| Enum → type mapping            | clap / swift `ExpressibleByArgument` | Reflection on enums       |
+| Subcommand variant dispatch    | clap / swift `CommandGroup`          | Sum types / tagged unions |
 
 ## 6. Parsing Algorithm
 

--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -685,8 +685,8 @@ These features use capabilities already available in Mojo 0.26.2 and can be expe
 
 **Declarative API summary** (see [full design doc](declarative_api_planning.md)):
 
-- **Layered on builder** — `declarative.mojo` is a consumer of `Command` + `Argument`; no new parsing engine.
-- **Swift-inspired** — Parametric wrapper types (`Option[T, ...]`, `Flag[...]`, `Argument[T, ...]`, `Count[...]`) mirror Swift's property wrappers (`@Option`, `@Flag`, `@Argument`). `ArgStruct` trait mirrors `ParsableCommand`.
+- **Layered on builder** — `declaration.mojo` is a consumer of `Command` + `Argument`; no new parsing engine.
+- **Swift-inspired** — Parametric wrapper types (`Option[T, ...]`, `Flag[...]`, `Positional[T, ...]`, `Count[...]`) mirror Swift's property wrappers (`@Option`, `@Flag`, `@Argument`). `Declarable` trait mirrors `ParsableCommand`.
 - **Two innovations beyond Swift**: (1) `to_command()` exposes the underlying `Command` for builder-level tweaks (groups, implications, coloured help); (2) `parse_split()` returns both typed struct + `ParseResult` for hybrid workflows.
 - **Optional** — Users who prefer the builder API are completely unaffected. Zero change to existing code.
 

--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -1,6 +1,6 @@
 # ArgMojo — Overall Planning
 
-> A command-line argument parser library for Mojo.
+> A command-line argument parser library for Mojo, inspired by Python's `argparse`, Rust's `clap`, Go's `cobra`, Swift's `swift-argument-parser`, and other popular libraries.
 
 ## 1. Why ArgMojo?
 

--- a/docs/declarative_api_planning.md
+++ b/docs/declarative_api_planning.md
@@ -3,19 +3,24 @@
 > **Status**: Planning  
 > **Target**: argmojo v0.5.0  
 > **Mojo Version**: 0.26.2+  
-> **Date**: 2026-03-24
+> **Intial Date**: 2026-03-24
+
+> 子曰工欲善其事必先利其器
+> The mechanic, who wishes to do his work well, must first sharpen his tools -- Confucius
 
 ## 1. Design Goals
 
-1. **Optional** — Users who prefer the builder API are completely unaffected. The declarative module is a separate import (`from argmojo.declarative import ...`). Zero change to existing code.
+I want the declarative API to satisfy five goals:
 
-2. **Hybrid** — Builder and declarative can coexist in a single program. A user can define a struct for 80% of arguments, then use builder methods for the remaining 20% (groups, implications, advanced constraints).
+1. **Optional** — If you prefer the builder API, nothing changes for you. The declaration module is a separate import (`from argmojo.declaration import ...`). Zero change to existing code.
 
-3. **Layered** — The declarative layer is a *consumer* of the builder layer. Internally it constructs `Command` + `Argument` objects and calls `Command.parse()`. No new parsing engine.
+2. **Hybrid** — Builder and declarative can coexist in a single program. You define a struct for 80% of arguments, then reach for builder methods for the remaining 20% (groups, implications, advanced constraints).
 
-4. **Type-safe** — Parsed results are returned as the user's own struct with typed fields, not `ParseResult.get_string("name")`.
+3. **Layered** — The declarative layer is a *consumer* of the builder layer. Internally it constructs `Command` + `Argument` objects and calls `Command.parse()`. I'm not building a new parsing engine.
 
-5. **Two innovations** - I think that there might be two possible features beyond what Swift Argument Parser offers (see [this section](#6-innovations)).
+4. **Type-safe** — Parsed results come back as your own struct with typed fields, not `ParseResult.get_string("name")`.
+
+5. **Two innovations** — I think there are two features I can offer beyond what Swift Argument Parser does (see [§6](#6-innovations)).
 
 ## 2. Mojo Reflection Capabilities (v0.26.2)
 
@@ -34,9 +39,9 @@ Available compile-time reflection primitives:
 | `comptime for idx in range(N)`      | Compile-time loop                        |
 | `comptime if condition`             | Compile-time conditional                 |
 
-**Key limitation**: No proc macros, no custom decorators, no `#[derive(...)]`. All declarative behavior must be implemented via parametric functions that reflect over user-defined structs.
+**Key limitation**: No proc macros, no custom decorators, no `#[derive(...)]`. So all declarative behavior has to be implemented via parametric functions that reflect over user-defined structs.
 
-**Primary inspiration — Swift Argument Parser**: Apple's [swift-argument-parser](https://github.com/apple/swift-argument-parser) is the most relevant prior art because Swift and Mojo share key language characteristics — static typing, struct-oriented design, and protocol/trait conformance. Swift uses **property wrappers** (`@Argument`, `@Option`, `@Flag`) as metadata carriers on struct fields. ArgMojo adopts the same vocabulary directly as **parametric wrapper types** (`Argument[T, ...]`, `Option[T, ...]`, `Flag[...]`), which carry CLI metadata as compile-time keyword parameters. Example:
+**Primary inspiration — Swift Argument Parser**: My main inspiration is Apple's [swift-argument-parser](https://github.com/apple/swift-argument-parser). Swift and Mojo share key language characteristics — static typing, struct-oriented design, and protocol/trait conformance — so it's the most relevant prior art. Swift uses **property wrappers** (`@Argument`, `@Option`, `@Flag`) as metadata carriers on struct fields. I adopted a similar approach using **parametric wrapper types** (`Positional[T, ...]`, `Option[T, ...]`, `Flag[...]`, `Count[...]`), which carry CLI metadata as compile-time keyword parameters. Here's how Swift looks:
 
 ```swift
 struct Greet: ParsableCommand {
@@ -58,22 +63,35 @@ Greet.main()
 
 Direct mapping to argmojo declarative API:
 
-| Swift Mechanism                  | ArgMojo Equivalent                          |
-| -------------------------------- | ------------------------------------------- |
-| `@Argument(help: "...")`         | `Argument[T, help="..."]`                   |
-| `@Option(name: .shortAndLong)`   | `Option[T, long="...", short="..."]`        |
-| `@Flag(inversion: .prefixedNo)`  | `Flag[negatable=True]`                      |
-| (no Swift equivalent)            | `Count[short="v", max=3]`                   |
-| `ParsableCommand` protocol       | `ArgStruct` trait                           |
-| `@OptionGroup`                   | Argument parents via `Command.add_parent()` |
-| `ExpressibleByArgument` protocol | Planned `Parseable` trait                   |
-| `CommandGroup`                   | `SubApp[...]`                               |
-| `mutating func run()`            | Separate: `App[T].parse()` returns T        |
-| `mutating func validate()`       | `def validate(self) raises` on `ArgStruct`  |
+| Swift Mechanism                  | ArgMojo Equivalent                           |
+| -------------------------------- | -------------------------------------------- |
+| `@Argument(help: "...")`         | `Positional[T, help="..."]`                  |
+| `@Option(name: .shortAndLong)`   | `Option[T, long="...", short="..."]`         |
+| `@Flag(inversion: .prefixedNo)`  | `Flag[negatable=True]`                       |
+| (no Swift equivalent)            | `Count[short="v", max=3]`                    |
+| (no Swift equivalent)            | `Declaration[T]`                             |
+| `ParsableCommand` protocol       | `Declarable` trait                           |
+| `@OptionGroup`                   | Argument parents via `Command.add_parent()`  |
+| `ExpressibleByArgument` protocol | `ExpressibleByArgument` trait                |
+| `CommandGroup`                   | `SubDeclaration[...]`                        |
+| `mutating func run()`            | Separate: `Declaration[T].parse()` returns T |
+| `mutating func validate()`       | `def validate(self) raises` on `Declarable`  |
 
-**What argmojo adds beyond Swift**: (1) `to_command()` exposes the underlying `Command` for builder-level customisation — Swift's `ParsableCommand` is a sealed box with no escape hatch to builder-level features like mutually exclusive groups, implications, or custom help formatting. (2) `parse_split()` returns both typed struct + `ParseResult` — Swift requires all fields to live in the struct. (3) Declarative is optional — Swift has no builder alternative; you must use the struct-based approach.
+What I think argmojo can add beyond Swift:
 
-**Lesson — `validate()`**: An optional `def validate(self) raises` method on `ArgStruct` (mirroring Swift's `validate()`) could complement `to_command()` for post-parse cross-field validation without requiring the builder API.
+1. `to_command()` exposes the underlying `Command` for builder-level customisation — Swift's `ParsableCommand` is a sealed box with no escape hatch to things like mutually exclusive groups, implications, or custom help formatting.
+2. `parse_split()` returns both typed struct + `ParseResult` — Swift requires all fields to live in the struct.
+3. Declarative is optional — Swift has no builder alternative; you *must* use the struct-based approach.
+
+**`validate()`**: I'm also thinking about an optional `def validate(self) raises` method on `Declarable` (mirroring Swift's `validate()`). It would complement `to_command()` for post-parse cross-field validation without requiring the builder API.
+
+**A note on naming** — I had to pick names for several structs and traits. Some were genuinely hard. The final names inevitably reflect my personal taste, but I tried to be consistent and self-explanatory. Here's what I chose and why:
+
+1. **`Declaration`**: It's really a declarative command — you call `.parse()` on it, much like `Command`. I wanted to call it `DeclarativeCommand`, but that's too long. `CLI` was another candidate, but `CLI.to_command()` reads oddly. `Declaration` felt right — short, clear, and it tells you this is the declarative counterpart to `Command`.
+
+2. **`Declarable`**: This is the trait that user structs conform to. I followed Mojo's `TypeName+able` pattern (`Int`→`Intable`, `String`→`Stringable`, `Declaration`→`Declarable`). I considered `Parsable` (à la Swift's `ParsableCommand`), but parsing is what `Declaration` does, not what the struct does — the struct *declares* CLI structure. `Declaration[T: Declarable]` reads naturally: "a declaration of something declarable." The deeper reason this naming is tricky: unlike Swift or Rust, we need *two* layers of abstraction — a user-defined struct layer and a builder layer. You should always think of the user struct (`Declarable`) and `Declaration` as a pair — one cannot exist without the other.
+
+3. **`Positional`**: Swift calls it `@Argument`, but I already have an `Argument` struct in the builder layer that covers *all* argument types. Two different `Argument` types with different meanings would be confusing. `Positional` is unambiguous — it tells you exactly what kind of argument it is.
 
 ## 3. Architecture
 
@@ -82,27 +100,27 @@ Direct mapping to argmojo declarative API:
 │  User Code                                                               │
 │                                                                          │
 │  @fieldwise_init                                                         │
-│  struct MyArgs(ArgStruct):                                               │
-│      var name: Argument[String, help="Name", required=True]              │
+│  struct MyArgs(Declarable):                                                │
+│      var name: Positional[String, help="Name", required=True]            │
 │      var verbose: Flag[short="v", help="Verbose"]                        │
 │      var output: Option[String, long="output", short="o"]                │
 │      def __init__(out self): self = arg_defaults[Self]()                 │
 │                                                                          │
-│  var app = App[MyArgs]()                                                 │
-│  var cmd = app.to_command()                                              │
+│  var decl = Declaration[MyArgs]()                                        │
+│  var cmd = decl.to_command()                                             │
 │  cmd.mutually_exclusive([...])                                           │
-│  var args = app.parse()  →  MyArgs (typed struct)                        │
+│  var args = decl.parse()  →  MyArgs (typed struct)                       │
 │                                                                          │
 ├──────────────────────────────────────────────────────────────────────────┤
-│  declarative.mojo  (NEW — ~400-600 lines)                                │
+│  declaration.mojo  (NEW — ~400-600 lines)                                │
 │                                                                          │
-│  App[T].to_command()    → Command    (reflect T → builder calls)         │
-│  App[T].parse()         → T          (parse + write-back)                │
-│  App[T].from_result()   → T          (ParseResult → struct)              │
+│  Declaration[T].to_command() → Command  (reflect T → builder calls)      │
+│  Declaration[T].parse()      → T        (parse + write-back)             │
+│  Declaration[T].from_result()→ T        (ParseResult → struct)           │
 │  arg_defaults[T]()      → T          (default-initialized)               │
 │                                                                          │
-│  Wrapper types: Option[T, ...], Flag[...], Argument[T, ...], Count[...]  │
-│  Trait: ArgStruct                                                        │
+│  Wrapper types: Positional[T, ...], Option[T, ...], Flag[...], Count[...]│
+│  Trait: Declarable                                                         │
 │                                                                          │
 ├──────────────────────────────────────────────────────────────────────────┤
 │  argument.mojo + command.mojo + parse_result.mojo  (UNCHANGED)           │
@@ -117,46 +135,53 @@ Direct mapping to argmojo declarative API:
 
 | File                           | Change                                           |
 | ------------------------------ | ------------------------------------------------ |
-| `src/argmojo/declarative.mojo` | **New file** — all declarative types and logic   |
-| `src/argmojo/__init__.mojo`    | Add `from .declarative import ...` (conditional) |
+| `src/argmojo/declaration.mojo` | **New file** — all declaration types and logic   |
+| `src/argmojo/__init__.mojo`    | Add `from .declaration import ...` (conditional) |
 | Everything else                | **Zero changes**                                 |
 
 ## 4. Detailed API Design
 
 ### 4.1 Wrapper Types
 
-These are lightweight parametric structs that carry CLI metadata as compile-time parameters while wrapping an inner value at runtime.
+These are lightweight parametric structs. They carry CLI metadata as compile-time parameters while wrapping an inner value at runtime. I'll walk through each one.
 
 ```mojo
 struct Option[
     T: Defaultable & Movable,
     *,
+    # ── Naming ──
     long: StringLiteral = "",       # --option name (empty = auto from field name)
     short: StringLiteral = "",      # -o single char
     help: StringLiteral = "",       # help text
+    alias_name: StringLiteral = "", # comma-separated alias long names
+    # ── Argument type ──
+    negatable: Bool = False,        # --x / --no-x (only if T is Bool)
+    # ── Value defaults & validation ──
     default: StringLiteral = "",    # default value as string
     required: Bool = False,         # must be provided
     choices: StringLiteral = "",    # comma-separated allowed values: "json,yaml,csv"
-    value_name: StringLiteral = "", # display name in help
-    hidden: Bool = False,           # hidden from help
-    deprecated: StringLiteral = "", # deprecation message
-    append: Bool = False,           # collect into list (T should be List[String])
-    delimiter: StringLiteral = "",  # split by delimiter
-    nargs: Int = 0,                 # number of values (0 = single)
     range_min: Int = 0,             # numeric range min
     range_max: Int = 0,             # numeric range max
     has_range: Bool = False,        # enable range validation
     clamp: Bool = False,            # clamp instead of error
+    # ── Collection modes ──
+    append: Bool = False,           # collect into list (T should be List[String])
+    delimiter: StringLiteral = "",  # split by delimiter
+    nargs: Int = 0,                 # number of values (0 = single)
     map_option: Bool = False,       # key=value map mode
+    # ── Parsing behavior ──
+    require_equals: Bool = False,   # require --key=value syntax
+    allow_hyphen: Bool = False,     # allow hyphen-prefixed values
     persistent: Bool = False,       # inherited by subcommands
+    # ── Display & help ──
+    value_name: StringLiteral = "", # display name in help
+    hidden: Bool = False,           # hidden from help
+    deprecated: StringLiteral = "", # deprecation message
+    group: StringLiteral = "",      # help group name
+    # ── Interactive prompting ──
     prompt: Bool = False,           # interactive prompt if missing
     prompt_text: StringLiteral = "",# custom prompt message
     password: Bool = False,         # masked input
-    require_equals: Bool = False,   # require --key=value syntax
-    alias: StringLiteral = "",      # comma-separated alias long names
-    negatable: Bool = False,        # --x / --no-x (only if T is Bool)
-    allow_hyphen: Bool = False,     # allow hyphen-prefixed values
-    group: StringLiteral = "",      # help group name
 ](Copyable, Movable, Defaultable):
     var value: T
 
@@ -170,16 +195,17 @@ struct Option[
 ```mojo
 # Convenience aliases for common patterns
 
-alias Flag = Option[Bool, ...]     # Can't do this directly in Mojo yet.
-                                # Instead, Flag is a separate struct:
-
 struct Flag[
     *,
+    # ── Naming ──
     long: StringLiteral = "",
     short: StringLiteral = "",
     help: StringLiteral = "",
+    # ── Argument type ──
     negatable: Bool = False,
+    # ── Parsing behavior ──
     persistent: Bool = False,
+    # ── Display & help ──
     hidden: Bool = False,
     deprecated: StringLiteral = "",
     group: StringLiteral = "",
@@ -198,15 +224,18 @@ struct Flag[
 ```
 
 ```mojo
-struct Argument[
+struct Positional[
     T: Defaultable & Movable,
     *,
     help: StringLiteral = "",
+    # ── Argument type ──
+    remainder: Bool = False,       # consume all remaining tokens
+    # ── Value defaults & validation ──
     default: StringLiteral = "",
     required: Bool = False,
     choices: StringLiteral = "",
+    # ── Display & help ──
     value_name: StringLiteral = "",
-    remainder: Bool = False,       # consume all remaining tokens
     group: StringLiteral = "",
 ](Copyable, Movable, Defaultable):
     var value: T
@@ -221,11 +250,15 @@ struct Argument[
 ```mojo
 struct Count[
     *,
+    # ── Naming ──
     long: StringLiteral = "",
     short: StringLiteral = "",
     help: StringLiteral = "",
+    # ── Argument type ──
     max: Int = 0,                  # 0 = no ceiling
+    # ── Parsing behavior ──
     persistent: Bool = False,
+    # ── Display & help ──
     hidden: Bool = False,
     group: StringLiteral = "",
 ](Copyable, Movable, Defaultable):
@@ -238,30 +271,36 @@ struct Count[
         self.value = val
 ```
 
-**Design choice**: Four wrapper types (`Option`, `Flag`, `Argument`, `Count`) instead of one overloaded `Option` with `is_arg=True` / `is_flag=True`. This is intentional:
+I use four distinct wrapper types (`Positional`, `Option`, `Flag`, `Count`) instead of one overloaded struct with `is_arg=True` / `is_flag=True`. Each type maps to exactly one **mental model** of how a CLI argument works:
 
-- Explicit intent: `Flag[...]` is obviously a flag, `Argument[...]` is obviously positional
-- Fewer confusing parameter combinations (e.g., `Argument` doesn't have `long`/`short`)
-- Better compile-time validation (can't accidentally make a positional with `long`)
+| Wrapper         | CLI syntax                   | Mental model                                | Example               |
+| --------------- | ---------------------------- | ------------------------------------------- | --------------------- |
+| `Positional[T]` | Bare value, matched by order | "user types a bare value"                   | `tool input.txt`      |
+| `Option[T]`     | `--key value` or `-k value`  | "user types a named key-value pair"         | `tool --output f.txt` |
+| `Flag`          | `--switch` (no value)        | "user flips a boolean switch"               | `tool --verbose`      |
+| `Count`         | `-vvv` (repeated)            | "user repeats a flag to increase intensity" | `tool -vvv`           |
 
-Users can also use **bare types** (like `String`, `Int`, `Bool`) for fields without metadata — they become options named after the field, following Swift's convention for fields without property wrappers.
+This is intentional. Here's why I like it:
 
-**Naming note — `Argument` builder vs declarative**: The builder API already has an `Argument` struct (in `argument.mojo`) for defining individual arguments. The declarative module introduces `Argument[T, ...]` (in `declarative.mojo`) as the positional argument wrapper, matching Swift's `@Argument`. They live in separate modules:
+- **Explicit intent**: `Flag[...]` is obviously a flag, `Positional[...]` is obviously positional — the type name *is* the documentation.
+- **Fewer confusing parameter combinations**: `Positional` doesn't have `long`/`short`, `Flag` doesn't have `append`/`delimiter` — impossible states are unrepresentable.
+- **Better compile-time validation**: You can't accidentally make a positional with `long`, or a flag with `nargs`.
 
-- `from argmojo import Argument` — builder struct, constructed at runtime: `Argument("name", help="...")`
-- `from argmojo.declarative import Argument` — parametric wrapper, used as a field type: `var name: Argument[String, help="..."]`
+**Why `Positional` instead of `Argument`?** Swift Argument Parser uses `@Argument` for positional arguments. I deliberately chose `Positional` instead, because my builder API already has an `Argument` struct (in `argument.mojo`) that covers *all* argument types. Two different `Argument` types — one meaning "everything" in the builder layer and another meaning "positional only" in the declarative layer — would be confusing. `Positional` is unambiguous: it tells you exactly what it does.
 
-In **pure declarative** mode, no conflict. In **hybrid** mode where both are needed, use aliased imports:
+You can also use **bare types** (like `String`, `Int`, `Bool`) for fields without metadata — they become options named after the field, following Swift's convention for fields without property wrappers.
+
+In **hybrid** mode, imports are clean with no name collisions:
 
 ```mojo
-from argmojo import Command, Argument as BuilderArgument
-from argmojo.declarative import App, Option, Flag, Argument, ArgStruct
+from argmojo import Command, Argument
+from argmojo.declaration import Declaration, Option, Flag, Positional, Declarable
 ```
 
-### 4.2 The `ArgStruct` Trait
+### 4.2 The `Declarable` Trait
 
 ```mojo
-trait ArgStruct(Defaultable, Movable):
+trait Declarable(Defaultable, Movable):
     """Marker trait for structs that can be parsed from CLI arguments."""
 
     @staticmethod
@@ -280,12 +319,12 @@ trait ArgStruct(Defaultable, Movable):
         ...
 ```
 
-Minimal implementation by users:
+Minimal implementation — you only need to provide `description()`:
 
 ```mojo
 @fieldwise_init
-struct MyArgs(ArgStruct):
-    var input: Argument[String, help="Input file", required=True]
+struct MyArgs(Declarable):
+    var input: Positional[String, help="Input file", required=True]
 
     def __init__(out self): self = arg_defaults[Self]()
 
@@ -296,10 +335,10 @@ struct MyArgs(ArgStruct):
 
 `version()` and `name()` have default implementations in the trait, so they're optional.
 
-### 4.3 The `App[T]` Orchestrator
+### 4.3 The `Declaration[T]` Orchestrator
 
 ```mojo
-struct App[T: ArgStruct]:
+struct Declaration[T: Declarable]:
     """Orchestrates struct-to-command conversion, parsing, and write-back."""
 
     var _command: Command
@@ -386,8 +425,8 @@ struct App[T: ArgStruct]:
                 self._register_option(fname, ftype)
             elif _is_flag_type(ftype):
                 self._register_flag(fname, ftype)
-            elif _is_argument_type(ftype):
-                self._register_argument(fname, ftype)
+            elif _is_positional_type(ftype):
+                self._register_positional(fname, ftype)
             elif _is_count_type(ftype):
                 self._register_count(fname, ftype)
             else:
@@ -411,13 +450,13 @@ struct App[T: ArgStruct]:
             elif _is_count_type(ftype):
                 ref field = __struct_field_ref(idx, out)
                 field.value = result.get_count(String(fname))
-            elif _is_argument_type(ftype):
+            elif _is_positional_type(ftype):
                 ref field = __struct_field_ref(idx, out)
                 # Write positional value:
                 #   If T is List[String] → get_list
                 #   If T is String → get_string
                 #   If T is Int → get_int
-                _write_argument_value(field, fname, result)
+                _write_positional_value(field, fname, result)
             elif _is_option_type(ftype):
                 ref field = __struct_field_ref(idx, out)
                 _write_option_value(field, fname, result)
@@ -431,19 +470,19 @@ struct App[T: ArgStruct]:
 
 ### 4.4 The `arg_defaults[T]()` Helper
 
-Initialises all wrapper fields to their defaults (inspired by Swift's default property initialization):
+This initialises all wrapper fields to their defaults (inspired by Swift's default property initialization):
 
 ```mojo
-def arg_defaults[T: ArgStruct]() -> T:
+def arg_defaults[T: Declarable]() -> T:
     """Create a default-initialized instance of T.
-    Wrapper types (Option, Flag, Argument, Count) are initialized to their defaults.
+    Wrapper types (Positional, Option, Flag, Count) are initialized to their defaults.
     Bare types use their Defaultable implementation."""
     return T()  # Works because T: Defaultable, and all wrappers are Defaultable
 ```
 
 ### 4.5 Auto-Naming Convention
 
-When `long` is not explicitly provided, the field name is used with underscores converted to hyphens:
+When you don't provide an explicit `long`, I use the field name with underscores converted to hyphens:
 
 | Field name    | Auto-generated long | Short  |
 | ------------- | ------------------- | ------ |
@@ -451,11 +490,11 @@ When `long` is not explicitly provided, the field name is used with underscores 
 | `verbose`     | `--verbose`         | (none) |
 | `output_file` | `--output-file`     | (none) |
 
-This matches the Swift and clap convention. Fields wrapped in `Argument[...]` do not get auto-generated long names.
+This matches how Swift and clap do it. Fields wrapped in `Positional[...]` don't get auto-generated long names.
 
 ### 4.6 Choice Parsing from StringLiteral
 
-Since Mojo parameters must be compile-time constants and we can't pass `List[StringLiteral]`, choices are encoded as a comma-separated string:
+Since Mojo parameters must be compile-time constants and I can't pass `List[StringLiteral]`, choices are encoded as a comma-separated string:
 
 ```mojo
 var format: Option[String, choices="json,yaml,csv", default="json"]
@@ -463,10 +502,10 @@ var format: Option[String, choices="json,yaml,csv", default="json"]
 
 Internally, `_register_option()` splits by `,` and calls `.choice["json"]().choice["yaml"]().choice["csv"]()` etc.
 
-Similarly, `alias` is comma-separated:
+Similarly, `alias_name` is comma-separated:
 
 ```mojo
-var output: Option[String, long="output", alias="out,dest"]
+var output: Option[String, long="output", alias_name="out,dest"]
 ```
 
 This generates `.alias_name["out"]().alias_name["dest"]()`.
@@ -476,14 +515,14 @@ This generates `.alias_name["out"]().alias_name["dest"]()`.
 ### 5.1 Pure Declarative (Simple Tool)
 
 ```mojo
-from argmojo.declarative import App, Option, Flag, Argument, Count, ArgStruct, arg_defaults
+from argmojo.declaration import Declaration, Option, Flag, Positional, Count, Declarable, arg_defaults
 
 @fieldwise_init
-struct Grep(ArgStruct):
+struct Grep(Declarable):
     """Search for patterns in files."""
 
-    var pattern: Argument[String, help="Search pattern", required=True]
-    var path: Argument[String, help="File or directory", default="."]
+    var pattern: Positional[String, help="Search pattern", required=True]
+    var path: Positional[String, help="File or directory", default="."]
     var ignore_case: Flag[short="i", help="Case-insensitive search"]
     var count_only: Flag[short="c", long="count", help="Only print match count"]
     var max_count: Option[Int, short="m", long="max-count", help="Stop after N matches", default="0"]
@@ -502,7 +541,7 @@ struct Grep(ArgStruct):
         return "1.0.0"
 
 def main() raises:
-    var args = App[Grep]().parse()
+    var args = Declaration[Grep]().parse()
 
     print("Pattern:", args.pattern.value)
     print("Path:", args.path.value)
@@ -517,12 +556,12 @@ def main() raises:
 ### 5.2 Declarative + Builder Hybrid (Complex Tool)
 
 ```mojo
-from argmojo import Command, Argument as BuilderArgument
-from argmojo.declarative import App, Option, Flag, Argument, ArgStruct, arg_defaults
+from argmojo import Command, Argument
+from argmojo.declaration import Declaration, Option, Flag, Positional, Declarable, arg_defaults
 
 @fieldwise_init
-struct Deploy(ArgStruct):
-    var target: Argument[String, help="Deploy target", required=True, choices="staging,prod"]
+struct Deploy(Declarable):
+    var target: Positional[String, help="Deploy target", required=True, choices="staging,prod"]
     var force: Flag[short="f", help="Force deploy without checks"]
     var dry_run: Flag[long="dry-run", help="Simulate without changes"]
     var tag: Option[String, long="tag", short="t", help="Release tag"]
@@ -536,19 +575,19 @@ struct Deploy(ArgStruct):
         return "Deploy application to target environment."
 
 def main() raises:
-    var app = App[Deploy]()
+    var decl = Declaration[Deploy]()
 
-    # Bridge to builder: add constraints that declarative can't express
-    var cmd = app.to_command()
+    # Bridge to builder: add constraints that declaration can't express
+    var cmd = decl.to_command()
     cmd.mutually_exclusive(["force", "dry-run"])
     cmd.implies("force", "tag")       # force requires a tag
     cmd.confirmation_option["Deploy to production?"]()
     cmd.header_color["CYAN"]()
     cmd.add_tip("Use --dry-run to preview changes first")
 
-    # app.parse() returns typed T; cmd.parse() would return untyped ParseResult.
-    # Always prefer app.parse() or app.parse_split() in hybrid mode.
-    var args = app.parse()
+    # decl.parse() returns typed T; cmd.parse() would return untyped ParseResult.
+    # Always prefer decl.parse() or decl.parse_split() in hybrid mode.
+    var args = decl.parse()
     print("Deploying to:", args.target.value)
     print("Tag:", args.tag.value)
 ```
@@ -556,12 +595,12 @@ def main() raises:
 ### 5.3 Split Parse (Declarative + Extra Builder Fields)
 
 ```mojo
-from argmojo import Command, Argument as BuilderArgument
-from argmojo.declarative import App, Argument, Option, Flag, ArgStruct, arg_defaults
+from argmojo import Command, Argument
+from argmojo.declaration import Declaration, Positional, Option, Flag, Declarable, arg_defaults
 
 @fieldwise_init
-struct Convert(ArgStruct):
-    var input: Argument[String, help="Input file", required=True]
+struct Convert(Declarable):
+    var input: Positional[String, help="Input file", required=True]
     var output: Option[String, long="output", short="o", help="Output file"]
 
     def __init__(out self): self = arg_defaults[Self]()
@@ -571,24 +610,24 @@ struct Convert(ArgStruct):
         return "File format converter."
 
 def main() raises:
-    var app = App[Convert]()
+    var decl = Declaration[Convert]()
 
     # Add extra builder-only arguments via to_command()
-    var cmd = app.to_command()
+    var cmd = decl.to_command()
     cmd.add_argument(
-        BuilderArgument("format", help="Output format")
+        Argument("format", help="Output format")
         .long["format"]().short["f"]()
         .choice["json"]().choice["yaml"]().choice["toml"]()
         .default["json"]()
     )
     cmd.add_argument(
-        BuilderArgument("indent", help="Indent level")
+        Argument("indent", help="Indent level")
         .long["indent"]()
         .range[0, 8]().default["2"]()
     )
 
     # parse_split returns BOTH the typed struct AND the raw ParseResult
-    args, result = app.parse_split()
+    args, result = decl.parse_split()
 
     # Declarative fields: typed access
     print("Input:", args.input.value)
@@ -602,11 +641,11 @@ def main() raises:
 ### 5.4 Subcommands with Declarative
 
 ```mojo
-from argmojo.declarative import App, SubApp, Option, Flag, Argument, ArgStruct, arg_defaults
+from argmojo.declaration import Declaration, SubDeclaration, Option, Flag, Positional, Declarable, arg_defaults
 
 @fieldwise_init
-struct Clone(ArgStruct):
-    var url: Argument[String, help="Repository URL", required=True]
+struct Clone(Declarable):
+    var url: Positional[String, help="Repository URL", required=True]
     var depth: Option[Int, long="depth", help="Clone depth", default="0"]
     var branch: Option[String, short="b", long="branch", help="Branch to clone"]
 
@@ -621,8 +660,8 @@ struct Clone(ArgStruct):
         return "clone"
 
 @fieldwise_init
-struct Push(ArgStruct):
-    var remote: Argument[String, help="Remote name", default="origin"]
+struct Push(Declarable):
+    var remote: Positional[String, help="Remote name", default="origin"]
     var force: Flag[short="f", help="Force push"]
     var tags: Flag[long="tags", help="Push all tags"]
 
@@ -637,8 +676,8 @@ struct Push(ArgStruct):
         return "push"
 
 def main() raises:
-    # SubApp registers multiple ArgStruct types as subcommands
-    var result = SubApp["mgit", "A mini git tool", Clone, Push]().parse()
+    # SubDeclaration registers multiple Declarable types as subcommands
+    var result = SubDeclaration["mgit", "A mini git tool", Clone, Push]().parse()
 
     if result.subcommand == "clone":
         var args = result.get[Clone]()
@@ -652,13 +691,13 @@ def main() raises:
 
 ### 6.1 Innovation #1: `to_command()` — First-Class Declarative-Builder Bridge
 
-**What Swift Argument Parser lacks**: Swift's `ParsableCommand` is a sealed protocol — there is no escape hatch to add builder-level configuration (mutually exclusive groups, implications, colored help, tips, completions). Users who need advanced constraints must implement `validate()` and custom help formatting manually, with no access to a builder API.
+**What Swift Argument Parser lacks**: Swift's `ParsableCommand` is a sealed protocol — there's no escape hatch to add builder-level configuration. If you need mutually exclusive groups, implications, colored help, tips, or completions, you're on your own with `validate()` and custom help formatting.
 
-**What argmojo adds**: `to_command()` returns a mutable reference to the underlying `Command` object, allowing arbitrary builder modifications before parsing:
+**What I'm adding**: `to_command()` returns a mutable reference to the underlying `Command` object, so you can do arbitrary builder modifications before parsing:
 
 ```mojo
-var app = App[MyArgs]()
-var cmd = app.to_command()
+var decl = Declaration[MyArgs]()
+var cmd = decl.to_command()
 cmd.mutually_exclusive(["json", "yaml"])
 cmd.required_together(["username", "password"])
 cmd.implies("debug", "verbose")
@@ -666,7 +705,7 @@ cmd.confirmation_option()
 cmd.header_color["CYAN"]()
 cmd.add_tip("See docs at https://example.com")
 cmd.completions_as_subcommand()
-var args = app.parse()
+var args = decl.parse()
 ```
 
 This creates a **smooth gradient** between simplicity and power:
@@ -677,49 +716,49 @@ Pure declarative     Declarative + to_command()    Pure builder
 Simple tools    →    Medium complexity tools   →    Maximum control
 ```
 
-No other Mojo CLI library offers this continuum. You never have to completely rewrite from one style to another when requirements grow.
+I don't know of any other Mojo CLI library that offers this continuum. You never have to completely rewrite from one style to another when requirements grow.
 
-**Type safety note**: Using `to_command()` to add **constraints** (groups, implications, colours) preserves full type safety — `parse()` still returns `T`. Using it to add **new arguments** (`add_argument(...)`) introduces partially untyped access — those fields are only available via `ParseResult` from `parse_split()`. This is an intentional trade-off:
+**Type safety note**: If you use `to_command()` to add **constraints** (groups, implications, colours), full type safety is preserved — `parse()` still returns `T`. But if you add **new arguments** (`add_argument(...)`), those fields are only available via `ParseResult` from `parse_split()`. This is an intentional trade-off:
 
 ```txt
-to_command() + constraints only     →  parse()        →  T (fully typed ✅)
+to_command() + constraints only     →  parse()        →  T (fully typed ✓)
 to_command() + new arguments        →  parse_split()  →  (T, ParseResult) (partially typed ⚠️)
 ```
 
-**`configure()` with non-capturing callbacks**: Verified in Mojo 0.26.2 — `configure()` works with non-capturing callbacks (nested functions that don't capture external state). Since `configure()` callbacks only operate on the `mut Command` parameter, capturing is unnecessary:
+**`configure()` with non-capturing callbacks**: I've verified in Mojo 0.26.2 that `configure()` works with non-capturing callbacks (nested functions that don't capture external state). Since `configure()` callbacks only operate on the `mut Command` parameter, capturing is unnecessary:
 
 ```mojo
-var args = App[MyArgs]()
+var args = Declaration[MyArgs]()
     .configure(def(mut cmd) raises: cmd.mutually_exclusive([...]))
     .configure(def(mut cmd) raises: cmd.implies("a", "b"))
     .parse()
 ```
 
-**Limitation**: Mojo's capturing closures (`unified {mut x}`) produce a `nonescaping closure` type that cannot be passed as a bare `def()` argument. This doesn't affect `configure()` since its callbacks don't need captures — the `mut Command` parameter provides all necessary state.
+**Limitation**: Mojo's capturing closures (`unified {mut x}`) produce a `nonescaping closure` type that can't be passed as a bare `def()` argument. This doesn't affect `configure()` since its callbacks don't need captures — the `mut Command` parameter provides all necessary state.
 
-`to_command()` remains the primary bridge for multi-step customization; `configure()` is syntactic sugar for one-liner tweaks.
+`to_command()` is the primary bridge for multi-step customization; `configure()` is syntactic sugar for one-liner tweaks.
 
 ### 6.2 Innovation #2: `parse_split()` — Dual-Return Parsing
 
-**Problem**: When mixing declarative and builder fields, how do you get typed access to declarative fields AND untyped access to builder-added fields?
+**The problem**: When mixing declarative and builder fields, how do I give you typed access to declarative fields AND untyped access to builder-added fields?
 
-**Swift's approach**: Not possible. All fields must be declared in the struct. There is no mechanism for dynamically added options.
+**Swift's answer**: You can't. All fields must be declared in the struct.
 
 **Naive approach**: Return only `ParseResult`, losing the typed struct benefit.
 
-**ArgMojo's approach**: `parse_split()` returns a **tuple of both**:
+**My approach**: `parse_split()` returns a **tuple of both**:
 
 ```mojo
 def parse_split(mut self) raises -> (T, ParseResult):
 ```
 
-- The first element is the user's struct `T` with all declarative-registered fields populated & typed.
+- The first element is your struct `T` with all declarative-registered fields populated & typed.
 - The second element is the full `ParseResult` containing everything (declarative fields + builder-added fields).
 
 This means:
 
 ```mojo
-var (args, result) = app.parse_split()
+var (args, result) = decl.parse_split()
 
 # Declarative fields: compile-time typed access, no string keys
 args.verbose          # Bool
@@ -732,7 +771,7 @@ result.get_int("threads")
 result.get_list("tags")
 ```
 
-This is a **new pattern** not seen in any CLI library in any language. Even Rust's clap cannot do this — once you use its derive macro, all fields must be in the struct. There's no mechanism for "some fields are struct, some are ParseResult."
+As far as I know, this is a **new pattern** not seen in any CLI library in any language. Even Rust's clap can't do this — once you use its derive macro, all fields must be in the struct. There's no mechanism for "some fields are struct, some are ParseResult."
 
 The dual-return enables a practical workflow:
 
@@ -744,7 +783,7 @@ The dual-return enables a practical workflow:
 
 ### 7.1 Reflect-to-Builder Translation Table
 
-Each wrapper type maps to specific `Argument` builder calls:
+Here's how each wrapper parameter maps to builder calls under the hood:
 
 | Wrapper param                               | Builder call generated                           |
 | ------------------------------------------- | ------------------------------------------------ |
@@ -768,46 +807,46 @@ Each wrapper type maps to specific `Argument` builder calls:
 | `prompt_text="msg"`                         | `.prompt["msg"]()`                               |
 | `password=True`                             | `.password()`                                    |
 | `require_equals=True`                       | `.require_equals()`                              |
-| `alias="out,dest"`                          | `.alias_name["out"]().alias_name["dest"]()`      |
+| `alias_name="out,dest"`                     | `.alias_name["out"]().alias_name["dest"]()`      |
 | `negatable=True`                            | `.negatable()`                                   |
 | `allow_hyphen=True`                         | `.allow_hyphen_values()`                         |
 | `group="Advanced"`                          | `.group["Advanced"]()`                           |
 | **Flag[...]**                               | `.flag()`                                        |
-| **Argument[...]**                           | `.positional()`                                  |
-| **Argument[..., remainder=True]**           | `.remainder()`                                   |
+| **Positional[...]**                         | `.positional()`                                  |
+| **Positional[..., remainder=True]**         | `.remainder()`                                   |
 | **Count[..., max=5]**                       | `.count().max[5]()`                              |
 | **bare String/Int/Bool**                    | auto-detected: Bool→`.flag()`, else named option |
 
 ### 7.2 Write-Back Type Dispatch
 
-When populating the user's struct from `ParseResult`, the type determines which accessor to call:
+When populating your struct from `ParseResult`, I dispatch based on the field type:
 
-| Field type                                    | ParseResult accessor | Write-back                   |
-| --------------------------------------------- | -------------------- | ---------------------------- |
-| `Flag[...]`                                   | `get_flag(name)`     | `field.value = Bool`         |
-| `Count[...]`                                  | `get_count(name)`    | `field.value = Int`          |
-| `Option[String, ...]`                         | `get_string(name)`   | `field.value = String`       |
-| `Option[Int, ...]`                            | `get_int(name)`      | `field.value = Int`          |
-| `Option[List[String], ..., append=True]`      | `get_list(name)`     | `field.value = List[String]` |
-| `Option[Dict[...], ..., map_option=True]`     | `get_map(name)`      | `field.value = Dict`         |
-| `Argument[String, ...]`                       | `get_string(name)`   | `field.value = String`       |
-| `Argument[Int, ...]`                          | `get_int(name)`      | `field.value = Int`          |
-| `Argument[List[String], ..., remainder=True]` | `get_list(name)`     | `field.value = List[String]` |
-| bare `String`                                 | `get_string(name)`   | `field = String`             |
-| bare `Int`                                    | `get_int(name)`      | `field = Int`                |
-| bare `Bool`                                   | `get_flag(name)`     | `field = Bool`               |
+| Field type                                      | ParseResult accessor | Write-back                   |
+| ----------------------------------------------- | -------------------- | ---------------------------- |
+| `Flag[...]`                                     | `get_flag(name)`     | `field.value = Bool`         |
+| `Count[...]`                                    | `get_count(name)`    | `field.value = Int`          |
+| `Option[String, ...]`                           | `get_string(name)`   | `field.value = String`       |
+| `Option[Int, ...]`                              | `get_int(name)`      | `field.value = Int`          |
+| `Option[List[String], ..., append=True]`        | `get_list(name)`     | `field.value = List[String]` |
+| `Option[Dict[...], ..., map_option=True]`       | `get_map(name)`      | `field.value = Dict`         |
+| `Positional[String, ...]`                       | `get_string(name)`   | `field.value = String`       |
+| `Positional[Int, ...]`                          | `get_int(name)`      | `field.value = Int`          |
+| `Positional[List[String], ..., remainder=True]` | `get_list(name)`     | `field.value = List[String]` |
+| bare `String`                                   | `get_string(name)`   | `field = String`             |
+| bare `Int`                                      | `get_int(name)`      | `field = Int`                |
+| bare `Bool`                                     | `get_flag(name)`     | `field = Bool`               |
 
-Missing/optional values: If `result.has(name)` returns `False` and the field is not required, the default value remains.
+Missing/optional values: if `result.has(name)` returns `False` and the field isn't required, the default value stays.
 
-### 7.3 SubApp Design
+### 7.3 SubDeclaration Design
 
-`SubApp` is parameterized on variadic types:
+`SubDeclaration` is parameterized on variadic types:
 
 ```mojo
-struct SubApp[
+struct SubDeclaration[
     app_name: StringLiteral,
     app_description: StringLiteral,
-    *Ts: ArgStruct,
+    *Ts: Declarable,
 ]:
     var _command: Command
 
@@ -818,18 +857,18 @@ struct SubApp[
         # For each type in Ts, build a sub-Command and register via add_subcommand
         @parameter
         for i in range(len(Ts)):
-            var sub_cmd = App[Ts[i]]().to_command()
+            var sub_cmd = Declaration[Ts[i]]().to_command()
             self._command.add_subcommand(sub_cmd)
         return SubResult[*Ts](self._command.parse())
 ```
 
 `SubResult` provides a `get[T]()` method that does the write-back for the matched subcommand.
 
-**Note**: Variadic type parameters are evolving in Mojo. If `*Ts` is not yet stable, a fallback approach uses explicit overloads for 1-8 subcommand types (like `SubApp2[T1, T2]`, `SubApp3[T1, T2, T3]`, etc.).
+**Note**: Variadic type parameters are still evolving in Mojo. If `*Ts` isn't stable yet, I'll fall back to explicit overloads for 1–8 subcommand types (like `SubDeclaration2[T1, T2]`, `SubDeclaration3[T1, T2, T3]`, etc.).
 
 ## 8. What Stays in Builder-Only Territory
 
-Some features are inherently imperative and don't map well to struct declarations. These remain builder-only (accessible via `to_command()`):
+Some features are inherently imperative and don't fit neatly into struct declarations. I'm keeping these builder-only (accessible via `to_command()`):
 
 | Feature                    | Reason                                 |
 | -------------------------- | -------------------------------------- |
@@ -847,55 +886,55 @@ Some features are inherently imperative and don't map well to struct declaration
 | `allow_negative_numbers()` | Parser behavior flag                   |
 | `add_parent()`             | Cross-command inheritance              |
 
-This is the right approach — these features describe *relationships between* arguments or *command-level* behavior, not individual argument metadata. Forcing them into struct field attributes would create a confusing, non-composable API.
+I think this is the right call — these features describe *relationships between* arguments or *command-level* behavior, not individual argument metadata. Trying to force them into struct field attributes would create a confusing, non-composable API.
 
 ## 9. Comparison with Swift Argument Parser
 
-| Aspect                          | Swift Argument Parser           | ArgMojo Declarative                         |
-| ------------------------------- | ------------------------------- | ------------------------------------------- |
-| Language mechanism              | Property wrappers (`@Option`)   | Parametric wrapper types (`Option[T]`)      |
-| Wrapper vocabulary              | `@Argument`, `@Option`, `@Flag` | `Argument[T]`, `Option[T]`, `Flag`, `Count` |
-| Protocol / trait                | `ParsableCommand`               | `ArgStruct`                                 |
-| Type-safe value access          | Direct field access             | `args.field.value`                          |
-| Flag as Bool                    | Direct Bool                     | `Flag.__bool__()` implicit conversion       |
-| Count flag                      | ❌ not built-in                  | ✅ `Count[short="v", max=3]`                 |
-| Builder fallback                | ❌ no builder API                | ✅ full builder API as alternative           |
-| Declarative ↔ builder bridge    | ❌ no escape hatch               | ✅ `to_command()` exposes `Command`          |
-| Dual-return parse               | ❌ struct-only return            | ✅ `parse_split()` → (T, ParseResult)        |
-| Post-parse validation           | `mutating func validate()`      | `def validate(self) raises` (planned)       |
-| Mutually exclusive groups       | ❌ not in struct schema          | ✅ via `to_command()`                        |
-| Interactive prompt              | ❌ not supported                 | ✅ `prompt=True` in wrapper                  |
-| Password / masked input         | ❌ not supported                 | ✅ `password=True` in wrapper                |
-| Shell completions               | ✅ built-in                      | ✅ inherited from builder                    |
-| Subcommands                     | ✅ nested `ParsableCommand`      | ✅ `SubApp[...]` variadic types              |
-| CJK-aware help                  | ❌ not supported                 | ✅ inherited from builder                    |
-| Auto-naming (underscore→hyphen) | ✅ camelCase→kebab-case          | ✅ snake_case→kebab-case                     |
+| Aspect                          | Swift Argument Parser           | ArgMojo Declarative                           |
+| ------------------------------- | ------------------------------- | --------------------------------------------- |
+| Language mechanism              | Property wrappers (`@Option`)   | Parametric wrapper types (`Option[T]`)        |
+| Wrapper vocabulary              | `@Argument`, `@Option`, `@Flag` | `Positional[T]`, `Option[T]`, `Flag`, `Count` |
+| Protocol / trait                | `ParsableCommand`               | `Declarable`                                  |
+| Type-safe value access          | Direct field access             | `args.field.value`                            |
+| Flag as Bool                    | Direct Bool                     | `Flag.__bool__()` implicit conversion         |
+| Count flag                      | ✗ not built-in                  | ✓ `Count[short="v", max=3]`                   |
+| Builder fallback                | ✗ no builder API                | ✓ full builder API as alternative             |
+| Declarative ↔ builder bridge    | ✗ no escape hatch               | ✓ `to_command()` exposes `Command`            |
+| Dual-return parse               | ✗ struct-only return            | ✓ `parse_split()` → (T, ParseResult)          |
+| Post-parse validation           | `mutating func validate()`      | `def validate(self) raises` (planned)         |
+| Mutually exclusive groups       | ✗ not in struct schema          | ✓ via `to_command()`                          |
+| Interactive prompt              | ✗ not supported                 | ✓ `prompt=True` in wrapper                    |
+| Password / masked input         | ✗ not supported                 | ✓ `password=True` in wrapper                  |
+| Shell completions               | ✓ built-in                      | ✓ inherited from builder                      |
+| Subcommands                     | ✓ nested `ParsableCommand`      | ✓ `SubDeclaration[...]` variadic types        |
+| CJK-aware help                  | ✗ not supported                 | ✓ inherited from builder                      |
+| Auto-naming (underscore→hyphen) | ✓ camelCase→kebab-case          | ✓ snake_case→kebab-case                       |
 
 ## 10. Implementation Roadmap
 
-### Phase 1: Core Wrapper Types + App
+### Phase 1: Core Wrapper Types + Declaration
 
-- [ ] Implement `Option`, `Flag`, `Argument`, `Count` wrapper structs
-- [ ] Implement `ArgStruct` trait
+- [ ] Implement `Positional`, `Option`, `Flag`, `Count` wrapper structs
+- [ ] Implement `Declarable` trait
 - [ ] Implement `arg_defaults[T]()` 
-- [ ] Implement `App[T]._build()` — reflection to Command builder calls
-- [ ] Implement `App[T]._from_result()` — ParseResult to struct write-back
-- [ ] Implement `App[T].parse()` — end-to-end
+- [ ] Implement `Declaration[T]._build()` — reflection to Command builder calls
+- [ ] Implement `Declaration[T]._from_result()` — ParseResult to struct write-back
+- [ ] Implement `Declaration[T].parse()` — end-to-end
 - [ ] Auto-naming convention (underscore → hyphen)
 
 ### Phase 2: Hybrid Features
 
-- [ ] Implement `App[T].to_command()` escape hatch
-- [ ] Implement `App[T].parse_split()` dual return
-- [ ] Test: declarative + `mutually_exclusive()` via to_command()
-- [ ] Test: declarative + extra builder args via parse_split
-- [ ] Implement `App[T].configure()` callback (non-capturing, works in 0.26.2)
+- [ ] Implement `Declaration[T].to_command()` escape hatch
+- [ ] Implement `Declaration[T].parse_split()` dual return
+- [ ] Test: declaration + `mutually_exclusive()` via to_command()
+- [ ] Test: declaration + extra builder args via parse_split
+- [ ] Implement `Declaration[T].configure()` callback (non-capturing, works in 0.26.2)
 
 ### Phase 3: Subcommands
 
-- [ ] Implement `SubApp[..., *Ts]` or `SubApp2/3/...` overloads
+- [ ] Implement `SubDeclaration[..., *Ts]` or `SubDeclaration2/3/...` overloads
 - [ ] Implement `SubResult.get[T]()` typed subcommand access
-- [ ] Test: nested subcommands with declarative
+- [ ] Test: nested subcommands with declaration
 
 ### Phase 4: Polish
 
@@ -903,27 +942,3 @@ This is the right approach — these features describe *relationships between* a
 - [ ] Examples: simple, hybrid, subcommands
 - [ ] User manual additions
 - [ ] README update with declarative examples
-
-## 11. Open Questions & Risks
-
-1. **Mojo `@parameter for` over struct fields stability** — This API is marked as "newly introduced and currently incomplete." If reflection primitives change, the declarative module needs updating. Mitigation: keep all reflection code in one file, well-isolated.
-
-2. **Variadic type parameters** — `*Ts: ArgStruct` may not be stable in 0.26.2. Fallback: explicit `SubApp2[T1, T2]`, `SubApp3[T1, T2, T3]` up to a reasonable limit.
-
-3. **Compile-time StringLiteral splitting** — Splitting `choices="a,b,c"` into individual choices at compile time requires careful implementation. May need `@parameter for` over characters or a compile-time string split utility.
-
-4. **`__struct_field_ref` stability** — This is a compiler internal. If Mojo changes the API, write-back logic breaks. Mitigation: encapsulate all uses in helper functions.
-
-5. **Error messages** — When declarative-generated constraints fail, error messages should reference the user's field name, not internal Argument names. May need to customize error formatting.
-
-## 12. Summary
-
-The declarative API adds a **struct-based shorthand** on top of argmojo's existing builder engine, modelled after Swift Argument Parser's `@Argument`/`@Option`/`@Flag` property wrapper pattern.
-
-- **Same vocabulary as Swift**: `Argument`, `Option`, `Flag` — plus `Count` for repeat-counting flags
-- **No existing code changes** — builder users are completely unaffected
-- **Two innovations** beyond what Swift (or any other CLI library) offers:
-  - `to_command()`: first-class declarative↔builder bridge — Swift's `ParsableCommand` has no escape hatch
-  - `parse_split()`: dual typed-struct + ParseResult return — Swift requires all fields in the struct
-- **Smooth gradient**: pure declarative → declarative + to_command() → declarative + parse_split → pure builder
-- The right architecture: **engine first, syntax sugar second** — validated by both Rust's clap and Swift's argument-parser

--- a/docs/declarative_api_planning.md
+++ b/docs/declarative_api_planning.md
@@ -3,7 +3,7 @@
 > **Status**: Planning  
 > **Target**: argmojo v0.5.0  
 > **Mojo Version**: 0.26.2+  
-> **Intial Date**: 2026-03-24
+> **Initial Date**: 2026-03-24
 
 > 子曰工欲善其事必先利其器
 > The mechanic, who wishes to do his work well, must first sharpen his tools -- Confucius

--- a/docs/declarative_api_planning.md
+++ b/docs/declarative_api_planning.md
@@ -69,48 +69,48 @@ Direct mapping to argmojo declarative API:
 | `ExpressibleByArgument` protocol | Planned `Parseable` trait                   |
 | `CommandGroup`                   | `SubApp[...]`                               |
 | `mutating func run()`            | Separate: `App[T].parse()` returns T        |
-| `mutating func validate()`       | `fn validate(self) raises` on `ArgStruct`   |
+| `mutating func validate()`       | `def validate(self) raises` on `ArgStruct`  |
 
 **What argmojo adds beyond Swift**: (1) `to_command()` exposes the underlying `Command` for builder-level customisation — Swift's `ParsableCommand` is a sealed box with no escape hatch to builder-level features like mutually exclusive groups, implications, or custom help formatting. (2) `parse_split()` returns both typed struct + `ParseResult` — Swift requires all fields to live in the struct. (3) Declarative is optional — Swift has no builder alternative; you must use the struct-based approach.
 
-**Lesson — `validate()`**: An optional `fn validate(self) raises` method on `ArgStruct` (mirroring Swift's `validate()`) could complement `to_command()` for post-parse cross-field validation without requiring the builder API.
+**Lesson — `validate()`**: An optional `def validate(self) raises` method on `ArgStruct` (mirroring Swift's `validate()`) could complement `to_command()` for post-parse cross-field validation without requiring the builder API.
 
 ## 3. Architecture
 
 ```txt
-┌──────────────────────────────────────────────────────────────────┐
-│  User Code                                                       │
-│                                                                  │
-│  @fieldwise_init                                                 │
-│  struct MyArgs(ArgStruct):                                       │
-│      var name: Argument[String, help="Name", required=True]      │
-│      var verbose: Flag[short="v", help="Verbose"]                │
-│      var output: Option[String, long="output", short="o"]        │
-│      fn __init__(out self): self = arg_defaults[Self]()          │
-│                                                                  │
-│  var app = App[MyArgs]()                                         │
-│  var cmd = app.to_command()                                      │
-│  cmd.mutually_exclusive([...])                                   │
-│  var args = app.parse()  →  MyArgs (typed struct)                │
-│                                                                  │
-├──────────────────────────────────────────────────────────────────┤
-│  declarative.mojo  (NEW — ~400-600 lines)                        │
-│                                                                  │
-│  App[T].to_command()    → Command    (reflect T → builder calls) │
-│  App[T].parse()         → T          (parse + write-back)        │
-│  App[T].from_result()   → T          (ParseResult → struct)      │
-│  arg_defaults[T]()      → T          (default-initialized)       │
+┌──────────────────────────────────────────────────────────────────────────┐
+│  User Code                                                               │
+│                                                                          │
+│  @fieldwise_init                                                         │
+│  struct MyArgs(ArgStruct):                                               │
+│      var name: Argument[String, help="Name", required=True]              │
+│      var verbose: Flag[short="v", help="Verbose"]                        │
+│      var output: Option[String, long="output", short="o"]                │
+│      def __init__(out self): self = arg_defaults[Self]()                 │
+│                                                                          │
+│  var app = App[MyArgs]()                                                 │
+│  var cmd = app.to_command()                                              │
+│  cmd.mutually_exclusive([...])                                           │
+│  var args = app.parse()  →  MyArgs (typed struct)                        │
+│                                                                          │
+├──────────────────────────────────────────────────────────────────────────┤
+│  declarative.mojo  (NEW — ~400-600 lines)                                │
+│                                                                          │
+│  App[T].to_command()    → Command    (reflect T → builder calls)         │
+│  App[T].parse()         → T          (parse + write-back)                │
+│  App[T].from_result()   → T          (ParseResult → struct)              │
+│  arg_defaults[T]()      → T          (default-initialized)               │
 │                                                                          │
 │  Wrapper types: Option[T, ...], Flag[...], Argument[T, ...], Count[...]  │
 │  Trait: ArgStruct                                                        │
 │                                                                          │
-├──────────────────────────────────────────────────────────────────┤
-│  argument.mojo + command.mojo + parse_result.mojo  (UNCHANGED)   │
-│                                                                  │
-│  Argument(...).long["x"]().short["y"]().flag()                   │
-│  Command("app").add_argument(...).parse() → ParseResult          │
-│                                                                  │
-└──────────────────────────────────────────────────────────────────┘
+├──────────────────────────────────────────────────────────────────────────┤
+│  argument.mojo + command.mojo + parse_result.mojo  (UNCHANGED)           │
+│                                                                          │
+│  Argument(...).long["x"]().short["y"]().flag()                           │
+│  Command("app").add_argument(...).parse() → ParseResult                  │
+│                                                                          │
+└──────────────────────────────────────────────────────────────────────────┘
 ```
 
 ### Files Changed
@@ -160,10 +160,10 @@ struct Option[
 ](Copyable, Movable, Defaultable):
     var value: T
 
-    fn __init__(out self):
+    def __init__(out self):
         self.value = T()
 
-    fn __init__(out self, val: T):
+    def __init__(out self, val: T):
         self.value = val
 ```
 
@@ -186,14 +186,14 @@ struct Flag[
 ](Copyable, Movable, Defaultable):
     var value: Bool
 
-    fn __init__(out self):
+    def __init__(out self):
         self.value = False
 
-    fn __init__(out self, val: Bool):
+    def __init__(out self, val: Bool):
         self.value = val
 
     # Implicit conversion to Bool for convenience
-    fn __bool__(self) -> Bool:
+    def __bool__(self) -> Bool:
         return self.value
 ```
 
@@ -211,10 +211,10 @@ struct Argument[
 ](Copyable, Movable, Defaultable):
     var value: T
 
-    fn __init__(out self):
+    def __init__(out self):
         self.value = T()
 
-    fn __init__(out self, val: T):
+    def __init__(out self, val: T):
         self.value = val
 ```
 
@@ -231,10 +231,10 @@ struct Count[
 ](Copyable, Movable, Defaultable):
     var value: Int
 
-    fn __init__(out self):
+    def __init__(out self):
         self.value = 0
 
-    fn __init__(out self, val: Int):
+    def __init__(out self, val: Int):
         self.value = val
 ```
 
@@ -247,10 +247,12 @@ struct Count[
 Users can also use **bare types** (like `String`, `Int`, `Bool`) for fields without metadata — they become options named after the field, following Swift's convention for fields without property wrappers.
 
 **Naming note — `Argument` builder vs declarative**: The builder API already has an `Argument` struct (in `argument.mojo`) for defining individual arguments. The declarative module introduces `Argument[T, ...]` (in `declarative.mojo`) as the positional argument wrapper, matching Swift's `@Argument`. They live in separate modules:
+
 - `from argmojo import Argument` — builder struct, constructed at runtime: `Argument("name", help="...")`
 - `from argmojo.declarative import Argument` — parametric wrapper, used as a field type: `var name: Argument[String, help="..."]`
 
 In **pure declarative** mode, no conflict. In **hybrid** mode where both are needed, use aliased imports:
+
 ```mojo
 from argmojo import Command, Argument as BuilderArgument
 from argmojo.declarative import App, Option, Flag, Argument, ArgStruct
@@ -263,17 +265,17 @@ trait ArgStruct(Defaultable, Movable):
     """Marker trait for structs that can be parsed from CLI arguments."""
 
     @staticmethod
-    fn description() -> String:
+    def description() -> String:
         """Return the command description for --help."""
         ...
 
     @staticmethod
-    fn version() -> String:
+    def version() -> String:
         """Return the version string for --version. Default "0.1.0"."""
         ...
 
     @staticmethod
-    fn name() -> String:
+    def name() -> String:
         """Return the command name. Default: lowercased struct name."""
         ...
 ```
@@ -285,10 +287,10 @@ Minimal implementation by users:
 struct MyArgs(ArgStruct):
     var input: Argument[String, help="Input file", required=True]
 
-    fn __init__(out self): self = arg_defaults[Self]()
+    def __init__(out self): self = arg_defaults[Self]()
 
     @staticmethod
-    fn description() -> String:
+    def description() -> String:
         return "My awesome tool"
 ```
 
@@ -303,13 +305,13 @@ struct App[T: ArgStruct]:
     var _command: Command
     var _built: Bool
 
-    fn __init__(out self):
+    def __init__(out self):
         self._command = Command(T.name(), T.description(), version=T.version())
         self._built = False
 
     # ── Core methods ──
 
-    fn to_command(mut self) raises -> ref Command:
+    def to_command(mut self) raises -> ref Command:
         """Build and return the underlying Command.
         Users can modify it with builder methods before parsing."""
         if not self._built:
@@ -317,7 +319,7 @@ struct App[T: ArgStruct]:
             self._built = True
         return self._command
 
-    fn parse(mut self) raises -> T:
+    def parse(mut self) raises -> T:
         """Parse sys.argv() and return a populated T instance."""
         if not self._built:
             self._build()
@@ -325,7 +327,7 @@ struct App[T: ArgStruct]:
         var result = self._command.parse()
         return self._from_result(result)
 
-    fn parse_args(mut self, raw_args: List[String]) raises -> T:
+    def parse_args(mut self, raw_args: List[String]) raises -> T:
         """Parse explicit arg list and return a populated T instance."""
         if not self._built:
             self._build()
@@ -343,10 +345,10 @@ struct App[T: ArgStruct]:
     # ── configure() with non-capturing callback ──
     # Works in Mojo 0.26.2 as long as the callback does NOT capture external state.
     # This is fine for configure() because all operations target the `mut Command` parameter.
-    # NOTE: Capturing closures (unified {mut x}) cannot be passed as fn() arguments
-    #       due to type mismatch (nonescaping closure ≠ bare fn). Non-capturing is sufficient here.
+    # NOTE: Capturing closures (unified {mut x}) cannot be passed as def() arguments
+    #       due to type mismatch (nonescaping closure ≠ bare def). Non-capturing is sufficient here.
 
-    fn configure(mut self, callback: fn(mut Command) raises -> None) raises -> ref Self:
+    def configure(mut self, callback: def(mut Command) raises -> None) raises -> ref Self:
         """Apply builder-level customizations via callback."""
         if not self._built:
             self._build()
@@ -356,7 +358,7 @@ struct App[T: ArgStruct]:
 
     # ── Innovation #2: parse_split (see §6.2) ──
 
-    fn parse_split(mut self) raises -> (T, ParseResult):
+    def parse_split(mut self) raises -> (T, ParseResult):
         """Parse and return BOTH a typed struct AND the raw ParseResult.
         The struct contains declarative-registered fields.
         The ParseResult contains everything (including builder-added fields)."""
@@ -369,7 +371,7 @@ struct App[T: ArgStruct]:
 
     # ── Internal ──
 
-    fn _build(mut self) raises:
+    def _build(mut self) raises:
         """Reflect over T's fields and register Arguments."""
         comptime field_count = struct_field_count[T]()
         comptime field_names = struct_field_names[T]()
@@ -392,7 +394,7 @@ struct App[T: ArgStruct]:
                 # Bare type: treat as named option with field name as long name
                 self._register_bare(fname, ftype)
 
-    fn _from_result(self, result: ParseResult) raises -> T:
+    def _from_result(self, result: ParseResult) raises -> T:
         """Write ParseResult values back into a T instance."""
         var out = T()
         comptime field_count = struct_field_count[T]()
@@ -432,7 +434,7 @@ struct App[T: ArgStruct]:
 Initialises all wrapper fields to their defaults (inspired by Swift's default property initialization):
 
 ```mojo
-fn arg_defaults[T: ArgStruct]() -> T:
+def arg_defaults[T: ArgStruct]() -> T:
     """Create a default-initialized instance of T.
     Wrapper types (Option, Flag, Argument, Count) are initialized to their defaults.
     Bare types use their Defaultable implementation."""
@@ -488,15 +490,15 @@ struct Grep(ArgStruct):
     var verbose: Count[short="v", help="Increase verbosity", max=3]
     var ext: Option[List[String], short="e", long="ext", help="File extensions", append=True]
 
-    fn __init__(out self):
+    def __init__(out self):
         self = arg_defaults[Self]()
 
     @staticmethod
-    fn description() -> String:
+    def description() -> String:
         return "Search for patterns in files."
 
     @staticmethod
-    fn version() -> String:
+    def version() -> String:
         return "1.0.0"
 
 def main() raises:
@@ -527,10 +529,10 @@ struct Deploy(ArgStruct):
     var replicas: Option[Int, long="replicas", short="r", help="Number of replicas",
                       default="3", has_range=True, range_min=1, range_max=100]
 
-    fn __init__(out self): self = arg_defaults[Self]()
+    def __init__(out self): self = arg_defaults[Self]()
 
     @staticmethod
-    fn description() -> String:
+    def description() -> String:
         return "Deploy application to target environment."
 
 def main() raises:
@@ -562,10 +564,10 @@ struct Convert(ArgStruct):
     var input: Argument[String, help="Input file", required=True]
     var output: Option[String, long="output", short="o", help="Output file"]
 
-    fn __init__(out self): self = arg_defaults[Self]()
+    def __init__(out self): self = arg_defaults[Self]()
 
     @staticmethod
-    fn description() -> String:
+    def description() -> String:
         return "File format converter."
 
 def main() raises:
@@ -608,14 +610,14 @@ struct Clone(ArgStruct):
     var depth: Option[Int, long="depth", help="Clone depth", default="0"]
     var branch: Option[String, short="b", long="branch", help="Branch to clone"]
 
-    fn __init__(out self): self = arg_defaults[Self]()
+    def __init__(out self): self = arg_defaults[Self]()
 
     @staticmethod
-    fn description() -> String:
+    def description() -> String:
         return "Clone a repository."
 
     @staticmethod
-    fn name() -> String:
+    def name() -> String:
         return "clone"
 
 @fieldwise_init
@@ -624,14 +626,14 @@ struct Push(ArgStruct):
     var force: Flag[short="f", help="Force push"]
     var tags: Flag[long="tags", help="Push all tags"]
 
-    fn __init__(out self): self = arg_defaults[Self]()
+    def __init__(out self): self = arg_defaults[Self]()
 
     @staticmethod
-    fn description() -> String:
+    def description() -> String:
         return "Push commits to remote."
 
     @staticmethod
-    fn name() -> String:
+    def name() -> String:
         return "push"
 
 def main() raises:
@@ -669,7 +671,7 @@ var args = app.parse()
 
 This creates a **smooth gradient** between simplicity and power:
 
-```
+```txt
 Pure declarative     Declarative + to_command()    Pure builder
 (3 lines)            (10 lines)                    (30 lines)
 Simple tools    →    Medium complexity tools   →    Maximum control
@@ -688,12 +690,12 @@ to_command() + new arguments        →  parse_split()  →  (T, ParseResult) (p
 
 ```mojo
 var args = App[MyArgs]()
-    .configure(fn(mut cmd) raises: cmd.mutually_exclusive([...]))
-    .configure(fn(mut cmd) raises: cmd.implies("a", "b"))
+    .configure(def(mut cmd) raises: cmd.mutually_exclusive([...]))
+    .configure(def(mut cmd) raises: cmd.implies("a", "b"))
     .parse()
 ```
 
-**Limitation**: Mojo's capturing closures (`unified {mut x}`) produce a `nonescaping closure` type that cannot be passed as a bare `fn()` argument. This doesn't affect `configure()` since its callbacks don't need captures — the `mut Command` parameter provides all necessary state.
+**Limitation**: Mojo's capturing closures (`unified {mut x}`) produce a `nonescaping closure` type that cannot be passed as a bare `def()` argument. This doesn't affect `configure()` since its callbacks don't need captures — the `mut Command` parameter provides all necessary state.
 
 `to_command()` remains the primary bridge for multi-step customization; `configure()` is syntactic sugar for one-liner tweaks.
 
@@ -708,7 +710,7 @@ var args = App[MyArgs]()
 **ArgMojo's approach**: `parse_split()` returns a **tuple of both**:
 
 ```mojo
-fn parse_split(mut self) raises -> (T, ParseResult):
+def parse_split(mut self) raises -> (T, ParseResult):
 ```
 
 - The first element is the user's struct `T` with all declarative-registered fields populated & typed.
@@ -809,10 +811,10 @@ struct SubApp[
 ]:
     var _command: Command
 
-    fn __init__(out self):
+    def __init__(out self):
         self._command = Command(String(app_name), String(app_description))
 
-    fn parse(mut self) raises -> SubResult[*Ts]:
+    def parse(mut self) raises -> SubResult[*Ts]:
         # For each type in Ts, build a sub-Command and register via add_subcommand
         @parameter
         for i in range(len(Ts)):
@@ -860,7 +862,7 @@ This is the right approach — these features describe *relationships between* a
 | Builder fallback                | ❌ no builder API                | ✅ full builder API as alternative           |
 | Declarative ↔ builder bridge    | ❌ no escape hatch               | ✅ `to_command()` exposes `Command`          |
 | Dual-return parse               | ❌ struct-only return            | ✅ `parse_split()` → (T, ParseResult)        |
-| Post-parse validation           | `mutating func validate()`      | `fn validate(self) raises` (planned)        |
+| Post-parse validation           | `mutating func validate()`      | `def validate(self) raises` (planned)       |
 | Mutually exclusive groups       | ❌ not in struct schema          | ✅ via `to_command()`                        |
 | Interactive prompt              | ❌ not supported                 | ✅ `prompt=True` in wrapper                  |
 | Password / masked input         | ❌ not supported                 | ✅ `password=True` in wrapper                |

--- a/docs/declarative_api_planning.md
+++ b/docs/declarative_api_planning.md
@@ -1,0 +1,927 @@
+# ArgMojo Declarative API — Design & Implementation Plan
+
+> **Status**: Planning  
+> **Target**: argmojo v0.5.0  
+> **Mojo Version**: 0.26.2+  
+> **Date**: 2026-03-24
+
+## 1. Design Goals
+
+1. **Optional** — Users who prefer the builder API are completely unaffected. The declarative module is a separate import (`from argmojo.declarative import ...`). Zero change to existing code.
+
+2. **Hybrid** — Builder and declarative can coexist in a single program. A user can define a struct for 80% of arguments, then use builder methods for the remaining 20% (groups, implications, advanced constraints).
+
+3. **Layered** — The declarative layer is a *consumer* of the builder layer. Internally it constructs `Command` + `Argument` objects and calls `Command.parse()`. No new parsing engine.
+
+4. **Type-safe** — Parsed results are returned as the user's own struct with typed fields, not `ParseResult.get_string("name")`.
+
+5. **Two innovations** - I think that there might be two possible features beyond what Swift Argument Parser offers (see [this section](#6-innovations)).
+
+## 2. Mojo Reflection Capabilities (v0.26.2)
+
+Available compile-time reflection primitives:
+
+| API                                 | Purpose                                  |
+| ----------------------------------- | ---------------------------------------- |
+| `struct_field_count[T]()`           | Number of fields in struct T             |
+| `struct_field_names[T]()`           | Indexable list of field name strings     |
+| `struct_field_types[T]()`           | Indexable list of field types            |
+| `get_type_name[T]()`                | String name of type T                    |
+| `__struct_field_ref(idx, instance)` | Reference to field by compile-time index |
+| `conforms_to(type, Trait)`          | Compile-time trait conformance check     |
+| `trait_downcast[Trait](value)`      | Cast value to trait-conforming type      |
+| `@fieldwise_init`                   | Auto-generate constructor from fields    |
+| `comptime for idx in range(N)`      | Compile-time loop                        |
+| `comptime if condition`             | Compile-time conditional                 |
+
+**Key limitation**: No proc macros, no custom decorators, no `#[derive(...)]`. All declarative behavior must be implemented via parametric functions that reflect over user-defined structs.
+
+**Primary inspiration — Swift Argument Parser**: Apple's [swift-argument-parser](https://github.com/apple/swift-argument-parser) is the most relevant prior art because Swift and Mojo share key language characteristics — static typing, struct-oriented design, and protocol/trait conformance. Swift uses **property wrappers** (`@Argument`, `@Option`, `@Flag`) as metadata carriers on struct fields. ArgMojo adopts the same vocabulary directly as **parametric wrapper types** (`Argument[T, ...]`, `Option[T, ...]`, `Flag[...]`), which carry CLI metadata as compile-time keyword parameters. Example:
+
+```swift
+struct Greet: ParsableCommand {
+    @Argument(help: "The person's name.")
+    var name: String
+
+    @Option(name: .shortAndLong, help: "Repeat count.")
+    var count: Int = 1
+
+    @Flag(inversion: .prefixedNo, help: "Include greeting.")
+    var includeGreeting = true
+
+    mutating func run() throws {
+        for _ in 0..<count { print("Hello, \(name)!") }
+    }
+}
+Greet.main()
+```
+
+Direct mapping to argmojo declarative API:
+
+| Swift Mechanism                  | ArgMojo Equivalent                          |
+| -------------------------------- | ------------------------------------------- |
+| `@Argument(help: "...")`         | `Argument[T, help="..."]`                   |
+| `@Option(name: .shortAndLong)`   | `Option[T, long="...", short="..."]`        |
+| `@Flag(inversion: .prefixedNo)`  | `Flag[negatable=True]`                      |
+| (no Swift equivalent)            | `Count[short="v", max=3]`                   |
+| `ParsableCommand` protocol       | `ArgStruct` trait                           |
+| `@OptionGroup`                   | Argument parents via `Command.add_parent()` |
+| `ExpressibleByArgument` protocol | Planned `Parseable` trait                   |
+| `CommandGroup`                   | `SubApp[...]`                               |
+| `mutating func run()`            | Separate: `App[T].parse()` returns T        |
+| `mutating func validate()`       | `fn validate(self) raises` on `ArgStruct`   |
+
+**What argmojo adds beyond Swift**: (1) `to_command()` exposes the underlying `Command` for builder-level customisation — Swift's `ParsableCommand` is a sealed box with no escape hatch to builder-level features like mutually exclusive groups, implications, or custom help formatting. (2) `parse_split()` returns both typed struct + `ParseResult` — Swift requires all fields to live in the struct. (3) Declarative is optional — Swift has no builder alternative; you must use the struct-based approach.
+
+**Lesson — `validate()`**: An optional `fn validate(self) raises` method on `ArgStruct` (mirroring Swift's `validate()`) could complement `to_command()` for post-parse cross-field validation without requiring the builder API.
+
+## 3. Architecture
+
+```txt
+┌──────────────────────────────────────────────────────────────────┐
+│  User Code                                                       │
+│                                                                  │
+│  @fieldwise_init                                                 │
+│  struct MyArgs(ArgStruct):                                       │
+│      var name: Argument[String, help="Name", required=True]      │
+│      var verbose: Flag[short="v", help="Verbose"]                │
+│      var output: Option[String, long="output", short="o"]        │
+│      fn __init__(out self): self = arg_defaults[Self]()          │
+│                                                                  │
+│  var app = App[MyArgs]()                                         │
+│  var cmd = app.to_command()                                      │
+│  cmd.mutually_exclusive([...])                                   │
+│  var args = app.parse()  →  MyArgs (typed struct)                │
+│                                                                  │
+├──────────────────────────────────────────────────────────────────┤
+│  declarative.mojo  (NEW — ~400-600 lines)                        │
+│                                                                  │
+│  App[T].to_command()    → Command    (reflect T → builder calls) │
+│  App[T].parse()         → T          (parse + write-back)        │
+│  App[T].from_result()   → T          (ParseResult → struct)      │
+│  arg_defaults[T]()      → T          (default-initialized)       │
+│                                                                          │
+│  Wrapper types: Option[T, ...], Flag[...], Argument[T, ...], Count[...]  │
+│  Trait: ArgStruct                                                        │
+│                                                                          │
+├──────────────────────────────────────────────────────────────────┤
+│  argument.mojo + command.mojo + parse_result.mojo  (UNCHANGED)   │
+│                                                                  │
+│  Argument(...).long["x"]().short["y"]().flag()                   │
+│  Command("app").add_argument(...).parse() → ParseResult          │
+│                                                                  │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### Files Changed
+
+| File                           | Change                                           |
+| ------------------------------ | ------------------------------------------------ |
+| `src/argmojo/declarative.mojo` | **New file** — all declarative types and logic   |
+| `src/argmojo/__init__.mojo`    | Add `from .declarative import ...` (conditional) |
+| Everything else                | **Zero changes**                                 |
+
+## 4. Detailed API Design
+
+### 4.1 Wrapper Types
+
+These are lightweight parametric structs that carry CLI metadata as compile-time parameters while wrapping an inner value at runtime.
+
+```mojo
+struct Option[
+    T: Defaultable & Movable,
+    *,
+    long: StringLiteral = "",       # --option name (empty = auto from field name)
+    short: StringLiteral = "",      # -o single char
+    help: StringLiteral = "",       # help text
+    default: StringLiteral = "",    # default value as string
+    required: Bool = False,         # must be provided
+    choices: StringLiteral = "",    # comma-separated allowed values: "json,yaml,csv"
+    value_name: StringLiteral = "", # display name in help
+    hidden: Bool = False,           # hidden from help
+    deprecated: StringLiteral = "", # deprecation message
+    append: Bool = False,           # collect into list (T should be List[String])
+    delimiter: StringLiteral = "",  # split by delimiter
+    nargs: Int = 0,                 # number of values (0 = single)
+    range_min: Int = 0,             # numeric range min
+    range_max: Int = 0,             # numeric range max
+    has_range: Bool = False,        # enable range validation
+    clamp: Bool = False,            # clamp instead of error
+    map_option: Bool = False,       # key=value map mode
+    persistent: Bool = False,       # inherited by subcommands
+    prompt: Bool = False,           # interactive prompt if missing
+    prompt_text: StringLiteral = "",# custom prompt message
+    password: Bool = False,         # masked input
+    require_equals: Bool = False,   # require --key=value syntax
+    alias: StringLiteral = "",      # comma-separated alias long names
+    negatable: Bool = False,        # --x / --no-x (only if T is Bool)
+    allow_hyphen: Bool = False,     # allow hyphen-prefixed values
+    group: StringLiteral = "",      # help group name
+](Copyable, Movable, Defaultable):
+    var value: T
+
+    fn __init__(out self):
+        self.value = T()
+
+    fn __init__(out self, val: T):
+        self.value = val
+```
+
+```mojo
+# Convenience aliases for common patterns
+
+alias Flag = Option[Bool, ...]     # Can't do this directly in Mojo yet.
+                                # Instead, Flag is a separate struct:
+
+struct Flag[
+    *,
+    long: StringLiteral = "",
+    short: StringLiteral = "",
+    help: StringLiteral = "",
+    negatable: Bool = False,
+    persistent: Bool = False,
+    hidden: Bool = False,
+    deprecated: StringLiteral = "",
+    group: StringLiteral = "",
+](Copyable, Movable, Defaultable):
+    var value: Bool
+
+    fn __init__(out self):
+        self.value = False
+
+    fn __init__(out self, val: Bool):
+        self.value = val
+
+    # Implicit conversion to Bool for convenience
+    fn __bool__(self) -> Bool:
+        return self.value
+```
+
+```mojo
+struct Argument[
+    T: Defaultable & Movable,
+    *,
+    help: StringLiteral = "",
+    default: StringLiteral = "",
+    required: Bool = False,
+    choices: StringLiteral = "",
+    value_name: StringLiteral = "",
+    remainder: Bool = False,       # consume all remaining tokens
+    group: StringLiteral = "",
+](Copyable, Movable, Defaultable):
+    var value: T
+
+    fn __init__(out self):
+        self.value = T()
+
+    fn __init__(out self, val: T):
+        self.value = val
+```
+
+```mojo
+struct Count[
+    *,
+    long: StringLiteral = "",
+    short: StringLiteral = "",
+    help: StringLiteral = "",
+    max: Int = 0,                  # 0 = no ceiling
+    persistent: Bool = False,
+    hidden: Bool = False,
+    group: StringLiteral = "",
+](Copyable, Movable, Defaultable):
+    var value: Int
+
+    fn __init__(out self):
+        self.value = 0
+
+    fn __init__(out self, val: Int):
+        self.value = val
+```
+
+**Design choice**: Four wrapper types (`Option`, `Flag`, `Argument`, `Count`) instead of one overloaded `Option` with `is_arg=True` / `is_flag=True`. This is intentional:
+
+- Explicit intent: `Flag[...]` is obviously a flag, `Argument[...]` is obviously positional
+- Fewer confusing parameter combinations (e.g., `Argument` doesn't have `long`/`short`)
+- Better compile-time validation (can't accidentally make a positional with `long`)
+
+Users can also use **bare types** (like `String`, `Int`, `Bool`) for fields without metadata — they become options named after the field, following Swift's convention for fields without property wrappers.
+
+**Naming note — `Argument` builder vs declarative**: The builder API already has an `Argument` struct (in `argument.mojo`) for defining individual arguments. The declarative module introduces `Argument[T, ...]` (in `declarative.mojo`) as the positional argument wrapper, matching Swift's `@Argument`. They live in separate modules:
+- `from argmojo import Argument` — builder struct, constructed at runtime: `Argument("name", help="...")`
+- `from argmojo.declarative import Argument` — parametric wrapper, used as a field type: `var name: Argument[String, help="..."]`
+
+In **pure declarative** mode, no conflict. In **hybrid** mode where both are needed, use aliased imports:
+```mojo
+from argmojo import Command, Argument as BuilderArgument
+from argmojo.declarative import App, Option, Flag, Argument, ArgStruct
+```
+
+### 4.2 The `ArgStruct` Trait
+
+```mojo
+trait ArgStruct(Defaultable, Movable):
+    """Marker trait for structs that can be parsed from CLI arguments."""
+
+    @staticmethod
+    fn description() -> String:
+        """Return the command description for --help."""
+        ...
+
+    @staticmethod
+    fn version() -> String:
+        """Return the version string for --version. Default "0.1.0"."""
+        ...
+
+    @staticmethod
+    fn name() -> String:
+        """Return the command name. Default: lowercased struct name."""
+        ...
+```
+
+Minimal implementation by users:
+
+```mojo
+@fieldwise_init
+struct MyArgs(ArgStruct):
+    var input: Argument[String, help="Input file", required=True]
+
+    fn __init__(out self): self = arg_defaults[Self]()
+
+    @staticmethod
+    fn description() -> String:
+        return "My awesome tool"
+```
+
+`version()` and `name()` have default implementations in the trait, so they're optional.
+
+### 4.3 The `App[T]` Orchestrator
+
+```mojo
+struct App[T: ArgStruct]:
+    """Orchestrates struct-to-command conversion, parsing, and write-back."""
+
+    var _command: Command
+    var _built: Bool
+
+    fn __init__(out self):
+        self._command = Command(T.name(), T.description(), version=T.version())
+        self._built = False
+
+    # ── Core methods ──
+
+    fn to_command(mut self) raises -> ref Command:
+        """Build and return the underlying Command.
+        Users can modify it with builder methods before parsing."""
+        if not self._built:
+            self._build()
+            self._built = True
+        return self._command
+
+    fn parse(mut self) raises -> T:
+        """Parse sys.argv() and return a populated T instance."""
+        if not self._built:
+            self._build()
+            self._built = True
+        var result = self._command.parse()
+        return self._from_result(result)
+
+    fn parse_args(mut self, raw_args: List[String]) raises -> T:
+        """Parse explicit arg list and return a populated T instance."""
+        if not self._built:
+            self._build()
+            self._built = True
+        var result = self._command.parse_arguments(raw_args)
+        return self._from_result(result)
+
+    # ── Innovation #1: to_command() — expose Command for builder tweaks (see §6.1) ──
+
+    # to_command() is already defined above in "Core methods".
+    # It returns a mutable reference to the underlying Command,
+    # allowing arbitrary builder modifications before parsing.
+    # No closure required — works in Mojo 0.26.2.
+
+    # ── configure() with non-capturing callback ──
+    # Works in Mojo 0.26.2 as long as the callback does NOT capture external state.
+    # This is fine for configure() because all operations target the `mut Command` parameter.
+    # NOTE: Capturing closures (unified {mut x}) cannot be passed as fn() arguments
+    #       due to type mismatch (nonescaping closure ≠ bare fn). Non-capturing is sufficient here.
+
+    fn configure(mut self, callback: fn(mut Command) raises -> None) raises -> ref Self:
+        """Apply builder-level customizations via callback."""
+        if not self._built:
+            self._build()
+            self._built = True
+        callback(self._command)
+        return self
+
+    # ── Innovation #2: parse_split (see §6.2) ──
+
+    fn parse_split(mut self) raises -> (T, ParseResult):
+        """Parse and return BOTH a typed struct AND the raw ParseResult.
+        The struct contains declarative-registered fields.
+        The ParseResult contains everything (including builder-added fields)."""
+        if not self._built:
+            self._build()
+            self._built = True
+        var result = self._command.parse()
+        var typed = self._from_result(result)
+        return (typed, result)
+
+    # ── Internal ──
+
+    fn _build(mut self) raises:
+        """Reflect over T's fields and register Arguments."""
+        comptime field_count = struct_field_count[T]()
+        comptime field_names = struct_field_names[T]()
+        comptime field_types = struct_field_types[T]()
+
+        comptime for idx in range(field_count):
+            comptime fname = field_names[idx]
+            comptime ftype = field_types[idx]
+
+            # Dispatch based on wrapper type
+            comptime if _is_option_type(ftype):
+                self._register_option(fname, ftype)
+            elif _is_flag_type(ftype):
+                self._register_flag(fname, ftype)
+            elif _is_argument_type(ftype):
+                self._register_argument(fname, ftype)
+            elif _is_count_type(ftype):
+                self._register_count(fname, ftype)
+            else:
+                # Bare type: treat as named option with field name as long name
+                self._register_bare(fname, ftype)
+
+    fn _from_result(self, result: ParseResult) raises -> T:
+        """Write ParseResult values back into a T instance."""
+        var out = T()
+        comptime field_count = struct_field_count[T]()
+        comptime field_names = struct_field_names[T]()
+        comptime field_types = struct_field_types[T]()
+
+        comptime for idx in range(field_count):
+            comptime fname = field_names[idx]
+            comptime ftype = field_types[idx]
+
+            comptime if _is_flag_type(ftype):
+                ref field = __struct_field_ref(idx, out)
+                field.value = result.get_flag(String(fname))
+            elif _is_count_type(ftype):
+                ref field = __struct_field_ref(idx, out)
+                field.value = result.get_count(String(fname))
+            elif _is_argument_type(ftype):
+                ref field = __struct_field_ref(idx, out)
+                # Write positional value:
+                #   If T is List[String] → get_list
+                #   If T is String → get_string
+                #   If T is Int → get_int
+                _write_argument_value(field, fname, result)
+            elif _is_option_type(ftype):
+                ref field = __struct_field_ref(idx, out)
+                _write_option_value(field, fname, result)
+            else:
+                # Bare type
+                ref field = __struct_field_ref(idx, out)
+                _write_bare_value(field, fname, result)
+
+        return out
+```
+
+### 4.4 The `arg_defaults[T]()` Helper
+
+Initialises all wrapper fields to their defaults (inspired by Swift's default property initialization):
+
+```mojo
+fn arg_defaults[T: ArgStruct]() -> T:
+    """Create a default-initialized instance of T.
+    Wrapper types (Option, Flag, Argument, Count) are initialized to their defaults.
+    Bare types use their Defaultable implementation."""
+    return T()  # Works because T: Defaultable, and all wrappers are Defaultable
+```
+
+### 4.5 Auto-Naming Convention
+
+When `long` is not explicitly provided, the field name is used with underscores converted to hyphens:
+
+| Field name    | Auto-generated long | Short  |
+| ------------- | ------------------- | ------ |
+| `max_count`   | `--max-count`       | (none) |
+| `verbose`     | `--verbose`         | (none) |
+| `output_file` | `--output-file`     | (none) |
+
+This matches the Swift and clap convention. Fields wrapped in `Argument[...]` do not get auto-generated long names.
+
+### 4.6 Choice Parsing from StringLiteral
+
+Since Mojo parameters must be compile-time constants and we can't pass `List[StringLiteral]`, choices are encoded as a comma-separated string:
+
+```mojo
+var format: Option[String, choices="json,yaml,csv", default="json"]
+```
+
+Internally, `_register_option()` splits by `,` and calls `.choice["json"]().choice["yaml"]().choice["csv"]()` etc.
+
+Similarly, `alias` is comma-separated:
+
+```mojo
+var output: Option[String, long="output", alias="out,dest"]
+```
+
+This generates `.alias_name["out"]().alias_name["dest"]()`.
+
+## 5. Usage Examples
+
+### 5.1 Pure Declarative (Simple Tool)
+
+```mojo
+from argmojo.declarative import App, Option, Flag, Argument, Count, ArgStruct, arg_defaults
+
+@fieldwise_init
+struct Grep(ArgStruct):
+    """Search for patterns in files."""
+
+    var pattern: Argument[String, help="Search pattern", required=True]
+    var path: Argument[String, help="File or directory", default="."]
+    var ignore_case: Flag[short="i", help="Case-insensitive search"]
+    var count_only: Flag[short="c", long="count", help="Only print match count"]
+    var max_count: Option[Int, short="m", long="max-count", help="Stop after N matches", default="0"]
+    var verbose: Count[short="v", help="Increase verbosity", max=3]
+    var ext: Option[List[String], short="e", long="ext", help="File extensions", append=True]
+
+    fn __init__(out self):
+        self = arg_defaults[Self]()
+
+    @staticmethod
+    fn description() -> String:
+        return "Search for patterns in files."
+
+    @staticmethod
+    fn version() -> String:
+        return "1.0.0"
+
+def main() raises:
+    var args = App[Grep]().parse()
+
+    print("Pattern:", args.pattern.value)
+    print("Path:", args.path.value)
+    if args.ignore_case:           # Flag.__bool__() works
+        print("Case insensitive mode")
+    if args.verbose.value > 0:
+        print("Verbosity level:", args.verbose.value)
+    for e in args.ext.value:
+        print("Extension:", e[])
+```
+
+### 5.2 Declarative + Builder Hybrid (Complex Tool)
+
+```mojo
+from argmojo import Command, Argument as BuilderArgument
+from argmojo.declarative import App, Option, Flag, Argument, ArgStruct, arg_defaults
+
+@fieldwise_init
+struct Deploy(ArgStruct):
+    var target: Argument[String, help="Deploy target", required=True, choices="staging,prod"]
+    var force: Flag[short="f", help="Force deploy without checks"]
+    var dry_run: Flag[long="dry-run", help="Simulate without changes"]
+    var tag: Option[String, long="tag", short="t", help="Release tag"]
+    var replicas: Option[Int, long="replicas", short="r", help="Number of replicas",
+                      default="3", has_range=True, range_min=1, range_max=100]
+
+    fn __init__(out self): self = arg_defaults[Self]()
+
+    @staticmethod
+    fn description() -> String:
+        return "Deploy application to target environment."
+
+def main() raises:
+    var app = App[Deploy]()
+
+    # Bridge to builder: add constraints that declarative can't express
+    var cmd = app.to_command()
+    cmd.mutually_exclusive(["force", "dry-run"])
+    cmd.implies("force", "tag")       # force requires a tag
+    cmd.confirmation_option["Deploy to production?"]()
+    cmd.header_color["CYAN"]()
+    cmd.add_tip("Use --dry-run to preview changes first")
+
+    # app.parse() returns typed T; cmd.parse() would return untyped ParseResult.
+    # Always prefer app.parse() or app.parse_split() in hybrid mode.
+    var args = app.parse()
+    print("Deploying to:", args.target.value)
+    print("Tag:", args.tag.value)
+```
+
+### 5.3 Split Parse (Declarative + Extra Builder Fields)
+
+```mojo
+from argmojo import Command, Argument as BuilderArgument
+from argmojo.declarative import App, Argument, Option, Flag, ArgStruct, arg_defaults
+
+@fieldwise_init
+struct Convert(ArgStruct):
+    var input: Argument[String, help="Input file", required=True]
+    var output: Option[String, long="output", short="o", help="Output file"]
+
+    fn __init__(out self): self = arg_defaults[Self]()
+
+    @staticmethod
+    fn description() -> String:
+        return "File format converter."
+
+def main() raises:
+    var app = App[Convert]()
+
+    # Add extra builder-only arguments via to_command()
+    var cmd = app.to_command()
+    cmd.add_argument(
+        BuilderArgument("format", help="Output format")
+        .long["format"]().short["f"]()
+        .choice["json"]().choice["yaml"]().choice["toml"]()
+        .default["json"]()
+    )
+    cmd.add_argument(
+        BuilderArgument("indent", help="Indent level")
+        .long["indent"]()
+        .range[0, 8]().default["2"]()
+    )
+
+    # parse_split returns BOTH the typed struct AND the raw ParseResult
+    args, result = app.parse_split()
+
+    # Declarative fields: typed access
+    print("Input:", args.input.value)
+    print("Output:", args.output.value)
+
+    # Builder fields: ParseResult access
+    var format = result.get_string("format")
+    var indent = result.get_int("indent")
+```
+
+### 5.4 Subcommands with Declarative
+
+```mojo
+from argmojo.declarative import App, SubApp, Option, Flag, Argument, ArgStruct, arg_defaults
+
+@fieldwise_init
+struct Clone(ArgStruct):
+    var url: Argument[String, help="Repository URL", required=True]
+    var depth: Option[Int, long="depth", help="Clone depth", default="0"]
+    var branch: Option[String, short="b", long="branch", help="Branch to clone"]
+
+    fn __init__(out self): self = arg_defaults[Self]()
+
+    @staticmethod
+    fn description() -> String:
+        return "Clone a repository."
+
+    @staticmethod
+    fn name() -> String:
+        return "clone"
+
+@fieldwise_init
+struct Push(ArgStruct):
+    var remote: Argument[String, help="Remote name", default="origin"]
+    var force: Flag[short="f", help="Force push"]
+    var tags: Flag[long="tags", help="Push all tags"]
+
+    fn __init__(out self): self = arg_defaults[Self]()
+
+    @staticmethod
+    fn description() -> String:
+        return "Push commits to remote."
+
+    @staticmethod
+    fn name() -> String:
+        return "push"
+
+def main() raises:
+    # SubApp registers multiple ArgStruct types as subcommands
+    var result = SubApp["mgit", "A mini git tool", Clone, Push]().parse()
+
+    if result.subcommand == "clone":
+        var args = result.get[Clone]()
+        print("Cloning:", args.url.value)
+    elif result.subcommand == "push":
+        var args = result.get[Push]()
+        print("Pushing to:", args.remote.value)
+```
+
+## 6. Innovations
+
+### 6.1 Innovation #1: `to_command()` — First-Class Declarative-Builder Bridge
+
+**What Swift Argument Parser lacks**: Swift's `ParsableCommand` is a sealed protocol — there is no escape hatch to add builder-level configuration (mutually exclusive groups, implications, colored help, tips, completions). Users who need advanced constraints must implement `validate()` and custom help formatting manually, with no access to a builder API.
+
+**What argmojo adds**: `to_command()` returns a mutable reference to the underlying `Command` object, allowing arbitrary builder modifications before parsing:
+
+```mojo
+var app = App[MyArgs]()
+var cmd = app.to_command()
+cmd.mutually_exclusive(["json", "yaml"])
+cmd.required_together(["username", "password"])
+cmd.implies("debug", "verbose")
+cmd.confirmation_option()
+cmd.header_color["CYAN"]()
+cmd.add_tip("See docs at https://example.com")
+cmd.completions_as_subcommand()
+var args = app.parse()
+```
+
+This creates a **smooth gradient** between simplicity and power:
+
+```
+Pure declarative     Declarative + to_command()    Pure builder
+(3 lines)            (10 lines)                    (30 lines)
+Simple tools    →    Medium complexity tools   →    Maximum control
+```
+
+No other Mojo CLI library offers this continuum. You never have to completely rewrite from one style to another when requirements grow.
+
+**Type safety note**: Using `to_command()` to add **constraints** (groups, implications, colours) preserves full type safety — `parse()` still returns `T`. Using it to add **new arguments** (`add_argument(...)`) introduces partially untyped access — those fields are only available via `ParseResult` from `parse_split()`. This is an intentional trade-off:
+
+```txt
+to_command() + constraints only     →  parse()        →  T (fully typed ✅)
+to_command() + new arguments        →  parse_split()  →  (T, ParseResult) (partially typed ⚠️)
+```
+
+**`configure()` with non-capturing callbacks**: Verified in Mojo 0.26.2 — `configure()` works with non-capturing callbacks (nested functions that don't capture external state). Since `configure()` callbacks only operate on the `mut Command` parameter, capturing is unnecessary:
+
+```mojo
+var args = App[MyArgs]()
+    .configure(fn(mut cmd) raises: cmd.mutually_exclusive([...]))
+    .configure(fn(mut cmd) raises: cmd.implies("a", "b"))
+    .parse()
+```
+
+**Limitation**: Mojo's capturing closures (`unified {mut x}`) produce a `nonescaping closure` type that cannot be passed as a bare `fn()` argument. This doesn't affect `configure()` since its callbacks don't need captures — the `mut Command` parameter provides all necessary state.
+
+`to_command()` remains the primary bridge for multi-step customization; `configure()` is syntactic sugar for one-liner tweaks.
+
+### 6.2 Innovation #2: `parse_split()` — Dual-Return Parsing
+
+**Problem**: When mixing declarative and builder fields, how do you get typed access to declarative fields AND untyped access to builder-added fields?
+
+**Swift's approach**: Not possible. All fields must be declared in the struct. There is no mechanism for dynamically added options.
+
+**Naive approach**: Return only `ParseResult`, losing the typed struct benefit.
+
+**ArgMojo's approach**: `parse_split()` returns a **tuple of both**:
+
+```mojo
+fn parse_split(mut self) raises -> (T, ParseResult):
+```
+
+- The first element is the user's struct `T` with all declarative-registered fields populated & typed.
+- The second element is the full `ParseResult` containing everything (declarative fields + builder-added fields).
+
+This means:
+
+```mojo
+var (args, result) = app.parse_split()
+
+# Declarative fields: compile-time typed access, no string keys
+args.verbose          # Bool
+args.output.value     # String
+args.count.value      # Int
+
+# Builder-added fields: runtime string-keyed access
+result.get_string("extra-option")
+result.get_int("threads")
+result.get_list("tags")
+```
+
+This is a **new pattern** not seen in any CLI library in any language. Even Rust's clap cannot do this — once you use its derive macro, all fields must be in the struct. There's no mechanism for "some fields are struct, some are ParseResult."
+
+The dual-return enables a practical workflow:
+
+1. Start with pure declarative
+2. Need one advanced option? Add it via `to_command()` + `parse_split()`
+3. No need to convert the struct field (or add a new nested type)
+
+## 7. Internal Implementation Details
+
+### 7.1 Reflect-to-Builder Translation Table
+
+Each wrapper type maps to specific `Argument` builder calls:
+
+| Wrapper param                               | Builder call generated                           |
+| ------------------------------------------- | ------------------------------------------------ |
+| `long="output"`                             | `.long["output"]()`                              |
+| `short="o"`                                 | `.short["o"]()`                                  |
+| `help="..."`                                | `Argument("name", help="...")`                   |
+| `default="val"`                             | `.default["val"]()`                              |
+| `required=True`                             | `.required()`                                    |
+| `choices="a,b,c"`                           | `.choice["a"]().choice["b"]().choice["c"]()`     |
+| `value_name="FILE"`                         | `.value_name["FILE"]()`                          |
+| `hidden=True`                               | `.hidden()`                                      |
+| `deprecated="msg"`                          | `.deprecated["msg"]()`                           |
+| `append=True`                               | `.append()`                                      |
+| `delimiter=","`                             | `.delimiter[","]()`                              |
+| `nargs=3`                                   | `.number_of_values[3]()`                         |
+| `has_range=True, range_min=1, range_max=10` | `.range[1, 10]()`                                |
+| `clamp=True`                                | `.clamp()`                                       |
+| `map_option=True`                           | `.map_option()`                                  |
+| `persistent=True`                           | `.persistent()`                                  |
+| `prompt=True`                               | `.prompt()`                                      |
+| `prompt_text="msg"`                         | `.prompt["msg"]()`                               |
+| `password=True`                             | `.password()`                                    |
+| `require_equals=True`                       | `.require_equals()`                              |
+| `alias="out,dest"`                          | `.alias_name["out"]().alias_name["dest"]()`      |
+| `negatable=True`                            | `.negatable()`                                   |
+| `allow_hyphen=True`                         | `.allow_hyphen_values()`                         |
+| `group="Advanced"`                          | `.group["Advanced"]()`                           |
+| **Flag[...]**                               | `.flag()`                                        |
+| **Argument[...]**                           | `.positional()`                                  |
+| **Argument[..., remainder=True]**           | `.remainder()`                                   |
+| **Count[..., max=5]**                       | `.count().max[5]()`                              |
+| **bare String/Int/Bool**                    | auto-detected: Bool→`.flag()`, else named option |
+
+### 7.2 Write-Back Type Dispatch
+
+When populating the user's struct from `ParseResult`, the type determines which accessor to call:
+
+| Field type                                    | ParseResult accessor | Write-back                   |
+| --------------------------------------------- | -------------------- | ---------------------------- |
+| `Flag[...]`                                   | `get_flag(name)`     | `field.value = Bool`         |
+| `Count[...]`                                  | `get_count(name)`    | `field.value = Int`          |
+| `Option[String, ...]`                         | `get_string(name)`   | `field.value = String`       |
+| `Option[Int, ...]`                            | `get_int(name)`      | `field.value = Int`          |
+| `Option[List[String], ..., append=True]`      | `get_list(name)`     | `field.value = List[String]` |
+| `Option[Dict[...], ..., map_option=True]`     | `get_map(name)`      | `field.value = Dict`         |
+| `Argument[String, ...]`                       | `get_string(name)`   | `field.value = String`       |
+| `Argument[Int, ...]`                          | `get_int(name)`      | `field.value = Int`          |
+| `Argument[List[String], ..., remainder=True]` | `get_list(name)`     | `field.value = List[String]` |
+| bare `String`                                 | `get_string(name)`   | `field = String`             |
+| bare `Int`                                    | `get_int(name)`      | `field = Int`                |
+| bare `Bool`                                   | `get_flag(name)`     | `field = Bool`               |
+
+Missing/optional values: If `result.has(name)` returns `False` and the field is not required, the default value remains.
+
+### 7.3 SubApp Design
+
+`SubApp` is parameterized on variadic types:
+
+```mojo
+struct SubApp[
+    app_name: StringLiteral,
+    app_description: StringLiteral,
+    *Ts: ArgStruct,
+]:
+    var _command: Command
+
+    fn __init__(out self):
+        self._command = Command(String(app_name), String(app_description))
+
+    fn parse(mut self) raises -> SubResult[*Ts]:
+        # For each type in Ts, build a sub-Command and register via add_subcommand
+        @parameter
+        for i in range(len(Ts)):
+            var sub_cmd = App[Ts[i]]().to_command()
+            self._command.add_subcommand(sub_cmd)
+        return SubResult[*Ts](self._command.parse())
+```
+
+`SubResult` provides a `get[T]()` method that does the write-back for the matched subcommand.
+
+**Note**: Variadic type parameters are evolving in Mojo. If `*Ts` is not yet stable, a fallback approach uses explicit overloads for 1-8 subcommand types (like `SubApp2[T1, T2]`, `SubApp3[T1, T2, T3]`, etc.).
+
+## 8. What Stays in Builder-Only Territory
+
+Some features are inherently imperative and don't map well to struct declarations. These remain builder-only (accessible via `to_command()`):
+
+| Feature                    | Reason                                 |
+| -------------------------- | -------------------------------------- |
+| `mutually_exclusive()`     | Cross-field constraint on N args       |
+| `required_together()`      | Cross-field constraint on N args       |
+| `one_required()`           | Cross-field constraint on N args       |
+| `required_if()`            | Cross-field conditional                |
+| `implies()`                | Cross-field chain with cycle detection |
+| `confirmation_option()`    | Adds a synthetic `--yes` arg           |
+| `help_on_no_arguments()`   | Command-level behavior                 |
+| `add_tip()`                | Help formatting                        |
+| Color config               | Command-level presentation             |
+| Completions config         | Command-level behavior                 |
+| Response file config       | Command-level behavior                 |
+| `allow_negative_numbers()` | Parser behavior flag                   |
+| `add_parent()`             | Cross-command inheritance              |
+
+This is the right approach — these features describe *relationships between* arguments or *command-level* behavior, not individual argument metadata. Forcing them into struct field attributes would create a confusing, non-composable API.
+
+## 9. Comparison with Swift Argument Parser
+
+| Aspect                          | Swift Argument Parser           | ArgMojo Declarative                         |
+| ------------------------------- | ------------------------------- | ------------------------------------------- |
+| Language mechanism              | Property wrappers (`@Option`)   | Parametric wrapper types (`Option[T]`)      |
+| Wrapper vocabulary              | `@Argument`, `@Option`, `@Flag` | `Argument[T]`, `Option[T]`, `Flag`, `Count` |
+| Protocol / trait                | `ParsableCommand`               | `ArgStruct`                                 |
+| Type-safe value access          | Direct field access             | `args.field.value`                          |
+| Flag as Bool                    | Direct Bool                     | `Flag.__bool__()` implicit conversion       |
+| Count flag                      | ❌ not built-in                  | ✅ `Count[short="v", max=3]`                 |
+| Builder fallback                | ❌ no builder API                | ✅ full builder API as alternative           |
+| Declarative ↔ builder bridge    | ❌ no escape hatch               | ✅ `to_command()` exposes `Command`          |
+| Dual-return parse               | ❌ struct-only return            | ✅ `parse_split()` → (T, ParseResult)        |
+| Post-parse validation           | `mutating func validate()`      | `fn validate(self) raises` (planned)        |
+| Mutually exclusive groups       | ❌ not in struct schema          | ✅ via `to_command()`                        |
+| Interactive prompt              | ❌ not supported                 | ✅ `prompt=True` in wrapper                  |
+| Password / masked input         | ❌ not supported                 | ✅ `password=True` in wrapper                |
+| Shell completions               | ✅ built-in                      | ✅ inherited from builder                    |
+| Subcommands                     | ✅ nested `ParsableCommand`      | ✅ `SubApp[...]` variadic types              |
+| CJK-aware help                  | ❌ not supported                 | ✅ inherited from builder                    |
+| Auto-naming (underscore→hyphen) | ✅ camelCase→kebab-case          | ✅ snake_case→kebab-case                     |
+
+## 10. Implementation Roadmap
+
+### Phase 1: Core Wrapper Types + App
+
+- [ ] Implement `Option`, `Flag`, `Argument`, `Count` wrapper structs
+- [ ] Implement `ArgStruct` trait
+- [ ] Implement `arg_defaults[T]()` 
+- [ ] Implement `App[T]._build()` — reflection to Command builder calls
+- [ ] Implement `App[T]._from_result()` — ParseResult to struct write-back
+- [ ] Implement `App[T].parse()` — end-to-end
+- [ ] Auto-naming convention (underscore → hyphen)
+
+### Phase 2: Hybrid Features
+
+- [ ] Implement `App[T].to_command()` escape hatch
+- [ ] Implement `App[T].parse_split()` dual return
+- [ ] Test: declarative + `mutually_exclusive()` via to_command()
+- [ ] Test: declarative + extra builder args via parse_split
+- [ ] Implement `App[T].configure()` callback (non-capturing, works in 0.26.2)
+
+### Phase 3: Subcommands
+
+- [ ] Implement `SubApp[..., *Ts]` or `SubApp2/3/...` overloads
+- [ ] Implement `SubResult.get[T]()` typed subcommand access
+- [ ] Test: nested subcommands with declarative
+
+### Phase 4: Polish
+
+- [ ] Comprehensive test suite (parallel to existing builder tests)
+- [ ] Examples: simple, hybrid, subcommands
+- [ ] User manual additions
+- [ ] README update with declarative examples
+
+## 11. Open Questions & Risks
+
+1. **Mojo `@parameter for` over struct fields stability** — This API is marked as "newly introduced and currently incomplete." If reflection primitives change, the declarative module needs updating. Mitigation: keep all reflection code in one file, well-isolated.
+
+2. **Variadic type parameters** — `*Ts: ArgStruct` may not be stable in 0.26.2. Fallback: explicit `SubApp2[T1, T2]`, `SubApp3[T1, T2, T3]` up to a reasonable limit.
+
+3. **Compile-time StringLiteral splitting** — Splitting `choices="a,b,c"` into individual choices at compile time requires careful implementation. May need `@parameter for` over characters or a compile-time string split utility.
+
+4. **`__struct_field_ref` stability** — This is a compiler internal. If Mojo changes the API, write-back logic breaks. Mitigation: encapsulate all uses in helper functions.
+
+5. **Error messages** — When declarative-generated constraints fail, error messages should reference the user's field name, not internal Argument names. May need to customize error formatting.
+
+## 12. Summary
+
+The declarative API adds a **struct-based shorthand** on top of argmojo's existing builder engine, modelled after Swift Argument Parser's `@Argument`/`@Option`/`@Flag` property wrapper pattern.
+
+- **Same vocabulary as Swift**: `Argument`, `Option`, `Flag` — plus `Count` for repeat-counting flags
+- **No existing code changes** — builder users are completely unaffected
+- **Two innovations** beyond what Swift (or any other CLI library) offers:
+  - `to_command()`: first-class declarative↔builder bridge — Swift's `ParsableCommand` has no escape hatch
+  - `parse_split()`: dual typed-struct + ParseResult return — Swift requires all fields in the struct
+- **Smooth gradient**: pure declarative → declarative + to_command() → declarative + parse_split → pure builder
+- The right architecture: **engine first, syntax sugar second** — validated by both Rust's clap and Swift's argument-parser

--- a/src/argmojo/argument.mojo
+++ b/src/argmojo/argument.mojo
@@ -65,37 +65,46 @@ struct Argument(Copyable, Movable, Writable):
     var help_text: String
     """Help text displayed in usage information."""
 
-    # === Private fields ===
+    # === Private fields — Naming ===
     var _long_name: String
     """Long option name (e.g., 'output' for --output). Empty if not set."""
     var _short_name: String
     """Short option name (e.g., 'o' for -o). Empty if not set."""
+    var _alias_names: List[String]
+    """Alternative long names that resolve to this argument."""
+
+    # === Private fields — Argument type ===
     var _is_flag: Bool
     """If True, this argument is a boolean flag that takes no value."""
-    var _is_required: Bool
-    """If True, parsing fails when this argument is not provided."""
     var _is_positional: Bool
     """If True, this argument is matched by position rather than by name."""
+    var _is_count: Bool
+    """If True, each occurrence increments a counter (e.g., -vvv → 3)."""
+    var _count_max: Int
+    """Maximum count value (ceiling) for counter flags. 0 means no limit."""
+    var _has_count_max: Bool
+    """Whether a count ceiling has been set via ``.max()``."""
+    var _is_negatable: Bool
+    """If True, this flag also accepts --no-X to set it to False."""
+    var _is_remainder: Bool
+    """If True, this positional argument consumes all remaining tokens
+    (including those starting with ``-``).  Implies ``.positional()`` and
+    ``.append()``.  Must be the last positional argument."""
+
+    # === Private fields — Value defaults & validation ===
     var _default_value: String
     """Default value used when the argument is not provided."""
     var _has_default: Bool
     """Whether a default value has been set."""
+    var _default_if_no_value: String
+    """Value to use when the option appears without an explicit value.
+    Only meaningful for value-taking options with ``_has_default_if_no_value`` set."""
+    var _has_default_if_no_value: Bool
+    """Whether a default-if-no-value has been set via ``.default_if_no_value()``."""
+    var _is_required: Bool
+    """If True, parsing fails when this argument is not provided."""
     var _choice_values: List[String]
     """Allowed values for this argument. Empty means any value is accepted."""
-    var _value_name: String
-    """Display name for the value in help text (e.g., 'FILE' for --output FILE)."""
-    var _is_hidden: Bool
-    """If True, this argument is not shown in help output."""
-    var _is_count: Bool
-    """If True, each occurrence increments a counter (e.g., -vvv → 3)."""
-    var _is_negatable: Bool
-    """If True, this flag also accepts --no-X to set it to False."""
-    var _is_append: Bool
-    """If True, repeated uses collect values into a list (e.g., --tag x --tag y)."""
-    var _delimiter_char: String
-    """If non-empty, each value is split by this delimiter into multiple list entries."""
-    var _number_of_values: Int
-    """Number of values to consume per occurrence (0 means single-value mode)."""
     var _range_min: Int
     """Minimum allowed value (inclusive) for numeric range validation."""
     var _range_max: Int
@@ -104,43 +113,46 @@ struct Argument(Copyable, Movable, Writable):
     """Whether numeric range validation is active."""
     var _is_clamp: Bool
     """If True, out-of-range values are clamped (adjusted with warning) instead of rejected."""
+
+    # === Private fields — Collection modes ===
+    var _is_append: Bool
+    """If True, repeated uses collect values into a list (e.g., --tag x --tag y)."""
+    var _delimiter_char: String
+    """If non-empty, each value is split by this delimiter into multiple list entries."""
+    var _number_of_values: Int
+    """Number of values to consume per occurrence (0 means single-value mode)."""
     var _is_map: Bool
     """If True, each value is parsed as key=value and stored in a Dict."""
-    var _alias_names: List[String]
-    """Alternative long names that resolve to this argument."""
-    var _deprecated_msg: String
-    """If non-empty, this argument is deprecated; the string is the warning message."""
-    var _count_max: Int
-    """Maximum count value (ceiling) for counter flags. 0 means no limit."""
-    var _has_count_max: Bool
-    """Whether a count ceiling has been set via ``.max()``."""
+
+    # === Private fields — Parsing behavior ===
+    var _require_equals: Bool
+    """If True, this option requires ``--key=value`` syntax;
+    ``--key value`` (space-separated) is not allowed."""
+    var _allow_hyphen_values: Bool
+    """If True, the literal token ``-`` is accepted as a valid value for
+    this argument (conventionally meaning stdin/stdout)."""
     var _is_persistent: Bool
     """If True, this argument is automatically inherited by every subcommand.
     Persistent flags/options are injected into child command parsers at
     dispatch time so the user may place them either before or after the
     subcommand token on the command line."""
-    var _default_if_no_value: String
-    """Value to use when the option appears without an explicit value.
-    Only meaningful for value-taking options with ``_has_default_if_no_value`` set."""
-    var _has_default_if_no_value: Bool
-    """Whether a default-if-no-value has been set via ``.default_if_no_value()``."""
-    var _require_equals: Bool
-    """If True, this option requires ``--key=value`` syntax;
-    ``--key value`` (space-separated) is not allowed."""
-    var _is_remainder: Bool
-    """If True, this positional argument consumes all remaining tokens
-    (including those starting with ``-``).  Implies ``.positional()`` and
-    ``.append()``.  Must be the last positional argument."""
-    var _allow_hyphen_values: Bool
-    """If True, the literal token ``-`` is accepted as a valid value for
-    this argument (conventionally meaning stdin/stdout)."""
+
+    # === Private fields — Display & help ===
+    var _value_name: String
+    """Display name for the value in help text (e.g., 'FILE' for --output FILE)."""
     var _value_name_wrapped: Bool
     """If True, the value_name is displayed wrapped in angle brackets
     (e.g. ``<FILE>`` instead of ``FILE``).  Defaults to True."""
+    var _is_hidden: Bool
+    """If True, this argument is not shown in help output."""
+    var _deprecated_msg: String
+    """If non-empty, this argument is deprecated; the string is the warning message."""
     var _group: String
     """Help-output group name for this argument.  Arguments with the same
     group name are displayed together under a shared heading.  Empty
     string means ungrouped (shown under the default 'Options:' heading)."""
+
+    # === Private fields — Interactive prompting ===
     var _prompt: Bool
     """If True, the user is interactively prompted for this argument's
     value when it is not provided on the command line."""
@@ -169,38 +181,45 @@ struct Argument(Copyable, Movable, Writable):
         """
         self.name = name
         self.help_text = help
+        # ── Naming ──
         self._long_name = ""
         self._short_name = ""
+        self._alias_names = List[String]()
+        # ── Argument type ──
         self._is_flag = False
-        self._is_required = False
         self._is_positional = False
+        self._is_count = False
+        self._count_max = 0
+        self._has_count_max = False
+        self._is_negatable = False
+        self._is_remainder = False
+        # ── Value defaults & validation ──
         self._default_value = ""
         self._has_default = False
+        self._default_if_no_value = ""
+        self._has_default_if_no_value = False
+        self._is_required = False
         self._choice_values = List[String]()
-        self._value_name = ""
-        self._is_hidden = False
-        self._is_count = False
-        self._is_negatable = False
-        self._is_append = False
-        self._delimiter_char = ""
-        self._number_of_values = 0
         self._range_min = 0
         self._range_max = 0
         self._has_range = False
         self._is_clamp = False
+        # ── Collection modes ──
+        self._is_append = False
+        self._delimiter_char = ""
+        self._number_of_values = 0
         self._is_map = False
-        self._alias_names = List[String]()
-        self._deprecated_msg = ""
-        self._count_max = 0
-        self._has_count_max = False
-        self._is_persistent = False
-        self._default_if_no_value = ""
-        self._has_default_if_no_value = False
+        # ── Parsing behavior ──
         self._require_equals = False
-        self._is_remainder = False
         self._allow_hyphen_values = False
+        self._is_persistent = False
+        # ── Display & help ──
+        self._value_name = ""
         self._value_name_wrapped = True
+        self._is_hidden = False
+        self._deprecated_msg = ""
         self._group = ""
+        # ── Interactive prompting ──
         self._prompt = False
         self._prompt_text = ""
         self._hide_input = False
@@ -214,42 +233,49 @@ struct Argument(Copyable, Movable, Writable):
         """
         self.name = copy.name
         self.help_text = copy.help_text
+        # ── Naming ──
         self._long_name = copy._long_name
         self._short_name = copy._short_name
+        self._alias_names = List[String]()
+        for i in range(len(copy._alias_names)):
+            self._alias_names.append(copy._alias_names[i])
+        # ── Argument type ──
         self._is_flag = copy._is_flag
-        self._is_required = copy._is_required
         self._is_positional = copy._is_positional
+        self._is_count = copy._is_count
+        self._count_max = copy._count_max
+        self._has_count_max = copy._has_count_max
+        self._is_negatable = copy._is_negatable
+        self._is_remainder = copy._is_remainder
+        # ── Value defaults & validation ──
         self._default_value = copy._default_value
         self._has_default = copy._has_default
+        self._default_if_no_value = copy._default_if_no_value
+        self._has_default_if_no_value = copy._has_default_if_no_value
+        self._is_required = copy._is_required
         self._choice_values = List[String]()
         for i in range(len(copy._choice_values)):
             self._choice_values.append(copy._choice_values[i])
-        self._value_name = copy._value_name
-        self._is_hidden = copy._is_hidden
-        self._is_count = copy._is_count
-        self._is_negatable = copy._is_negatable
-        self._is_append = copy._is_append
-        self._delimiter_char = copy._delimiter_char
-        self._number_of_values = copy._number_of_values
         self._range_min = copy._range_min
         self._range_max = copy._range_max
         self._has_range = copy._has_range
         self._is_clamp = copy._is_clamp
+        # ── Collection modes ──
+        self._is_append = copy._is_append
+        self._delimiter_char = copy._delimiter_char
+        self._number_of_values = copy._number_of_values
         self._is_map = copy._is_map
-        self._alias_names = List[String]()
-        for i in range(len(copy._alias_names)):
-            self._alias_names.append(copy._alias_names[i])
-        self._deprecated_msg = copy._deprecated_msg
-        self._count_max = copy._count_max
-        self._has_count_max = copy._has_count_max
-        self._is_persistent = copy._is_persistent
-        self._default_if_no_value = copy._default_if_no_value
-        self._has_default_if_no_value = copy._has_default_if_no_value
+        # ── Parsing behavior ──
         self._require_equals = copy._require_equals
-        self._is_remainder = copy._is_remainder
         self._allow_hyphen_values = copy._allow_hyphen_values
+        self._is_persistent = copy._is_persistent
+        # ── Display & help ──
+        self._value_name = copy._value_name
         self._value_name_wrapped = copy._value_name_wrapped
+        self._is_hidden = copy._is_hidden
+        self._deprecated_msg = copy._deprecated_msg
         self._group = copy._group
+        # ── Interactive prompting ──
         self._prompt = copy._prompt
         self._prompt_text = copy._prompt_text
         self._hide_input = copy._hide_input
@@ -263,38 +289,45 @@ struct Argument(Copyable, Movable, Writable):
         """
         self.name = take.name^
         self.help_text = take.help_text^
+        # ── Naming ──
         self._long_name = take._long_name^
         self._short_name = take._short_name^
+        self._alias_names = take._alias_names^
+        # ── Argument type ──
         self._is_flag = take._is_flag
-        self._is_required = take._is_required
         self._is_positional = take._is_positional
+        self._is_count = take._is_count
+        self._count_max = take._count_max
+        self._has_count_max = take._has_count_max
+        self._is_negatable = take._is_negatable
+        self._is_remainder = take._is_remainder
+        # ── Value defaults & validation ──
         self._default_value = take._default_value^
         self._has_default = take._has_default
+        self._default_if_no_value = take._default_if_no_value^
+        self._has_default_if_no_value = take._has_default_if_no_value
+        self._is_required = take._is_required
         self._choice_values = take._choice_values^
-        self._value_name = take._value_name^
-        self._is_hidden = take._is_hidden
-        self._is_count = take._is_count
-        self._is_negatable = take._is_negatable
-        self._is_append = take._is_append
-        self._delimiter_char = take._delimiter_char^
-        self._number_of_values = take._number_of_values
         self._range_min = take._range_min
         self._range_max = take._range_max
         self._has_range = take._has_range
         self._is_clamp = take._is_clamp
+        # ── Collection modes ──
+        self._is_append = take._is_append
+        self._delimiter_char = take._delimiter_char^
+        self._number_of_values = take._number_of_values
         self._is_map = take._is_map
-        self._alias_names = take._alias_names^
-        self._deprecated_msg = take._deprecated_msg^
-        self._count_max = take._count_max
-        self._has_count_max = take._has_count_max
-        self._is_persistent = take._is_persistent
-        self._default_if_no_value = take._default_if_no_value^
-        self._has_default_if_no_value = take._has_default_if_no_value
+        # ── Parsing behavior ──
         self._require_equals = take._require_equals
-        self._is_remainder = take._is_remainder
         self._allow_hyphen_values = take._allow_hyphen_values
+        self._is_persistent = take._is_persistent
+        # ── Display & help ──
+        self._value_name = take._value_name^
         self._value_name_wrapped = take._value_name_wrapped
+        self._is_hidden = take._is_hidden
+        self._deprecated_msg = take._deprecated_msg^
         self._group = take._group^
+        # ── Interactive prompting ──
         self._prompt = take._prompt
         self._prompt_text = take._prompt_text^
         self._hide_input = take._hide_input
@@ -303,6 +336,8 @@ struct Argument(Copyable, Movable, Writable):
     # ===------------------------------------------------------------------=== #
     # Builder methods for configuring the argument
     # ===------------------------------------------------------------------=== #
+
+    # ── Naming ──
 
     def long[name: StringLiteral](var self) -> Self:
         """Sets the long option name (e.g., 'verbose' for --verbose).
@@ -352,6 +387,39 @@ struct Argument(Copyable, Movable, Writable):
         self._short_name = name
         return self^
 
+    def alias_name[name: StringLiteral](var self) -> Self:
+        """Sets an alternative long name for this argument.
+
+        Any alias resolves to this argument during parsing.  For
+        example, ``.long["colour"]().alias_name["color"]()`` makes both
+        ``--colour`` and ``--color`` accepted.  Chain multiple calls
+        for several aliases:
+        ``.alias_name["out"]().alias_name["fmt"]()``.
+
+        Parameters:
+            name: The alternative long option name (without ``--``).
+
+        Returns:
+            Self with the alias registered.
+
+        Constraints:
+            The alias is validated at compile time (same rules as
+            ``.long[]``): must not be empty, must not start with ``-``,
+            and must not contain ``=``.
+        """
+        comptime assert len(name) > 0, "alias name must not be empty"
+        comptime assert not name.startswith(
+            "-"
+        ), "alias name must not start with '-'; omit the '--' prefix"
+        comptime assert name.find("=") == -1, (
+            "alias name must not contain '='; it conflicts with"
+            " --key=value syntax"
+        )
+        self._alias_names.append(name)
+        return self^
+
+    # ── Argument type ──
+
     def flag(var self) -> Self:
         """Marks this argument as a boolean flag (no value needed).
 
@@ -364,19 +432,6 @@ struct Argument(Copyable, Movable, Writable):
             absence leaves it False.
         """
         self._is_flag = True
-        return self^
-
-    def required(var self) -> Self:
-        """Marks this argument as required.
-
-        Returns:
-            Self marked as required.
-
-        Notes:
-            Required arguments must be provided in the input; otherwise, parsing
-            will fail.
-        """
-        self._is_required = True
         return self^
 
     def positional(var self) -> Self:
@@ -397,68 +452,6 @@ struct Argument(Copyable, Movable, Writable):
             Self with _is_flag set to False.
         """
         self._is_flag = False
-        return self^
-
-    def default[value: StringLiteral](var self) -> Self:
-        """Sets a default value for this argument.
-
-        Parameters:
-            value: The default value.
-
-        Returns:
-            Self with the default value set.
-        """
-        self._default_value = value
-        self._has_default = True
-        return self^
-
-    def choice[value: StringLiteral](var self) -> Self:
-        """Adds an allowed value for this argument.
-
-        Chain multiple calls to build the full set of choices:
-        ``.choice["json"]().choice["csv"]().choice["table"]()``.
-        Parameters:
-            value: An allowed value.
-
-        Returns:
-            Self with the choice added.
-
-        Constraints:
-            The value must not be empty.
-        """
-        comptime assert len(value) > 0, "choice value must not be empty"
-        self._choice_values.append(value)
-        return self^
-
-    def value_name[name: StringLiteral, wrapped: Bool = True](var self) -> Self:
-        """Sets the display name for the value in help text.
-
-        When *wrapped* is True (default), the name is displayed inside angle
-        brackets: ``--output <FILE>``.  When False, it is displayed bare:
-        ``--output FILE``.
-
-        Parameters:
-            name: The display name of the value (e.g., "FILE" for --output).
-            wrapped: Wrap the display name in ``<>`` (default True).
-
-        Returns:
-            Self with the value_name set.
-
-        Constraints:
-            The value name must be a non-empty string.
-        """
-        comptime assert len(name) > 0, "value name must be a non-empty string"
-        self._value_name = name
-        self._value_name_wrapped = wrapped
-        return self^
-
-    def hidden(var self) -> Self:
-        """Marks this argument as hidden (not shown in help output).
-
-        Returns:
-            Self marked as hidden.
-        """
-        self._is_hidden = True
         return self^
 
     def count(var self) -> Self:
@@ -525,6 +518,174 @@ struct Argument(Copyable, Movable, Writable):
         self._is_negatable = True
         return self^
 
+    def remainder(var self) -> Self:
+        """Marks this positional argument as a remainder collector.
+
+        A remainder argument consumes **all** remaining tokens on the
+        command line — including those starting with ``-``.  It is
+        equivalent to Python's ``nargs=argparse.REMAINDER``.
+
+        Implies ``.positional()`` and ``.append()`` — values are retrieved
+        via ``ParseResult.get_list()``.
+
+        A ``Command`` may have at most one remainder argument, and it
+        must be the last positional argument.  Tokens collected by a
+        remainder argument are **not** parsed as options; they are stored
+        verbatim.
+
+        Examples::
+
+            # myapp build -- -Wall -O2 src/main.c
+            # With .remainder(), everything after 'build' goes into rest:
+            _ = Argument("rest", help="...").remainder()
+
+            # Or without '--':
+            # myapp run script.py --script-flag
+            # rest = ["script.py", "--script-flag"]
+
+        Returns:
+            Self marked as a remainder positional.
+        """
+        self._is_remainder = True
+        self._is_positional = True
+        self._is_append = True
+        return self^
+
+    # ── Value defaults & validation ──
+
+    def default[value: StringLiteral](var self) -> Self:
+        """Sets a default value for this argument.
+
+        Parameters:
+            value: The default value.
+
+        Returns:
+            Self with the default value set.
+        """
+        self._default_value = value
+        self._has_default = True
+        return self^
+
+    def default_if_no_value[value: StringLiteral](var self) -> Self:
+        """Sets a default value for when the option appears without an explicit value.
+
+        When set, the option may appear without a value.  If no value
+        is given, this default-if-no-value is used.  If a value is
+        provided via ``=`` syntax for long options (``--compress=bzip2``)
+        or attached form for short options (``-cbzip2``), that explicit
+        value is used instead.
+
+        For long options this implies ``require_equals()``.  A
+        space-separated token like ``--compress val`` is not accepted
+        as the option's value; in that case ``--compress`` uses its
+        default-if-no-value and ``val`` is parsed as a separate
+        argument (positional or another option).  To supply an
+        explicit value for the option, the user must write
+        ``--compress=val``.
+
+        Parameters:
+            value: The value to use when no explicit value is given.
+
+        Returns:
+            Self with the default-if-no-value set.
+
+        Examples:
+
+        ```mojo
+        # --compress        → "gzip"  (default-if-no-value)
+        # --compress=bzip2  → "bzip2" (explicit)
+        # -c                → "gzip"  (default-if-no-value)
+        # -cbzip2           → "bzip2" (attached)
+
+        from argmojo import Argument
+        _ = (Argument("compress", help="...")
+            .long["compress"]()
+            .short["c"]()
+            .default_if_no_value["gzip"]())
+        ```
+        """
+        self._default_if_no_value = value
+        self._has_default_if_no_value = True
+        self._require_equals = True  # implied for long options
+        return self^
+
+    def required(var self) -> Self:
+        """Marks this argument as required.
+
+        Returns:
+            Self marked as required.
+
+        Notes:
+            Required arguments must be provided in the input; otherwise, parsing
+            will fail.
+        """
+        self._is_required = True
+        return self^
+
+    def choice[value: StringLiteral](var self) -> Self:
+        """Adds an allowed value for this argument.
+
+        Chain multiple calls to build the full set of choices:
+        ``.choice["json"]().choice["csv"]().choice["table"]()``.
+        Parameters:
+            value: An allowed value.
+
+        Returns:
+            Self with the choice added.
+
+        Constraints:
+            The value must not be empty.
+        """
+        comptime assert len(value) > 0, "choice value must not be empty"
+        self._choice_values.append(value)
+        return self^
+
+    def range[
+        min_val: Int, max_val: Int
+    ](var self) -> Self where max_val >= min_val:
+        """Sets numeric range validation for this argument.
+
+        When set, the parsed value must be an integer within
+        ``[min_val, max_val]`` (inclusive).  Validation occurs
+        after parsing, during the validation phase.
+
+        By default, out-of-range values cause an error.  Chain with
+        ``.clamp()`` to silently adjust the value (with a warning)
+        instead of erroring.
+
+        Parameters:
+            min_val: Minimum allowed value (inclusive).
+            max_val: Maximum allowed value (inclusive).
+
+        Returns:
+            Self with range validation enabled.
+        """
+        self._range_min = min_val
+        self._range_max = max_val
+        self._has_range = True
+        return self^
+
+    def clamp(var self) -> Self:
+        """Enables clamping for numeric range validation.
+
+        When clamping is enabled (used after ``.range[min, max]()``),
+        out-of-range values are adjusted to the nearest boundary
+        instead of causing an error.  A warning is printed to stderr
+        to inform the user of the adjustment.
+
+        For example, ``.range[1, 100]().clamp()`` causes ``--level 200``
+        to be silently adjusted to 100 with a warning.
+
+        Must be used after ``.range()``.
+
+        Returns:
+            Self with clamping enabled.
+        """
+        self._is_clamp = True
+        return self^
+
+    # ── Collection modes ──
+
     def append(var self) -> Self:
         """Marks this argument as an append/collect option.
 
@@ -588,50 +749,6 @@ struct Argument(Copyable, Movable, Writable):
         self._is_append = True
         return self^
 
-    def range[
-        min_val: Int, max_val: Int
-    ](var self) -> Self where max_val >= min_val:
-        """Sets numeric range validation for this argument.
-
-        When set, the parsed value must be an integer within
-        ``[min_val, max_val]`` (inclusive).  Validation occurs
-        after parsing, during the validation phase.
-
-        By default, out-of-range values cause an error.  Chain with
-        ``.clamp()`` to silently adjust the value (with a warning)
-        instead of erroring.
-
-        Parameters:
-            min_val: Minimum allowed value (inclusive).
-            max_val: Maximum allowed value (inclusive).
-
-        Returns:
-            Self with range validation enabled.
-        """
-        self._range_min = min_val
-        self._range_max = max_val
-        self._has_range = True
-        return self^
-
-    def clamp(var self) -> Self:
-        """Enables clamping for numeric range validation.
-
-        When clamping is enabled (used after ``.range[min, max]()``),
-        out-of-range values are adjusted to the nearest boundary
-        instead of causing an error.  A warning is printed to stderr
-        to inform the user of the adjustment.
-
-        For example, ``.range[1, 100]().clamp()`` causes ``--level 200``
-        to be silently adjusted to 100 with a warning.
-
-        Must be used after ``.range()``.
-
-        Returns:
-            Self with clamping enabled.
-        """
-        self._is_clamp = True
-        return self^
-
     def map_option(var self) -> Self:
         """Marks this argument as a key-value map option.
 
@@ -649,56 +766,54 @@ struct Argument(Copyable, Movable, Writable):
         self._is_append = True
         return self^
 
-    def alias_name[name: StringLiteral](var self) -> Self:
-        """Sets an alternative long name for this argument.
+    # ── Parsing behavior ──
 
-        Any alias resolves to this argument during parsing.  For
-        example, ``.long["colour"]().alias_name["color"]()`` makes both
-        ``--colour`` and ``--color`` accepted.  Chain multiple calls
-        for several aliases:
-        ``.alias_name["out"]().alias_name["fmt"]()``.
+    def require_equals(var self) -> Self:
+        """Requires that values be provided using ``=`` syntax.
 
-        Parameters:
-            name: The alternative long option name (without ``--``).
+        When set, ``--key value`` (space-separated) is rejected;
+        only ``--key=value`` is accepted.  This avoids ambiguity
+        when values may start with ``-``.
+
+        Can be combined with ``.default_if_no_value()`` so that ``--key``
+        without ``=`` uses the default-if-no-value, while ``--key=val``
+        uses ``val``.
+
+        Examples::
+
+            # --output=file.txt  → "file.txt" (OK)
+            # --output file.txt  → error
+            _ = Argument("output", help="...").long["output"]().require_equals()
 
         Returns:
-            Self with the alias registered.
-
-        Constraints:
-            The alias is validated at compile time (same rules as
-            ``.long[]``): must not be empty, must not start with ``-``,
-            and must not contain ``=``.
+            Self with require-equals enabled.
         """
-        comptime assert len(name) > 0, "alias name must not be empty"
-        comptime assert not name.startswith(
-            "-"
-        ), "alias name must not start with '-'; omit the '--' prefix"
-        comptime assert name.find("=") == -1, (
-            "alias name must not contain '='; it conflicts with"
-            " --key=value syntax"
-        )
-        self._alias_names.append(name)
+        self._require_equals = True
         return self^
 
-    def deprecated[message: StringLiteral](var self) -> Self:
-        """Marks this argument as deprecated.
+    def allow_hyphen_values(var self) -> Self:
+        """Allows tokens starting with ``-`` as valid values.
 
-        When the user provides a deprecated argument, a warning is
-        printed to stderr but parsing continues normally.
+        By default, tokens that start with ``-`` are interpreted as option
+        flags.  Call this method to accept such tokens as regular values
+        instead, without requiring ``--`` first.  This covers the common
+        Unix convention where a bare ``-`` means stdin/stdout, as well as
+        any other dash-prefixed literal value.
 
-        Parameters:
-            message: The deprecation message (e.g., "Use --format instead").
+        Can be used on positional arguments and value-taking options.
+
+        Examples::
+
+            # Positional: myapp -  → positional value is "-"
+            _ = Argument("input", help="...").positional().allow_hyphen_values()
+
+            # Option: myapp --file -  → file value is "-"
+            _ = Argument("file", help="...").long["file"]().allow_hyphen_values()
 
         Returns:
-            Self marked as deprecated.
-
-        Constraints:
-            The message must not be empty.
+            Self with hyphen-value support enabled.
         """
-        comptime assert (
-            len(message) > 0
-        ), "deprecation message must not be empty"
-        self._deprecated_msg = message
+        self._allow_hyphen_values = True
         return self^
 
     def persistent(var self) -> Self:
@@ -728,128 +843,58 @@ struct Argument(Copyable, Movable, Writable):
         self._is_persistent = True
         return self^
 
-    def default_if_no_value[value: StringLiteral](var self) -> Self:
-        """Sets a default value for when the option appears without an explicit value.
+    # ── Display & help ──
 
-        When set, the option may appear without a value.  If no value
-        is given, this default-if-no-value is used.  If a value is
-        provided via ``=`` syntax for long options (``--compress=bzip2``)
-        or attached form for short options (``-cbzip2``), that explicit
-        value is used instead.
+    def value_name[name: StringLiteral, wrapped: Bool = True](var self) -> Self:
+        """Sets the display name for the value in help text.
 
-        For long options this implies ``require_equals()``.  A
-        space-separated token like ``--compress val`` is not accepted
-        as the option's value; in that case ``--compress`` uses its
-        default-if-no-value and ``val`` is parsed as a separate
-        argument (positional or another option).  To supply an
-        explicit value for the option, the user must write
-        ``--compress=val``.
+        When *wrapped* is True (default), the name is displayed inside angle
+        brackets: ``--output <FILE>``.  When False, it is displayed bare:
+        ``--output FILE``.
 
         Parameters:
-            value: The value to use when no explicit value is given.
+            name: The display name of the value (e.g., "FILE" for --output).
+            wrapped: Wrap the display name in ``<>`` (default True).
 
         Returns:
-            Self with the default-if-no-value set.
+            Self with the value_name set.
 
-        Examples:
-
-        ```mojo
-        # --compress        → "gzip"  (default-if-no-value)
-        # --compress=bzip2  → "bzip2" (explicit)
-        # -c                → "gzip"  (default-if-no-value)
-        # -cbzip2           → "bzip2" (attached)
-
-        from argmojo import Argument
-        _ = (Argument("compress", help="...")
-            .long["compress"]()
-            .short["c"]()
-            .default_if_no_value["gzip"]())
-        ```
+        Constraints:
+            The value name must be a non-empty string.
         """
-        self._default_if_no_value = value
-        self._has_default_if_no_value = True
-        self._require_equals = True  # implied for long options
+        comptime assert len(name) > 0, "value name must be a non-empty string"
+        self._value_name = name
+        self._value_name_wrapped = wrapped
         return self^
 
-    def require_equals(var self) -> Self:
-        """Requires that values be provided using ``=`` syntax.
-
-        When set, ``--key value`` (space-separated) is rejected;
-        only ``--key=value`` is accepted.  This avoids ambiguity
-        when values may start with ``-``.
-
-        Can be combined with ``.default_if_no_value()`` so that ``--key``
-        without ``=`` uses the default-if-no-value, while ``--key=val``
-        uses ``val``.
-
-        Examples::
-
-            # --output=file.txt  → "file.txt" (OK)
-            # --output file.txt  → error
-            _ = Argument("output", help="...").long["output"]().require_equals()
+    def hidden(var self) -> Self:
+        """Marks this argument as hidden (not shown in help output).
 
         Returns:
-            Self with require-equals enabled.
+            Self marked as hidden.
         """
-        self._require_equals = True
+        self._is_hidden = True
         return self^
 
-    def remainder(var self) -> Self:
-        """Marks this positional argument as a remainder collector.
+    def deprecated[message: StringLiteral](var self) -> Self:
+        """Marks this argument as deprecated.
 
-        A remainder argument consumes **all** remaining tokens on the
-        command line — including those starting with ``-``.  It is
-        equivalent to Python's ``nargs=argparse.REMAINDER``.
+        When the user provides a deprecated argument, a warning is
+        printed to stderr but parsing continues normally.
 
-        Implies ``.positional()`` and ``.append()`` — values are retrieved
-        via ``ParseResult.get_list()``.
-
-        A ``Command`` may have at most one remainder argument, and it
-        must be the last positional argument.  Tokens collected by a
-        remainder argument are **not** parsed as options; they are stored
-        verbatim.
-
-        Examples::
-
-            # myapp build -- -Wall -O2 src/main.c
-            # With .remainder(), everything after 'build' goes into rest:
-            _ = Argument("rest", help="...").remainder()
-
-            # Or without '--':
-            # myapp run script.py --script-flag
-            # rest = ["script.py", "--script-flag"]
+        Parameters:
+            message: The deprecation message (e.g., "Use --format instead").
 
         Returns:
-            Self marked as a remainder positional.
+            Self marked as deprecated.
+
+        Constraints:
+            The message must not be empty.
         """
-        self._is_remainder = True
-        self._is_positional = True
-        self._is_append = True
-        return self^
-
-    def allow_hyphen_values(var self) -> Self:
-        """Allows tokens starting with ``-`` as valid values.
-
-        By default, tokens that start with ``-`` are interpreted as option
-        flags.  Call this method to accept such tokens as regular values
-        instead, without requiring ``--`` first.  This covers the common
-        Unix convention where a bare ``-`` means stdin/stdout, as well as
-        any other dash-prefixed literal value.
-
-        Can be used on positional arguments and value-taking options.
-
-        Examples::
-
-            # Positional: myapp -  → positional value is "-"
-            _ = Argument("input", help="...").positional().allow_hyphen_values()
-
-            # Option: myapp --file -  → file value is "-"
-            _ = Argument("file", help="...").long["file"]().allow_hyphen_values()
-
-        Returns:
-            Self with hyphen-value support enabled.
-        """
-        self._allow_hyphen_values = True
+        comptime assert (
+            len(message) > 0
+        ), "deprecation message must not be empty"
+        self._deprecated_msg = message
         return self^
 
     def group[name: StringLiteral](var self) -> Self:
@@ -872,6 +917,8 @@ struct Argument(Copyable, Movable, Writable):
         comptime assert len(name) > 0, "group name must not be empty"
         self._group = name
         return self^
+
+    # ── Interactive prompting ──
 
     def prompt(var self) -> Self:
         """Enables interactive prompting for this argument.

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -160,7 +160,7 @@ struct Command(Copyable, Movable, Writable):
     var subcommands: List[Command]
     """Registered subcommand definitions. Each is a full Command instance."""
 
-    # === Private fields ===
+    # === Private fields — Group constraints ===
     var _exclusive_groups: List[List[String]]
     """Groups of mutually exclusive argument names."""
     var _required_groups: List[List[String]]
@@ -171,16 +171,8 @@ struct Command(Copyable, Movable, Writable):
     """Pairs [target, condition]: target is required when condition is present."""
     var _implications: List[List[String]]
     """Pairs [trigger, implied]: when trigger is set, implied is auto-set."""
-    var _help_on_no_arguments: Bool
-    """When True, show help and exit if no arguments are provided."""
-    var _header_color: String
-    """ANSI code for section headers (Usage, Arguments, Options)."""
-    var _arg_color: String
-    """ANSI code for option / argument names."""
-    var _warn_color: String
-    """ANSI code for deprecation warning messages (default: orange)."""
-    var _error_color: String
-    """ANSI code for parse error messages (default: red)."""
+
+    # === Private fields — Subcommand behavior ===
     var _is_help_subcommand: Bool
     """True for the auto-inserted 'help' pseudo-subcommand.
     Never set this manually; use ``add_subcommand()`` to register subcommands and
@@ -189,6 +181,19 @@ struct Command(Copyable, Movable, Writable):
     var _help_subcommand_enabled: Bool
     """When True (default), auto-insert a 'help' subcommand on first 
     ``add_subcommand()`` call."""
+    var _command_aliases: List[String]
+    """Alternate names for this command when used as a subcommand.
+    Add entries via ``command_aliases()``.  Aliases are matched during
+    subcommand dispatch and appear inline next to the primary name in
+    help (e.g., "clone, cl"), but are not shown as separate entries."""
+    var _is_hidden: Bool
+    """When True, this command is excluded from help output, shell
+    completions, and 'available commands' error lists, but remains
+    dispatchable by exact name or alias.  Set via ``hidden()``."""
+
+    # === Private fields — Parser behavior ===
+    var _help_on_no_arguments: Bool
+    """When True, show help and exit if no arguments are provided."""
     var _allow_negative_numbers: Bool
     """When True, tokens matching negative-number format (-N, -N.N, -NeX)
     are always treated as positional arguments.
@@ -201,30 +206,6 @@ struct Command(Copyable, Movable, Writable):
     By default (False), registering a positional arg on a Command that already 
     has subcommands (or vice versa) raises an Error at registration time.
     Call ``allow_positional_with_subcommands()`` to opt in explicitly."""
-    var _completions_enabled: Bool
-    """When True (default), a built-in completion trigger is active.
-    Call ``disable_default_completions()`` to opt out entirely."""
-    var _completions_name: String
-    """The name used for the built-in completion trigger.
-    Defaults to ``"completions"`` → ``--completions <shell>``.
-    Change via ``completions_name()``."""
-    var _completions_is_subcommand: Bool
-    """When True, the completion trigger is a subcommand instead of an
-    option.  Default False → ``--completions``.  Call
-    ``completions_as_subcommand()`` to switch to ``myapp completions bash``."""
-    var _command_aliases: List[String]
-    """Alternate names for this command when used as a subcommand.
-    Add entries via ``command_aliases()``.  Aliases are matched during
-    subcommand dispatch and appear inline next to the primary name in
-    help (e.g., "clone, cl"), but are not shown as separate entries."""
-    var _tips: List[String]
-    """User-defined tips shown at the bottom of the help message.
-    Add entries via ``add_tip()``.  Each tip is printed on its own line
-    prefixed with the same bold ``Tip:`` label as the built-in hint."""
-    var _is_hidden: Bool
-    """When True, this command is excluded from help output, shell
-    completions, and 'available commands' error lists, but remains
-    dispatchable by exact name or alias.  Set via ``hidden()``."""
     var _response_file_prefix: String
     """Character prefix that marks a response-file token (e.g. ``@``).
     When a token starts with this prefix, the remainder is treated as a
@@ -245,6 +226,8 @@ struct Command(Copyable, Movable, Writable):
     CJK punctuation (e.g. em-dash ``U+2014``) is substituted before
     running Levenshtein typo suggestion.  Call
     ``disable_punctuation_correction()`` to opt out."""
+
+    # === Private fields — Interactive & confirmation ===
     var _confirmation_enabled: Bool
     """When True, the command prompts the user for confirmation before
     returning the parse result.  If ``--yes`` / ``-y`` is provided on
@@ -253,9 +236,36 @@ struct Command(Copyable, Movable, Writable):
     var _confirmation_prompt: String
     """The prompt text shown when asking for confirmation.
     Empty until ``confirmation_option()`` is called."""
+
+    # === Private fields — Help & display ===
+    var _header_color: String
+    """ANSI code for section headers (Usage, Arguments, Options)."""
+    var _arg_color: String
+    """ANSI code for option / argument names."""
+    var _warn_color: String
+    """ANSI code for deprecation warning messages (default: orange)."""
+    var _error_color: String
+    """ANSI code for parse error messages (default: red)."""
     var _custom_usage: String
     """When non-empty, replaces the auto-generated usage line.
     Set via ``usage("...")``."""
+    var _tips: List[String]
+    """User-defined tips shown at the bottom of the help message.
+    Add entries via ``add_tip()``.  Each tip is printed on its own line
+    prefixed with the same bold ``Tip:`` label as the built-in hint."""
+
+    # === Private fields — Shell completions ===
+    var _completions_enabled: Bool
+    """When True (default), a built-in completion trigger is active.
+    Call ``disable_default_completions()`` to opt out entirely."""
+    var _completions_name: String
+    """The name used for the built-in completion trigger.
+    Defaults to ``"completions"`` → ``--completions <shell>``.
+    Change via ``completions_name()``."""
+    var _completions_is_subcommand: Bool
+    """When True, the completion trigger is a subcommand instead of an
+    option.  Default False → ``--completions``.  Call
+    ``completions_as_subcommand()`` to switch to ``myapp completions bash``."""
 
     # ===------------------------------------------------------------------=== #
     # Life cycle methods
@@ -279,33 +289,39 @@ struct Command(Copyable, Movable, Writable):
         self.version = version
         self.args = List[Argument]()
         self.subcommands = List[Command]()
+        # ── Group constraints ──
         self._exclusive_groups = List[List[String]]()
         self._required_groups = List[List[String]]()
         self._one_required_groups = List[List[String]]()
         self._conditional_reqs = List[List[String]]()
         self._implications = List[List[String]]()
-        self._help_on_no_arguments = False
+        # ── Subcommand behavior ──
         self._is_help_subcommand = False
         self._help_subcommand_enabled = True
+        self._command_aliases = List[String]()
+        self._is_hidden = False
+        # ── Parser behavior ──
+        self._help_on_no_arguments = False
         self._allow_negative_numbers = False
         self._allow_positional_with_subcommands = False
-        self._completions_enabled = True
-        self._completions_name = String("completions")
-        self._completions_is_subcommand = False
-        self._command_aliases = List[String]()
-        self._tips = List[String]()
-        self._is_hidden = False
         self._response_file_prefix = String("")
         self._response_file_max_depth = 10
         self._disable_fullwidth_correction = False
         self._disable_punctuation_correction = False
+        # ── Interactive & confirmation ──
         self._confirmation_enabled = False
         self._confirmation_prompt = String("")
-        self._custom_usage = String("")
+        # ── Help & display ──
         self._header_color = _DEFAULT_HEADER_COLOR
         self._arg_color = _DEFAULT_ARG_COLOR
         self._warn_color = _DEFAULT_WARN_COLOR
         self._error_color = _DEFAULT_ERROR_COLOR
+        self._custom_usage = String("")
+        self._tips = List[String]()
+        # ── Shell completions ──
+        self._completions_enabled = True
+        self._completions_name = String("completions")
+        self._completions_is_subcommand = False
 
     def __init__(out self, *, deinit take: Self):
         """Moves a Command, transferring ownership of all fields.
@@ -318,37 +334,43 @@ struct Command(Copyable, Movable, Writable):
         self.version = take.version^
         self.args = take.args^
         self.subcommands = take.subcommands^
+        # ── Group constraints ──
         self._exclusive_groups = take._exclusive_groups^
         self._required_groups = take._required_groups^
         self._one_required_groups = take._one_required_groups^
         self._conditional_reqs = take._conditional_reqs^
         self._implications = take._implications^
-        self._help_on_no_arguments = take._help_on_no_arguments
+        # ── Subcommand behavior ──
         self._is_help_subcommand = take._is_help_subcommand
         self._help_subcommand_enabled = take._help_subcommand_enabled
+        self._command_aliases = take._command_aliases^
+        self._is_hidden = take._is_hidden
+        # ── Parser behavior ──
+        self._help_on_no_arguments = take._help_on_no_arguments
         self._allow_negative_numbers = take._allow_negative_numbers
         self._allow_positional_with_subcommands = (
             take._allow_positional_with_subcommands
         )
-        self._completions_enabled = take._completions_enabled
-        self._completions_name = take._completions_name^
-        self._completions_is_subcommand = take._completions_is_subcommand
-        self._command_aliases = take._command_aliases^
-        self._tips = take._tips^
-        self._is_hidden = take._is_hidden
         self._response_file_prefix = take._response_file_prefix^
         self._response_file_max_depth = take._response_file_max_depth
         self._disable_fullwidth_correction = take._disable_fullwidth_correction
         self._disable_punctuation_correction = (
             take._disable_punctuation_correction
         )
+        # ── Interactive & confirmation ──
         self._confirmation_enabled = take._confirmation_enabled
         self._confirmation_prompt = take._confirmation_prompt^
-        self._custom_usage = take._custom_usage^
+        # ── Help & display ──
         self._header_color = take._header_color^
         self._arg_color = take._arg_color^
         self._warn_color = take._warn_color^
         self._error_color = take._error_color^
+        self._custom_usage = take._custom_usage^
+        self._tips = take._tips^
+        # ── Shell completions ──
+        self._completions_enabled = take._completions_enabled
+        self._completions_name = take._completions_name^
+        self._completions_is_subcommand = take._completions_is_subcommand
 
     def __init__(out self, *, copy: Self):
         """Creates a deep copy of a Command.
@@ -366,6 +388,7 @@ struct Command(Copyable, Movable, Writable):
         self.version = copy.version
         self.args = copy.args.copy()
         self.subcommands = copy.subcommands.copy()
+        # ── Group constraints ──
         self._exclusive_groups = List[List[String]]()
         for i in range(len(copy._exclusive_groups)):
             self._exclusive_groups.append(copy._exclusive_groups[i].copy())
@@ -383,36 +406,43 @@ struct Command(Copyable, Movable, Writable):
         self._implications = List[List[String]]()
         for i in range(len(copy._implications)):
             self._implications.append(copy._implications[i].copy())
-        self._help_on_no_arguments = copy._help_on_no_arguments
+        # ── Subcommand behavior ──
         self._is_help_subcommand = copy._is_help_subcommand
         self._help_subcommand_enabled = copy._help_subcommand_enabled
+        self._command_aliases = copy._command_aliases.copy()
+        self._is_hidden = copy._is_hidden
+        # ── Parser behavior ──
+        self._help_on_no_arguments = copy._help_on_no_arguments
         self._allow_negative_numbers = copy._allow_negative_numbers
         self._allow_positional_with_subcommands = (
             copy._allow_positional_with_subcommands
         )
-        self._completions_enabled = copy._completions_enabled
-        self._completions_name = copy._completions_name
-        self._completions_is_subcommand = copy._completions_is_subcommand
-        self._command_aliases = copy._command_aliases.copy()
-        self._tips = copy._tips.copy()
-        self._is_hidden = copy._is_hidden
         self._response_file_prefix = copy._response_file_prefix
         self._response_file_max_depth = copy._response_file_max_depth
         self._disable_fullwidth_correction = copy._disable_fullwidth_correction
         self._disable_punctuation_correction = (
             copy._disable_punctuation_correction
         )
+        # ── Interactive & confirmation ──
         self._confirmation_enabled = copy._confirmation_enabled
         self._confirmation_prompt = copy._confirmation_prompt
-        self._custom_usage = copy._custom_usage
+        # ── Help & display ──
         self._header_color = copy._header_color
         self._arg_color = copy._arg_color
         self._warn_color = copy._warn_color
         self._error_color = copy._error_color
+        self._custom_usage = copy._custom_usage
+        self._tips = copy._tips.copy()
+        # ── Shell completions ──
+        self._completions_enabled = copy._completions_enabled
+        self._completions_name = copy._completions_name
+        self._completions_is_subcommand = copy._completions_is_subcommand
 
     # ===------------------------------------------------------------------=== #
     # Builder methods for configuring the command
     # ===------------------------------------------------------------------=== #
+
+    # ── Registration ──
 
     def add_argument(mut self, var argument: Argument) raises:
         """Registers an argument definition.
@@ -683,325 +713,7 @@ struct Command(Copyable, Movable, Writable):
         for i in range(len(parent._implications)):
             self._implications.append(parent._implications[i].copy())
 
-    def disable_help_subcommand(mut self):
-        """Opts out of the auto-added ``help`` subcommand.
-
-        By default, the first call to ``add_subcommand()`` automatically
-        registers a ``help`` subcommand so that ``app help <sub>`` works as
-        an alias for ``app <sub> --help``.
-
-        Call this before or after ``add_subcommand()`` to suppress the
-        feature — useful when ``"help"`` is a legitimate first positional
-        value (e.g. a search pattern or entity name).  After disabling, use
-        ``app <sub> --help`` directly.
-
-        Example:
-
-        ```mojo
-        from argmojo import Command
-        var app = Command("search", "Search engine")
-        app.disable_help_subcommand()   # "help" is a valid search query
-        # Now: ``search help init``  →  positionals ["help", "init"] on root,
-        #    so that you can do something like: search "help" in path "init".
-        #    ``search init --help``  →  shows init's help page
-        ```
-        """
-        self._help_subcommand_enabled = False
-        # Remove any already-inserted help subcommand.
-        var new_subs = List[Command]()
-        for i in range(len(self.subcommands)):
-            if not self.subcommands[i]._is_help_subcommand:
-                new_subs.append(self.subcommands[i].copy())
-        self.subcommands = new_subs^
-
-    def allow_negative_numbers(mut self):
-        """Treats tokens that look like negative numbers as positional arguments.
-
-        By default ArgMojo already auto-detects negative-number tokens
-        (``-9``, ``-3.14``, ``-1.5e10``) and passes them through as
-        positionals **when no registered short option starts with a digit**.
-        Call this method explicitly when you have registered a digit short
-        option (e.g., ``-3`` for ``--triple``) and still need negative-number
-        literals to be treated as positionals.
-
-        Example:
-
-        ```mojo
-        from argmojo import Command, Argument
-        var command = Command("calc", "Calculator")
-        command.allow_negative_numbers()
-        command.add_argument(Argument("expr", help="Expression").positional().required())
-        # Now: calc -10.18  →  positionals = ["-10.18"]
-        ```
-        """
-        self._allow_negative_numbers = True
-
-    def allow_positional_with_subcommands(mut self):
-        """Allows a Command to have both positional args and subcommands.
-
-        By default, ArgMojo follows the convention of cobra (Go) and clap
-        (Rust): a Command with subcommands cannot also have positional
-        arguments, because the parser cannot unambiguously distinguish a
-        subcommand name from a positional value.
-
-        Call this method **before** registering positional args and
-        subcommands to opt in to the mixed mode.  In mixed mode, a token
-        that exactly matches a registered subcommand name is dispatched;
-        any other token falls through to the positional list.
-
-        Example:
-
-        ```mojo
-        from argmojo import Command, Argument
-        var app = Command("tool", "Flexible tool")
-        app.allow_positional_with_subcommands()
-        app.add_argument(Argument("target", help="Default target").positional())
-        var sub = Command("build", "Build the project")
-        app.add_subcommand(sub^)
-        # Now: tool build    → dispatch to 'build' subcommand
-        #      tool foo.txt  → positional "foo.txt"
-        ```
-        """
-        self._allow_positional_with_subcommands = True
-
-    def disable_default_completions(mut self):
-        """Disables the built-in completion trigger entirely.
-
-        By default, every ``Command`` has a built-in ``--completions bash``
-        (or ``zsh`` / ``fish``) that prints a shell completion script and
-        exits.  Call this method to remove that trigger completely.
-
-        The ``generate_completion()`` method is still available for
-        programmatic use — only the automatic trigger is removed.
-
-        Example:
-
-        ```mojo
-        from argmojo import Command
-        var app = Command("myapp", "My CLI")
-        app.disable_default_completions()
-        # --completions is now an unknown option
-        # but app.generate_completion["bash"]() still works
-        ```
-        """
-        self._completions_enabled = False
-
-    def completions_name(mut self, name: String):
-        """Sets the name used for the built-in completion trigger.
-
-        Default is ``"completions"`` → ``--completions <shell>``.
-        Change to any name you prefer:
-
-        - ``app.completions_name("autocomp")`` → ``--autocomp bash``
-        - ``app.completions_name("generate-completions")`` → ``--generate-completions bash``
-
-        Combine with ``completions_as_subcommand()`` to use as a subcommand:
-
-        - ``app.completions_name("comp")`` + ``app.completions_as_subcommand()``
-          → ``myapp comp bash``
-
-        Args:
-            name: The new trigger name (without ``--`` prefix).
-
-        Example:
-
-        ```mojo
-        from argmojo import Command
-        var app = Command("myapp", "My CLI")
-        app.completions_name("autocomp")
-        # Now: myapp --autocomp bash
-        ```
-        """
-        self._completions_name = name
-
-    def completions_as_subcommand(mut self):
-        """Switches the built-in completion trigger from an option to a subcommand.
-
-        Default behaviour: ``myapp --completions bash``
-        After calling this: ``myapp completions bash``
-
-        Combine with ``completions_name()`` to customise the subcommand name:
-
-        ```mojo
-        from argmojo import Command
-        var app = Command("decimo", "CLI calculator based on decimo")
-        app.completions_name("comp")
-        app.completions_as_subcommand()
-        # → myapp comp bash
-        ```
-
-        The subcommand is auto-registered when ``parse()`` runs. It does
-        **not** appear in help output by default (like the ``help``
-        subcommand). The auto-registered subcommand takes one positional
-        argument (the shell name) and handles printing + exiting.
-        """
-        self._completions_is_subcommand = True
-
-    def add_tip(mut self, tip: String):
-        """Adds a custom tip line to the bottom of the help message.
-
-        Each tip is printed on its own line below the built-in ``--``
-        separator hint, prefixed with a bold ``Tip:`` label.  Useful for
-        documenting shell idioms, environment variables, or any other
-        usage notes that don't fit in argument help strings.
-
-        Args:
-            tip: The tip text to display.
-
-        Example:
-
-        ```mojo
-        from argmojo import Command, Argument
-        var command = Command("myapp", "A sample application")
-        command.add_tip("Set MYAPP_DEBUG=1 to enable debug logging.")
-        command.add_tip("Config file: ~/.config/myapp/config.toml")
-        ```
-        """
-        self._tips.append(tip)
-
-    # TODO: alias_name[name: StringLiteral](mut self) for compile-time checks
-    def command_aliases(mut self, var names: List[String]):
-        """Registers alternate names for this command when used as a subcommand.
-
-        Aliases are matched during subcommand dispatch and included in
-        shell completion scripts, but they do **not** appear as separate
-        entries in the ``Commands:`` help section.  Instead, aliases are
-        shown inline next to the primary name.
-
-        Args:
-            names: The list of alias strings.
-
-        Example:
-
-        ```mojo
-        from argmojo import Command
-        var clone = Command("clone", "Clone a repository")
-        var aliases: List[String] = ["cl"]
-        clone.command_aliases(aliases^)
-        # Now: mgit cl ... is equivalent to mgit clone ...
-        ```
-        """
-        for i in range(len(names)):
-            self._command_aliases.append(names[i])
-
-    def hidden(mut self):
-        """Marks this subcommand as hidden.
-
-        A hidden subcommand is excluded from help output, shell completion
-        scripts, and the "Available commands" error message, but remains
-        dispatchable by exact name or alias.  Useful for internal,
-        experimental, or deprecated subcommands.
-
-        Example:
-
-        ```mojo
-        from argmojo import Command
-        var app = Command("myapp", "A sample application")
-        var debug = Command("debug", "Internal debug command")
-        debug.hidden()
-        app.add_subcommand(debug^)
-        # 'debug' won't appear in --help or completions, but:
-        #   app debug ...   still works
-        ```
-        """
-        self._is_hidden = True
-
-    # TODO: response_file_prefix[prefix: StringLiteral](mut self) for compile-time checks
-    def response_file_prefix(mut self, prefix: String = "@"):
-        """Enables response-file expansion for this command.
-
-        Warning: **Temporarily disabled** — the underlying expansion
-        logic is compiled out to work around a Mojo compiler deadlock
-        triggered by ``-D ASSERT=all``.  Calling this method still
-        stores the prefix, but ``parse_arguments()`` will **not**
-        expand response-file tokens until the compiler bug is fixed.
-
-        When enabled, any token that starts with the given ``prefix``
-        is treated as a response-file reference.  The remainder of
-        the token is the file path; each non-empty, non-comment line
-        of that file is inserted as a separate argument in place of
-        the original token.
-
-        - Blank lines and lines starting with ``#`` are ignored.
-        - Leading / trailing whitespace on each line is stripped.
-        - Response files may reference other response files (recursive),
-          up to the configured nesting depth (set via
-          ``response_file_max_depth[depth]()``; default 10).
-        - To pass a literal token that starts with the prefix (e.g. an
-          email ``@user``), escape it by doubling the prefix: ``@@user``
-          is inserted as ``@user``.
-
-        Args:
-            prefix: The prefix character(s) that introduce a response
-                file (default ``"@"``).
-
-        Example:
-
-        ```mojo
-        from argmojo import Command
-        var command = Command("myapp", "A sample application")
-        command.response_file_prefix()  # uses default '@'
-        # Now: myapp @args.txt  reads arguments from args.txt
-        ```
-        """
-        self._response_file_prefix = prefix
-
-    def response_file_max_depth[depth: Int](mut self) where depth > 0:
-        """Sets the maximum nesting depth for response-file expansion.
-
-        Warning: **Temporarily disabled** — see
-        ``response_file_prefix()`` docstring for details.
-
-        Parameters:
-            depth: Maximum recursion depth (default 10).
-                Constraints: must be positive.
-        """
-        self._response_file_max_depth = depth
-
-    def disable_fullwidth_correction(mut self):
-        """Disables automatic full-width → half-width character correction.
-
-        By default, ArgMojo detects fullwidth ASCII characters
-        (``U+FF01``–``U+FF5E``) and fullwidth spaces (``U+3000``) in
-        option tokens (those starting with ``-``) and auto-corrects them
-        to their halfwidth equivalents with a warning.  This helps CJK
-        users who forget to switch input methods.
-
-        Call this method to disable that correction entirely — useful
-        when strict parsing is preferred.
-
-        Example:
-
-        ```mojo
-        from argmojo import Command
-        var app = Command("myapp", "My CLI")
-        app.disable_fullwidth_correction()
-        # Now: －－ｖｅｒｂｏｓｅ is NOT corrected → unknown option error
-        ```
-        """
-        self._disable_fullwidth_correction = True
-
-    def disable_punctuation_correction(mut self):
-        """Disables CJK punctuation detection in error recovery.
-
-        By default, when an unknown option is encountered, ArgMojo tries
-        substituting common CJK punctuation (e.g. em-dash ``——`` →
-        ``--``) before running Levenshtein typo suggestion.  This helps
-        CJK users who accidentally type Chinese punctuation.
-
-        Call this method to disable that behaviour — useful when strict
-        error messages are preferred.
-
-        Example:
-
-        ```mojo
-        from argmojo import Command
-        var app = Command("myapp", "My CLI")
-        app.disable_punctuation_correction()
-        # Now: ——verbose will NOT attempt em-dash → hyphen correction
-        ```
-        """
-        self._disable_punctuation_correction = True
+    # ── Group constraints ──
 
     def mutually_exclusive(mut self, var names: List[String]) raises:
         """Declares a group of mutually exclusive arguments.
@@ -1300,32 +1012,115 @@ struct Command(Copyable, Movable, Writable):
         var imp_triple: List[String] = [trigger, implied, implied_kind]
         self._implications.append(imp_triple^)
 
-    def usage(mut self, text: String):
-        """Sets a custom usage line, replacing the auto-generated one.
+    # ── Subcommand behavior ──
 
-        By default, ArgMojo generates a usage line like::
+    def command_aliases(mut self, var names: List[String]):
+        """Registers alternate names for this command when used as a subcommand.
 
-            Usage: myapp <file> [OPTIONS]
-
-        Call this method to override it with a completely custom string.
-        The string should **not** include the ``Usage:`` prefix — it will
-        be added automatically.
+        Aliases are matched during subcommand dispatch and included in
+        shell completion scripts, but they do **not** appear as separate
+        entries in the ``Commands:`` help section.  Instead, aliases are
+        shown inline next to the primary name.
 
         Args:
-            text: The custom usage text (e.g. ``"myapp [-v | --version]
-                [-C <path>] <command> [<args>]"``).
+            names: The list of alias strings.
 
         Example:
 
         ```mojo
         from argmojo import Command
-        var cmd = Command("git", "The stupid content tracker")
-        cmd.usage("git [-v | --version] [-C <path>] <command> [<args>]")
-        # --help will show:
-        #   Usage: git [-v | --version] [-C <path>] <command> [<args>]
+        var clone = Command("clone", "Clone a repository")
+        var aliases: List[String] = ["cl"]
+        clone.command_aliases(aliases^)
+        # Now: mgit cl ... is equivalent to mgit clone ...
         ```
         """
-        self._custom_usage = text
+        for i in range(len(names)):
+            self._command_aliases.append(names[i])
+
+    def hidden(mut self):
+        """Marks this subcommand as hidden.
+
+        A hidden subcommand is excluded from help output, shell completion
+        scripts, and the "Available commands" error message, but remains
+        dispatchable by exact name or alias.  Useful for internal,
+        experimental, or deprecated subcommands.
+
+        Example:
+
+        ```mojo
+        from argmojo import Command
+        var app = Command("myapp", "A sample application")
+        var debug = Command("debug", "Internal debug command")
+        debug.hidden()
+        app.add_subcommand(debug^)
+        # 'debug' won't appear in --help or completions, but:
+        #   app debug ...   still works
+        ```
+        """
+        self._is_hidden = True
+
+    # TODO: response_file_prefix[prefix: StringLiteral](mut self) for compile-time checks
+    def disable_help_subcommand(mut self):
+        """Opts out of the auto-added ``help`` subcommand.
+
+        By default, the first call to ``add_subcommand()`` automatically
+        registers a ``help`` subcommand so that ``app help <sub>`` works as
+        an alias for ``app <sub> --help``.
+
+        Call this before or after ``add_subcommand()`` to suppress the
+        feature — useful when ``"help"`` is a legitimate first positional
+        value (e.g. a search pattern or entity name).  After disabling, use
+        ``app <sub> --help`` directly.
+
+        Example:
+
+        ```mojo
+        from argmojo import Command
+        var app = Command("search", "Search engine")
+        app.disable_help_subcommand()   # "help" is a valid search query
+        # Now: ``search help init``  →  positionals ["help", "init"] on root,
+        #    so that you can do something like: search "help" in path "init".
+        #    ``search init --help``  →  shows init's help page
+        ```
+        """
+        self._help_subcommand_enabled = False
+        # Remove any already-inserted help subcommand.
+        var new_subs = List[Command]()
+        for i in range(len(self.subcommands)):
+            if not self.subcommands[i]._is_help_subcommand:
+                new_subs.append(self.subcommands[i].copy())
+        self.subcommands = new_subs^
+
+    def allow_positional_with_subcommands(mut self):
+        """Allows a Command to have both positional args and subcommands.
+
+        By default, ArgMojo follows the convention of cobra (Go) and clap
+        (Rust): a Command with subcommands cannot also have positional
+        arguments, because the parser cannot unambiguously distinguish a
+        subcommand name from a positional value.
+
+        Call this method **before** registering positional args and
+        subcommands to opt in to the mixed mode.  In mixed mode, a token
+        that exactly matches a registered subcommand name is dispatched;
+        any other token falls through to the positional list.
+
+        Example:
+
+        ```mojo
+        from argmojo import Command, Argument
+        var app = Command("tool", "Flexible tool")
+        app.allow_positional_with_subcommands()
+        app.add_argument(Argument("target", help="Default target").positional())
+        var sub = Command("build", "Build the project")
+        app.add_subcommand(sub^)
+        # Now: tool build    → dispatch to 'build' subcommand
+        #      tool foo.txt  → positional "foo.txt"
+        ```
+        """
+        self._allow_positional_with_subcommands = True
+
+    # ── Parser behavior ──
 
     def help_on_no_arguments(mut self) raises:
         """Enables showing help when invoked with no arguments.
@@ -1358,6 +1153,126 @@ struct Command(Copyable, Movable, Writable):
                     " help_on_no_arguments() or .prompt()"
                 )
         self._help_on_no_arguments = True
+
+    def allow_negative_numbers(mut self):
+        """Treats tokens that look like negative numbers as positional arguments.
+
+        By default ArgMojo already auto-detects negative-number tokens
+        (``-9``, ``-3.14``, ``-1.5e10``) and passes them through as
+        positionals **when no registered short option starts with a digit**.
+        Call this method explicitly when you have registered a digit short
+        option (e.g., ``-3`` for ``--triple``) and still need negative-number
+        literals to be treated as positionals.
+
+        Example:
+
+        ```mojo
+        from argmojo import Command, Argument
+        var command = Command("calc", "Calculator")
+        command.allow_negative_numbers()
+        command.add_argument(Argument("expr", help="Expression").positional().required())
+        # Now: calc -10.18  →  positionals = ["-10.18"]
+        ```
+        """
+        self._allow_negative_numbers = True
+
+    def response_file_prefix(mut self, prefix: String = "@"):
+        """Enables response-file expansion for this command.
+
+        Warning: **Temporarily disabled** — the underlying expansion
+        logic is compiled out to work around a Mojo compiler deadlock
+        triggered by ``-D ASSERT=all``.  Calling this method still
+        stores the prefix, but ``parse_arguments()`` will **not**
+        expand response-file tokens until the compiler bug is fixed.
+
+        When enabled, any token that starts with the given ``prefix``
+        is treated as a response-file reference.  The remainder of
+        the token is the file path; each non-empty, non-comment line
+        of that file is inserted as a separate argument in place of
+        the original token.
+
+        - Blank lines and lines starting with ``#`` are ignored.
+        - Leading / trailing whitespace on each line is stripped.
+        - Response files may reference other response files (recursive),
+          up to the configured nesting depth (set via
+          ``response_file_max_depth[depth]()``; default 10).
+        - To pass a literal token that starts with the prefix (e.g. an
+          email ``@user``), escape it by doubling the prefix: ``@@user``
+          is inserted as ``@user``.
+
+        Args:
+            prefix: The prefix character(s) that introduce a response
+                file (default ``"@"``).
+
+        Example:
+
+        ```mojo
+        from argmojo import Command
+        var command = Command("myapp", "A sample application")
+        command.response_file_prefix()  # uses default '@'
+        # Now: myapp @args.txt  reads arguments from args.txt
+        ```
+        """
+        self._response_file_prefix = prefix
+
+    def response_file_max_depth[depth: Int](mut self) where depth > 0:
+        """Sets the maximum nesting depth for response-file expansion.
+
+        Warning: **Temporarily disabled** — see
+        ``response_file_prefix()`` docstring for details.
+
+        Parameters:
+            depth: Maximum recursion depth (default 10).
+                Constraints: must be positive.
+        """
+        self._response_file_max_depth = depth
+
+    def disable_fullwidth_correction(mut self):
+        """Disables automatic full-width → half-width character correction.
+
+        By default, ArgMojo detects fullwidth ASCII characters
+        (``U+FF01``–``U+FF5E``) and fullwidth spaces (``U+3000``) in
+        option tokens (those starting with ``-``) and auto-corrects them
+        to their halfwidth equivalents with a warning.  This helps CJK
+        users who forget to switch input methods.
+
+        Call this method to disable that correction entirely — useful
+        when strict parsing is preferred.
+
+        Example:
+
+        ```mojo
+        from argmojo import Command
+        var app = Command("myapp", "My CLI")
+        app.disable_fullwidth_correction()
+        # Now: －－ｖｅｒｂｏｓｅ is NOT corrected → unknown option error
+        ```
+        """
+        self._disable_fullwidth_correction = True
+
+    def disable_punctuation_correction(mut self):
+        """Disables CJK punctuation detection in error recovery.
+
+        By default, when an unknown option is encountered, ArgMojo tries
+        substituting common CJK punctuation (e.g. em-dash ``——`` →
+        ``--``) before running Levenshtein typo suggestion.  This helps
+        CJK users who accidentally type Chinese punctuation.
+
+        Call this method to disable that behaviour — useful when strict
+        error messages are preferred.
+
+        Example:
+
+        ```mojo
+        from argmojo import Command
+        var app = Command("myapp", "My CLI")
+        app.disable_punctuation_correction()
+        # Now: ——verbose will NOT attempt em-dash → hyphen correction
+        ```
+        """
+        self._disable_punctuation_correction = True
+
+    # ── Interactive & confirmation ──
 
     def confirmation_option(mut self) raises:
         """Adds a ``--yes`` / ``-y`` flag to skip a confirmation prompt.
@@ -1446,6 +1361,59 @@ struct Command(Copyable, Movable, Writable):
     # This ensures developers get a compiler error for invalid colour
     # names during development, instead of end users seeing runtime
     # failures caused by a misspelled or unsupported colour.
+
+    # ── Help & display ──
+
+    def usage(mut self, text: String):
+        """Sets a custom usage line, replacing the auto-generated one.
+
+        By default, ArgMojo generates a usage line like::
+
+            Usage: myapp <file> [OPTIONS]
+
+        Call this method to override it with a completely custom string.
+        The string should **not** include the ``Usage:`` prefix — it will
+        be added automatically.
+
+        Args:
+            text: The custom usage text (e.g. ``"myapp [-v | --version]
+                [-C <path>] <command> [<args>]"``).
+
+        Example:
+
+        ```mojo
+        from argmojo import Command
+        var cmd = Command("git", "The stupid content tracker")
+        cmd.usage("git [-v | --version] [-C <path>] <command> [<args>]")
+        # --help will show:
+        #   Usage: git [-v | --version] [-C <path>] <command> [<args>]
+        ```
+        """
+        self._custom_usage = text
+
+    def add_tip(mut self, tip: String):
+        """Adds a custom tip line to the bottom of the help message.
+
+        Each tip is printed on its own line below the built-in ``--``
+        separator hint, prefixed with a bold ``Tip:`` label.  Useful for
+        documenting shell idioms, environment variables, or any other
+        usage notes that don't fit in argument help strings.
+
+        Args:
+            tip: The tip text to display.
+
+        Example:
+
+        ```mojo
+        from argmojo import Command, Argument
+        var command = Command("myapp", "A sample application")
+        command.add_tip("Set MYAPP_DEBUG=1 to enable debug logging.")
+        command.add_tip("Config file: ~/.config/myapp/config.toml")
+        ```
+        """
+        self._tips.append(tip)
+
+    # TODO: alias_name[name: StringLiteral](mut self) for compile-time checks
     def header_color[name: StringLiteral](mut self):
         """Sets the colour for section headers (Usage, Arguments, Options).
 
@@ -1528,6 +1496,81 @@ struct Command(Copyable, Movable, Writable):
         ```
         """
         self._error_color = _resolve_color[name]()
+
+    # ── Shell completions ──
+
+    def disable_default_completions(mut self):
+        """Disables the built-in completion trigger entirely.
+
+        By default, every ``Command`` has a built-in ``--completions bash``
+        (or ``zsh`` / ``fish``) that prints a shell completion script and
+        exits.  Call this method to remove that trigger completely.
+
+        The ``generate_completion()`` method is still available for
+        programmatic use — only the automatic trigger is removed.
+
+        Example:
+
+        ```mojo
+        from argmojo import Command
+        var app = Command("myapp", "My CLI")
+        app.disable_default_completions()
+        # --completions is now an unknown option
+        # but app.generate_completion["bash"]() still works
+        ```
+        """
+        self._completions_enabled = False
+
+    def completions_name(mut self, name: String):
+        """Sets the name used for the built-in completion trigger.
+
+        Default is ``"completions"`` → ``--completions <shell>``.
+        Change to any name you prefer:
+
+        - ``app.completions_name("autocomp")`` → ``--autocomp bash``
+        - ``app.completions_name("generate-completions")`` → ``--generate-completions bash``
+
+        Combine with ``completions_as_subcommand()`` to use as a subcommand:
+
+        - ``app.completions_name("comp")`` + ``app.completions_as_subcommand()``
+          → ``myapp comp bash``
+
+        Args:
+            name: The new trigger name (without ``--`` prefix).
+
+        Example:
+
+        ```mojo
+        from argmojo import Command
+        var app = Command("myapp", "My CLI")
+        app.completions_name("autocomp")
+        # Now: myapp --autocomp bash
+        ```
+        """
+        self._completions_name = name
+
+    def completions_as_subcommand(mut self):
+        """Switches the built-in completion trigger from an option to a subcommand.
+
+        Default behaviour: ``myapp --completions bash``
+        After calling this: ``myapp completions bash``
+
+        Combine with ``completions_name()`` to customise the subcommand name:
+
+        ```mojo
+        from argmojo import Command
+        var app = Command("decimo", "CLI calculator based on decimo")
+        app.completions_name("comp")
+        app.completions_as_subcommand()
+        # → myapp comp bash
+        ```
+
+        The subcommand is auto-registered when ``parse()`` runs. It does
+        **not** appear in help output by default (like the ``help``
+        subcommand). The auto-registered subcommand takes one positional
+        argument (the shell name) and handles printing + exiting.
+        """
+        self._completions_is_subcommand = True
 
     # ===------------------------------------------------------------------=== #
     # Private output helpers
@@ -1690,6 +1733,10 @@ struct Command(Copyable, Movable, Writable):
             s += " <COMMAND>"
         s += " [OPTIONS]"
         return s
+
+    # ===------------------------------------------------------------------=== #
+    # Public parse methods
+    # ===------------------------------------------------------------------=== #
 
     def parse(self) raises -> ParseResult:
         """Parses command-line arguments from ``sys.argv()``.

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -1060,7 +1060,6 @@ struct Command(Copyable, Movable, Writable):
         """
         self._is_hidden = True
 
-    # TODO: response_file_prefix[prefix: StringLiteral](mut self) for compile-time checks
     def disable_help_subcommand(mut self):
         """Opts out of the auto-added ``help`` subcommand.
 
@@ -1176,6 +1175,7 @@ struct Command(Copyable, Movable, Writable):
         """
         self._allow_negative_numbers = True
 
+    # TODO: response_file_prefix[prefix: StringLiteral](mut self) for compile-time checks
     def response_file_prefix(mut self, prefix: String = "@"):
         """Enables response-file expansion for this command.
 


### PR DESCRIPTION
This PR adds a planning/design document for a future declarative (struct-based) ArgMojo API and updates planning/overview docs to reference it, while also reorganizing `Command`/`Argument` internals for clearer grouping.

**Changes:**
- Add `docs/declarative_api_planning.md` with a detailed design + implementation roadmap for a declarative API layered on the existing builder API.
- Update `docs/argmojo_overall_planning.md` and `README.md` to include Swift `swift-argument-parser` as inspiration and to reference the new planning doc.
- Refactor/reorder `Command` and `Argument` private fields + builder method sections to be grouped by concern (constraints, parsing behavior, help/display, completions, etc.).