### PR TITLE
[core][declarative] Implement argument wrappers and Parsable trait

### DIFF
--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -685,8 +685,8 @@ These features use capabilities already available in Mojo 0.26.2 and can be expe
 
 **Declarative API summary** (see [full design doc](declarative_api_planning.md)):
 
-- **Layered on builder** — `declaration.mojo` is a consumer of `Command` + `Argument`; no new parsing engine.
-- **Swift-inspired** — Parametric wrapper types (`Option[T, ...]`, `Flag[...]`, `Positional[T, ...]`, `Count[...]`) mirror Swift's property wrappers (`@Option`, `@Flag`, `@Argument`). `Declarable` trait mirrors `ParsableCommand`.
+- **Layered on builder** — `parser.mojo` is a consumer of `Command` + `Argument`; no new parsing engine.
+- **Swift-inspired** — Parametric wrapper types (`Option[T, ...]`, `Flag[...]`, `Positional[T, ...]`, `Count[...]`) mirror Swift's property wrappers (`@Option`, `@Flag`, `@Argument`). `Parsable` trait mirrors `ParsableCommand`.
 - **Two innovations beyond Swift**: (1) `to_command()` exposes the underlying `Command` for builder-level tweaks (groups, implications, coloured help); (2) `parse_split()` returns both typed struct + `ParseResult` for hybrid workflows.
 - **Optional** — Users who prefer the builder API are completely unaffected. Zero change to existing code.
 

--- a/docs/declarative_api_planning.md
+++ b/docs/declarative_api_planning.md
@@ -801,7 +801,7 @@ var args = Parser[MyArgs]()
 **My approach**: `parse_split()` returns a **tuple of both**:
 
 ```mojo
-def parse_split(mut self) raises -> (T, ParseResult):
+def parse_split(mut self) raises -> Tuple[T, ParseResult]:
 ```
 
 - The first element is your struct `T` with all declarative-registered fields populated & typed.

--- a/docs/declarative_api_planning.md
+++ b/docs/declarative_api_planning.md
@@ -3,16 +3,16 @@
 > **Status**: Planning  
 > **Target**: argmojo v0.5.0  
 > **Mojo Version**: 0.26.2+  
-> **Initial Date**: 2026-03-24
-
-> 子曰工欲善其事必先利其器
+> **Initial Date**: 2026-03-24  
+>
+> 子曰工欲善其事必先利其器  
 > The mechanic, who wishes to do his work well, must first sharpen his tools -- Confucius
 
 ## 1. Design Goals
 
 I want the declarative API to satisfy five goals:
 
-1. **Optional** — If you prefer the builder API, nothing changes for you. The declaration module is a separate import (`from argmojo.declaration import ...`). Zero change to existing code.
+1. **Optional** — If you prefer the builder API, nothing changes for you. The parser module is a separate import (`from argmojo.parser import ...`). Zero change to existing code.
 
 2. **Hybrid** — Builder and declarative can coexist in a single program. You define a struct for 80% of arguments, then reach for builder methods for the remaining 20% (groups, implications, advanced constraints).
 
@@ -20,7 +20,7 @@ I want the declarative API to satisfy five goals:
 
 4. **Type-safe** — Parsed results come back as your own struct with typed fields, not `ParseResult.get_string("name")`.
 
-5. **Two innovations** — I think there are two features I can offer beyond what Swift Argument Parser does (see [§6](#6-innovations)).
+5. **Five innovations** — I think there are five features I can offer beyond what Swift Argument Parser does (see [§6](#6-innovations)).
 
 ## 2. Mojo Reflection Capabilities (v0.26.2)
 
@@ -61,35 +61,76 @@ struct Greet: ParsableCommand {
 Greet.main()
 ```
 
+What the compiler actually sees — Swift **desugars** the `@` property wrappers into hidden parametric structs:
+
+```swift
+struct Greet: ParsableCommand {
+    // @Argument(help: "The person's name.")
+    // var name: String
+    //   desugared into:
+    var _name: Argument<String> = Argument<String>(help: "The person's name.")
+    var name: String {
+        get { _name.wrappedValue }
+        set { _name.wrappedValue = newValue }
+    }
+
+    // @Option(name: .shortAndLong, help: "Repeat count.")
+    // var count: Int = 1
+    //   desugared into:
+    var _count: Option<Int> = Option<Int>(name: .shortAndLong, help: "Repeat count.", wrappedValue: 1)
+    var count: Int {
+        get { _count.wrappedValue }
+        set { _count.wrappedValue = newValue }
+    }
+
+    // @Flag(inversion: .prefixedNo, help: "Include greeting.")
+    // var includeGreeting = true
+    //   desugared into:
+    var _includeGreeting: Flag<Bool> = Flag<Bool>(inversion: .prefixedNo, help: "Include greeting.", wrappedValue: true)
+    var includeGreeting: Bool {
+        get { _includeGreeting.wrappedValue }
+        set { _includeGreeting.wrappedValue = newValue }
+    }
+
+    mutating func run() throws {
+        for _ in 0..<count { print("Hello, \(name)!") }
+    }
+}
+```
+
+So under the hood, Swift is wrapping each field in a parametric metadata-carrying struct (`Argument<String>`, `Option<Int>`, `Flag<Bool>`). The `@` sugar just hides the wrapper and generates a computed property so users write `args.name` instead of `args._name.wrappedValue`.
+
+This is inspiring, great! It can be translated into Mojo with explicit parametric structs — the only cost is the lack of `@` sugar, so users access the inner value via `.value` instead of a compiler-generated computed property.
+
 Direct mapping to argmojo declarative API:
 
-| Swift Mechanism                  | ArgMojo Equivalent                           |
-| -------------------------------- | -------------------------------------------- |
-| `@Argument(help: "...")`         | `Positional[T, help="..."]`                  |
-| `@Option(name: .shortAndLong)`   | `Option[T, long="...", short="..."]`         |
-| `@Flag(inversion: .prefixedNo)`  | `Flag[negatable=True]`                       |
-| (no Swift equivalent)            | `Count[short="v", max=3]`                    |
-| (no Swift equivalent)            | `Declaration[T]`                             |
-| `ParsableCommand` protocol       | `Declarable` trait                           |
-| `@OptionGroup`                   | Argument parents via `Command.add_parent()`  |
-| `ExpressibleByArgument` protocol | `ExpressibleByArgument` trait                |
-| `CommandGroup`                   | `SubDeclaration[...]`                        |
-| `mutating func run()`            | Separate: `Declaration[T].parse()` returns T |
-| `mutating func validate()`       | `def validate(self) raises` on `Declarable`  |
+| Swift Mechanism                  | ArgMojo Equivalent                          |
+| -------------------------------- | ------------------------------------------- |
+| `@Argument(help: "...")`         | `Positional[T, help="..."]`                 |
+| `@Option(name: .shortAndLong)`   | `Option[T, long="...", short="..."]`        |
+| `@Flag(inversion: .prefixedNo)`  | `Flag[negatable=True]`                      |
+| (no Swift equivalent)            | `Count[short="v", max=3]`                   |
+| (no Swift equivalent)            | `Parser[T]`                                 |
+| `ParsableCommand` protocol       | `Parsable` trait                            |
+| `@OptionGroup`                   | Argument parents via `Command.add_parent()` |
+| `ExpressibleByArgument` protocol | `ExpressibleByArgument` trait               |
+| `CommandGroup`                   | `SubParser[...]`                            |
+| `mutating func run()`            | Separate: `Parser[T].parse()` returns T     |
+| `mutating func validate()`       | `def validate(self) raises` on `Parsable`   |
 
 What I think argmojo can add beyond Swift:
 
-1. `to_command()` exposes the underlying `Command` for builder-level customisation — Swift's `ParsableCommand` is a sealed box with no escape hatch to things like mutually exclusive groups, implications, or custom help formatting.
+1. `to_command()` exposes the underlying `Command` (as reference) for builder-level customisation — Swift's `ParsableCommand` is a sealed box with no escape hatch to things like mutually exclusive groups, implications, or custom help formatting.
 2. `parse_split()` returns both typed struct + `ParseResult` — Swift requires all fields to live in the struct.
 3. Declarative is optional — Swift has no builder alternative; you *must* use the struct-based approach.
 
-**`validate()`**: I'm also thinking about an optional `def validate(self) raises` method on `Declarable` (mirroring Swift's `validate()`). It would complement `to_command()` for post-parse cross-field validation without requiring the builder API.
+**`validate()`**: I'm also thinking about an optional `def validate(self) raises` method on `Parsable` (mirroring Swift's `validate()`). It would complement `to_command()` for post-parse cross-field validation without requiring the builder API.
 
 **A note on naming** — I had to pick names for several structs and traits. Some were genuinely hard. The final names inevitably reflect my personal taste, but I tried to be consistent and self-explanatory. Here's what I chose and why:
 
-1. **`Declaration`**: It's really a declarative command — you call `.parse()` on it, much like `Command`. I wanted to call it `DeclarativeCommand`, but that's too long. `CLI` was another candidate, but `CLI.to_command()` reads oddly. `Declaration` felt right — short, clear, and it tells you this is the declarative counterpart to `Command`.
+1. **`Parser`**: The declarative orchestrator — you call `.parse()` on it, much like `Command`. I originally called it `Declaration`, but that was misleading since it wraps and drives a `Command` internally. `Parser` aligns with clap's `#[derive(Parser)]` and clearly communicates its role: it parses CLI arguments from a struct schema. `CLI` was another candidate, but `CLI.to_command()` reads oddly. `Parser[T]` felt right — short, familiar, and it tells you this is the declarative counterpart to `Command`.
 
-2. **`Declarable`**: This is the trait that user structs conform to. I followed Mojo's `TypeName+able` pattern (`Int`→`Intable`, `String`→`Stringable`, `Declaration`→`Declarable`). I considered `Parsable` (à la Swift's `ParsableCommand`), but parsing is what `Declaration` does, not what the struct does — the struct *declares* CLI structure. `Declaration[T: Declarable]` reads naturally: "a declaration of something declarable." The deeper reason this naming is tricky: unlike Swift or Rust, we need *two* layers of abstraction — a user-defined struct layer and a builder layer. You should always think of the user struct (`Declarable`) and `Declaration` as a pair — one cannot exist without the other.
+2. **`Parsable`**: This is the trait that user structs conform to. It follows Swift's `ParsableCommand` naming and Mojo's `TypeName+able` pattern (`Int`→`Intable`, `String`→`Stringable`, `Parser`→`Parsable`). `Parser[T: Parsable]` reads naturally: "a parser of something parsable." The user struct describes *what* to parse (the schema), and `Parser` knows *how* to parse it. You should always think of the user struct (`Parsable`) and `Parser` as a pair — one cannot exist without the other.
 
 3. **`Positional`**: Swift calls it `@Argument`, but I already have an `Argument` struct in the builder layer that covers *all* argument types. Two different `Argument` types with different meanings would be confusing. `Positional` is unambiguous — it tells you exactly what kind of argument it is.
 
@@ -100,27 +141,27 @@ What I think argmojo can add beyond Swift:
 │  User Code                                                               │
 │                                                                          │
 │  @fieldwise_init                                                         │
-│  struct MyArgs(Declarable):                                                │
+│  struct MyArgs(Parsable):                                                │
 │      var name: Positional[String, help="Name", required=True]            │
 │      var verbose: Flag[short="v", help="Verbose"]                        │
 │      var output: Option[String, long="output", short="o"]                │
 │      def __init__(out self): self = arg_defaults[Self]()                 │
 │                                                                          │
-│  var decl = Declaration[MyArgs]()                                        │
+│  var decl = Parser[MyArgs]()                                             │
 │  var cmd = decl.to_command()                                             │
 │  cmd.mutually_exclusive([...])                                           │
 │  var args = decl.parse()  →  MyArgs (typed struct)                       │
 │                                                                          │
 ├──────────────────────────────────────────────────────────────────────────┤
-│  declaration.mojo  (NEW — ~400-600 lines)                                │
+│  parser.mojo  (NEW — ~400-600 lines)                                     │
 │                                                                          │
-│  Declaration[T].to_command() → Command  (reflect T → builder calls)      │
-│  Declaration[T].parse()      → T        (parse + write-back)             │
-│  Declaration[T].from_result()→ T        (ParseResult → struct)           │
+│  Parser[T].to_command() → Command  (reflect T → builder calls)           │
+│  Parser[T].parse()      → T        (parse + write-back)                  │
+│  Parser[T].from_result()→ T        (ParseResult → struct)                │
 │  arg_defaults[T]()      → T          (default-initialized)               │
 │                                                                          │
 │  Wrapper types: Positional[T, ...], Option[T, ...], Flag[...], Count[...]│
-│  Trait: Declarable                                                         │
+│  Trait: Parsable                                                         │
 │                                                                          │
 ├──────────────────────────────────────────────────────────────────────────┤
 │  argument.mojo + command.mojo + parse_result.mojo  (UNCHANGED)           │
@@ -133,11 +174,22 @@ What I think argmojo can add beyond Swift:
 
 ### Files Changed
 
-| File                           | Change                                           |
-| ------------------------------ | ------------------------------------------------ |
-| `src/argmojo/declaration.mojo` | **New file** — all declaration types and logic   |
-| `src/argmojo/__init__.mojo`    | Add `from .declaration import ...` (conditional) |
-| Everything else                | **Zero changes**                                 |
+| File                        | Change                                      |
+| --------------------------- | ------------------------------------------- |
+| `src/argmojo/parser.mojo`   | **New file** — all parser types and logic   |
+| `src/argmojo/__init__.mojo` | Add `from .parser import ...` (conditional) |
+| Everything else             | **Zero changes**                            |
+
+### Comparison between Builder and Declarative APIs
+
+| Aspect        | Builder API                 | Declarative API                                            |
+| ------------- | --------------------------- | ---------------------------------------------------------- |
+| Command       | `Command`                   | `Parser[MyArgs: Parsable]` (two layers)                    |
+| Argument      | `Argument`                  | `Positional`, `Option`, `Flag`, `Count` (four types)       |
+| Add arguments | `command.add_argument(...)` | 4 types of structs within `MyArgs` (compile-time metadata) |
+| Parse         | `command.parse()`           | `parser.parse()` (returns typed struct)                    |
+| Parse result  | `ParseResult`               | Typed struct `MyArgs` with inner `.value` fields           |
+| Transform     | `Parser.to_command()`       | -                                                          |
 
 ## 4. Detailed API Design
 
@@ -294,13 +346,13 @@ In **hybrid** mode, imports are clean with no name collisions:
 
 ```mojo
 from argmojo import Command, Argument
-from argmojo.declaration import Declaration, Option, Flag, Positional, Declarable
+from argmojo.parser import Parser, Option, Flag, Positional, Parsable
 ```
 
-### 4.2 The `Declarable` Trait
+### 4.2 The `Parsable` Trait
 
 ```mojo
-trait Declarable(Defaultable, Movable):
+trait Parsable(Defaultable, Movable):
     """Marker trait for structs that can be parsed from CLI arguments."""
 
     @staticmethod
@@ -323,7 +375,7 @@ Minimal implementation — you only need to provide `description()`:
 
 ```mojo
 @fieldwise_init
-struct MyArgs(Declarable):
+struct MyArgs(Parsable):
     var input: Positional[String, help="Input file", required=True]
 
     def __init__(out self): self = arg_defaults[Self]()
@@ -335,10 +387,10 @@ struct MyArgs(Declarable):
 
 `version()` and `name()` have default implementations in the trait, so they're optional.
 
-### 4.3 The `Declaration[T]` Orchestrator
+### 4.3 The `Parser[T]` Orchestrator
 
 ```mojo
-struct Declaration[T: Declarable]:
+struct Parser[T: Parsable]:
     """Orchestrates struct-to-command conversion, parsing, and write-back."""
 
     var _command: Command
@@ -350,7 +402,7 @@ struct Declaration[T: Declarable]:
 
     # ── Core methods ──
 
-    def to_command(mut self) raises -> ref Command:
+    def to_command(mut self) raises -> ref [self._command] Command:
         """Build and return the underlying Command.
         Users can modify it with builder methods before parsing."""
         if not self._built:
@@ -387,7 +439,7 @@ struct Declaration[T: Declarable]:
     # NOTE: Capturing closures (unified {mut x}) cannot be passed as def() arguments
     #       due to type mismatch (nonescaping closure ≠ bare def). Non-capturing is sufficient here.
 
-    def configure(mut self, callback: def(mut Command) raises -> None) raises -> ref Self:
+    def configure(mut self, callback: def(mut Command) raises -> None) raises -> ref [self] Self:
         """Apply builder-level customizations via callback."""
         if not self._built:
             self._build()
@@ -473,7 +525,7 @@ struct Declaration[T: Declarable]:
 This initialises all wrapper fields to their defaults (inspired by Swift's default property initialization):
 
 ```mojo
-def arg_defaults[T: Declarable]() -> T:
+def arg_defaults[T: Parsable]() -> T:
     """Create a default-initialized instance of T.
     Wrapper types (Positional, Option, Flag, Count) are initialized to their defaults.
     Bare types use their Defaultable implementation."""
@@ -515,10 +567,10 @@ This generates `.alias_name["out"]().alias_name["dest"]()`.
 ### 5.1 Pure Declarative (Simple Tool)
 
 ```mojo
-from argmojo.declaration import Declaration, Option, Flag, Positional, Count, Declarable, arg_defaults
+from argmojo.parser import Parser, Option, Flag, Positional, Count, Parsable, arg_defaults
 
 @fieldwise_init
-struct Grep(Declarable):
+struct Grep(Parsable):
     """Search for patterns in files."""
 
     var pattern: Positional[String, help="Search pattern", required=True]
@@ -541,7 +593,7 @@ struct Grep(Declarable):
         return "1.0.0"
 
 def main() raises:
-    var args = Declaration[Grep]().parse()
+    var args = Parser[Grep]().parse()
 
     print("Pattern:", args.pattern.value)
     print("Path:", args.path.value)
@@ -557,10 +609,10 @@ def main() raises:
 
 ```mojo
 from argmojo import Command, Argument
-from argmojo.declaration import Declaration, Option, Flag, Positional, Declarable, arg_defaults
+from argmojo.parser import Parser, Option, Flag, Positional, Parsable, arg_defaults
 
 @fieldwise_init
-struct Deploy(Declarable):
+struct Deploy(Parsable):
     var target: Positional[String, help="Deploy target", required=True, choices="staging,prod"]
     var force: Flag[short="f", help="Force deploy without checks"]
     var dry_run: Flag[long="dry-run", help="Simulate without changes"]
@@ -575,9 +627,9 @@ struct Deploy(Declarable):
         return "Deploy application to target environment."
 
 def main() raises:
-    var decl = Declaration[Deploy]()
+    var decl = Parser[Deploy]()
 
-    # Bridge to builder: add constraints that declaration can't express
+    # Bridge to builder: add constraints that the parser can't express
     var cmd = decl.to_command()
     cmd.mutually_exclusive(["force", "dry-run"])
     cmd.implies("force", "tag")       # force requires a tag
@@ -596,10 +648,10 @@ def main() raises:
 
 ```mojo
 from argmojo import Command, Argument
-from argmojo.declaration import Declaration, Positional, Option, Flag, Declarable, arg_defaults
+from argmojo.parser import Parser, Positional, Option, Flag, Parsable, arg_defaults
 
 @fieldwise_init
-struct Convert(Declarable):
+struct Convert(Parsable):
     var input: Positional[String, help="Input file", required=True]
     var output: Option[String, long="output", short="o", help="Output file"]
 
@@ -610,7 +662,7 @@ struct Convert(Declarable):
         return "File format converter."
 
 def main() raises:
-    var decl = Declaration[Convert]()
+    var decl = Parser[Convert]()
 
     # Add extra builder-only arguments via to_command()
     var cmd = decl.to_command()
@@ -641,10 +693,10 @@ def main() raises:
 ### 5.4 Subcommands with Declarative
 
 ```mojo
-from argmojo.declaration import Declaration, SubDeclaration, Option, Flag, Positional, Declarable, arg_defaults
+from argmojo.parser import Parser, SubParser, Option, Flag, Positional, Parsable, arg_defaults
 
 @fieldwise_init
-struct Clone(Declarable):
+struct Clone(Parsable):
     var url: Positional[String, help="Repository URL", required=True]
     var depth: Option[Int, long="depth", help="Clone depth", default="0"]
     var branch: Option[String, short="b", long="branch", help="Branch to clone"]
@@ -660,7 +712,7 @@ struct Clone(Declarable):
         return "clone"
 
 @fieldwise_init
-struct Push(Declarable):
+struct Push(Parsable):
     var remote: Positional[String, help="Remote name", default="origin"]
     var force: Flag[short="f", help="Force push"]
     var tags: Flag[long="tags", help="Push all tags"]
@@ -676,8 +728,8 @@ struct Push(Declarable):
         return "push"
 
 def main() raises:
-    # SubDeclaration registers multiple Declarable types as subcommands
-    var result = SubDeclaration["mgit", "A mini git tool", Clone, Push]().parse()
+    # SubParser registers multiple Parsable types as subcommands
+    var result = SubParser["mgit", "A mini git tool", Clone, Push]().parse()
 
     if result.subcommand == "clone":
         var args = result.get[Clone]()
@@ -696,7 +748,7 @@ def main() raises:
 **What I'm adding**: `to_command()` returns a mutable reference to the underlying `Command` object, so you can do arbitrary builder modifications before parsing:
 
 ```mojo
-var decl = Declaration[MyArgs]()
+var decl = Parser[MyArgs]()
 var cmd = decl.to_command()
 cmd.mutually_exclusive(["json", "yaml"])
 cmd.required_together(["username", "password"])
@@ -728,7 +780,7 @@ to_command() + new arguments        →  parse_split()  →  (T, ParseResult) (p
 **`configure()` with non-capturing callbacks**: I've verified in Mojo 0.26.2 that `configure()` works with non-capturing callbacks (nested functions that don't capture external state). Since `configure()` callbacks only operate on the `mut Command` parameter, capturing is unnecessary:
 
 ```mojo
-var args = Declaration[MyArgs]()
+var args = Parser[MyArgs]()
     .configure(def(mut cmd) raises: cmd.mutually_exclusive([...]))
     .configure(def(mut cmd) raises: cmd.implies("a", "b"))
     .parse()
@@ -778,6 +830,122 @@ The dual-return enables a practical workflow:
 1. Start with pure declarative
 2. Need one advanced option? Add it via `to_command()` + `parse_split()`
 3. No need to convert the struct field (or add a new nested type)
+
+### 6.3 Innovation #3: Compile-Time Schema Validation
+
+**The problem**: In every runtime CLI library, schema errors (duplicate short flags, invalid short flag length, positional-after-optional ordering) only surface when you run the program — or worse, when a user triggers the specific code path.
+
+**What I'm adding**: Since all wrapper metadata lives in compile-time parameters (`StringLiteral`, `Bool`, `Int`), the declarative layer can validate the **entire schema at compile time** using `comptime assert`. Your program won't even compile if the schema is invalid.
+
+Concrete checks in `Parser[T]._build()`:
+
+```mojo
+@parameter
+fn _validate_schema[T: Parsable]():
+    # 1. Duplicate short flags
+    #    Nested comptime loop over all field pairs; extract each wrapper's
+    #    `short` parameter and assert no two are equal.
+
+    # 2. Invalid short flag length
+    #    comptime assert len(short) == 1 for every field that declares one.
+
+    # 3. Positional ordering
+    #    Track a "seen_non_positional" flag. If a Positional appears after
+    #    an Option/Flag, assert failure — positionals must come first.
+
+    # 4. Type-metadata mismatch
+    #    e.g. `choices` on a Flag has no meaning; `append` on a Positional
+    #    without `remainder` is contradictory. comptime assert catches these.
+
+    # 5. choices vs default consistency
+    #    If `choices="json,yaml,csv"` and `default="xml"`, the default is
+    #    not in the choices set — comptime assert failure.
+    ...
+```
+
+**Why this matters**: Neither Swift Argument Parser, Rust clap, nor mojopt can do this. Swift's property wrappers are validated at runtime. Rust's proc macros catch *some* errors but not all (e.g. duplicate short flags pass the proc macro and fail at runtime). Mojo's parametric type system uniquely enables full schema validation at compile time.
+
+**Zero-cost guarantee**: All checks use `comptime assert` — they're erased from the binary. No performance cost, no code bloat.
+
+### 6.4 Innovation #4: Declarative `depends_on` / `conflicts_with`
+
+**The problem**: Cross-field constraints like "username requires password" or "json conflicts with yaml" currently require the imperative `to_command()` escape hatch:
+
+```mojo
+var decl = Parser[MyArgs]()
+var cmd = decl.to_command()
+cmd.required_together(["username", "password"])
+cmd.mutually_exclusive(["json", "yaml"])
+var args = decl.parse()
+```
+
+This works, but it breaks the "everything in the struct" philosophy and requires string-keyed names (typo-prone).
+
+**What I'm adding**: `depends_on` and `conflicts_with` as StringLiteral parameters on wrapper types:
+
+```mojo
+@value
+struct MyArgs(Parsable):
+    var username: Option[String, long="username", short="u",
+                         depends_on="password"]
+    var password: Option[String, long="password", short="p",
+                         depends_on="username"]
+    var json: Flag[long="json", conflicts_with="yaml"]
+    var yaml: Flag[long="yaml", conflicts_with="json"]
+```
+
+**Translation in `_build()`**:
+
+| Declarative parameter        | Builder call generated                                   |
+| ---------------------------- | -------------------------------------------------------- |
+| `depends_on="password"`      | `cmd.required_if("password", "username")`                |
+| `conflicts_with="json,yaml"` | `cmd.mutually_exclusive(["this_field", "json", "yaml"])` |
+
+**Compile-time name validation**: Since `depends_on` and `conflicts_with` are `StringLiteral` parameters, and all field names are known at compile time via `struct_field_names`, I can verify at compile time that every referenced name actually exists in the struct:
+
+```mojo
+# In _build(), at comptime:
+# depends_on="password" → verify "password" is in struct_field_names[T]()
+# If not → comptime assert failure with a clear error message
+```
+
+This catches typos like `depends_on="passwrod"` at compile time — something no other CLI library can do.
+
+**Symmetry note**: `depends_on` is symmetric by convention (if A depends on B, B depends on A). A single `depends_on="password"` on `username` generates `required_together(["username", "password"])`. If both sides declare it, deduplication in `_build()` prevents double-registration.
+
+### 6.5 Innovation #5: Compile-Time Derived Completions from `choices`
+
+**The problem**: Shell completions for argument values usually require explicit registration — you declare choices in one place and completions in another, duplicating information. In the builder API:
+
+```mojo
+var arg = Argument("format", help="Output format")
+    .choice["json"]()
+    .choice["yaml"]()
+    .choice["csv"]()
+# Choices are registered, but completions only work if generate_completion is called
+```
+
+**What I'm adding**: Since `choices` is a compile-time `StringLiteral` parameter, the declarative layer can **automatically derive** shell completions from choices — no explicit completion registration needed:
+
+```mojo
+@value
+struct MyArgs(Parsable):
+    var format: Option[String, long="format", short="f",
+                       choices="json,yaml,csv"]
+    # ^ completions for --format automatically include "json", "yaml", "csv"
+```
+
+**How it works**: During `_build()`, when a field has a non-empty `choices` parameter, the generated completion script automatically includes those values as completions for that argument's value. The builder's `generate_completion["fish"]()` / `generate_completion["zsh"]()` / `generate_completion["bash"]()` already reads `_choice_values` — the declarative layer simply ensures they're populated.
+
+**Compile-time generation**: Since all choices are `StringLiteral` values known at compile time, the entire completion script could be generated as a compile-time constant:
+
+```mojo
+# Hypothetical: completion script as a compile-time StringLiteral
+alias fish_completion = Parser[MyArgs].completion_script["fish"]()
+# This is a StringLiteral — zero runtime cost to produce
+```
+
+**Practical value**: For tools with many `choices`-based arguments (e.g. `--format`, `--color`, `--log-level`), this eliminates the boilerplate of manually wiring completions. The struct declaration is the single source of truth for both validation and completions.
 
 ## 7. Internal Implementation Details
 
@@ -838,15 +1006,15 @@ When populating your struct from `ParseResult`, I dispatch based on the field ty
 
 Missing/optional values: if `result.has(name)` returns `False` and the field isn't required, the default value stays.
 
-### 7.3 SubDeclaration Design
+### 7.3 SubParser Design
 
-`SubDeclaration` is parameterized on variadic types:
+`SubParser` is parameterized on variadic types:
 
 ```mojo
-struct SubDeclaration[
+struct SubParser[
     app_name: StringLiteral,
     app_description: StringLiteral,
-    *Ts: Declarable,
+    *Ts: Parsable,
 ]:
     var _command: Command
 
@@ -857,34 +1025,34 @@ struct SubDeclaration[
         # For each type in Ts, build a sub-Command and register via add_subcommand
         @parameter
         for i in range(len(Ts)):
-            var sub_cmd = Declaration[Ts[i]]().to_command()
+            var sub_cmd = Parser[Ts[i]]().to_command()
             self._command.add_subcommand(sub_cmd)
         return SubResult[*Ts](self._command.parse())
 ```
 
 `SubResult` provides a `get[T]()` method that does the write-back for the matched subcommand.
 
-**Note**: Variadic type parameters are still evolving in Mojo. If `*Ts` isn't stable yet, I'll fall back to explicit overloads for 1–8 subcommand types (like `SubDeclaration2[T1, T2]`, `SubDeclaration3[T1, T2, T3]`, etc.).
+**Note**: Variadic type parameters are still evolving in Mojo. If `*Ts` isn't stable yet, I'll fall back to explicit overloads for 1–8 subcommand types (like `SubParser2[T1, T2]`, `SubParser3[T1, T2, T3]`, etc.).
 
 ## 8. What Stays in Builder-Only Territory
 
 Some features are inherently imperative and don't fit neatly into struct declarations. I'm keeping these builder-only (accessible via `to_command()`):
 
-| Feature                    | Reason                                 |
-| -------------------------- | -------------------------------------- |
-| `mutually_exclusive()`     | Cross-field constraint on N args       |
-| `required_together()`      | Cross-field constraint on N args       |
-| `one_required()`           | Cross-field constraint on N args       |
-| `required_if()`            | Cross-field conditional                |
-| `implies()`                | Cross-field chain with cycle detection |
-| `confirmation_option()`    | Adds a synthetic `--yes` arg           |
-| `help_on_no_arguments()`   | Command-level behavior                 |
-| `add_tip()`                | Help formatting                        |
-| Color config               | Command-level presentation             |
-| Completions config         | Command-level behavior                 |
-| Response file config       | Command-level behavior                 |
-| `allow_negative_numbers()` | Parser behavior flag                   |
-| `add_parent()`             | Cross-command inheritance              |
+| Feature                    | Reason                                                             |
+| -------------------------- | ------------------------------------------------------------------ |
+| `mutually_exclusive()`     | Partially declarative via `conflicts_with` (§6.4); builder for N>2 |
+| `required_together()`      | Partially declarative via `depends_on` (§6.4); builder for N>2     |
+| `one_required()`           | Cross-field constraint on N args                                   |
+| `required_if()`            | Cross-field conditional                                            |
+| `implies()`                | Cross-field chain with cycle detection                             |
+| `confirmation_option()`    | Adds a synthetic `--yes` arg                                       |
+| `help_on_no_arguments()`   | Command-level behavior                                             |
+| `add_tip()`                | Help formatting                                                    |
+| Color config               | Command-level presentation                                         |
+| Completions config         | Command-level behavior                                             |
+| Response file config       | Command-level behavior                                             |
+| `allow_negative_numbers()` | Parser behavior flag                                               |
+| `add_parent()`             | Cross-command inheritance                                          |
 
 I think this is the right call — these features describe *relationships between* arguments or *command-level* behavior, not individual argument metadata. Trying to force them into struct field attributes would create a confusing, non-composable API.
 
@@ -894,7 +1062,7 @@ I think this is the right call — these features describe *relationships betwee
 | ------------------------------- | ------------------------------- | --------------------------------------------- |
 | Language mechanism              | Property wrappers (`@Option`)   | Parametric wrapper types (`Option[T]`)        |
 | Wrapper vocabulary              | `@Argument`, `@Option`, `@Flag` | `Positional[T]`, `Option[T]`, `Flag`, `Count` |
-| Protocol / trait                | `ParsableCommand`               | `Declarable`                                  |
+| Protocol / trait                | `ParsableCommand`               | `Parsable`                                    |
 | Type-safe value access          | Direct field access             | `args.field.value`                            |
 | Flag as Bool                    | Direct Bool                     | `Flag.__bool__()` implicit conversion         |
 | Count flag                      | ✗ not built-in                  | ✓ `Count[short="v", max=3]`                   |
@@ -906,37 +1074,55 @@ I think this is the right call — these features describe *relationships betwee
 | Interactive prompt              | ✗ not supported                 | ✓ `prompt=True` in wrapper                    |
 | Password / masked input         | ✗ not supported                 | ✓ `password=True` in wrapper                  |
 | Shell completions               | ✓ built-in                      | ✓ inherited from builder                      |
-| Subcommands                     | ✓ nested `ParsableCommand`      | ✓ `SubDeclaration[...]` variadic types        |
+| Compile-time schema validation  | ✗ validated at runtime          | ✓ `comptime assert` catches errors (§6.3)     |
+| Declarative field constraints   | ✗ not in struct schema          | ✓ `depends_on`/`conflicts_with` (§6.4)        |
+| Auto-derived completions        | ✗ manual registration           | ✓ from `choices` at compile time (§6.5)       |
+| Subcommands                     | ✓ nested `ParsableCommand`      | ✓ `SubParser[...]` variadic types             |
 | CJK-aware help                  | ✗ not supported                 | ✓ inherited from builder                      |
 | Auto-naming (underscore→hyphen) | ✓ camelCase→kebab-case          | ✓ snake_case→kebab-case                       |
 
 ## 10. Implementation Roadmap
 
-### Phase 1: Core Wrapper Types + Declaration
+### Phase 1: Core Wrapper Types + Parser
 
 - [ ] Implement `Positional`, `Option`, `Flag`, `Count` wrapper structs
-- [ ] Implement `Declarable` trait
-- [ ] Implement `arg_defaults[T]()` 
-- [ ] Implement `Declaration[T]._build()` — reflection to Command builder calls
-- [ ] Implement `Declaration[T]._from_result()` — ParseResult to struct write-back
-- [ ] Implement `Declaration[T].parse()` — end-to-end
+- [ ] Implement `Parsable` trait
+- [ ] Implement `arg_defaults[T]()`
+- [ ] Implement `Parser[T]._build()` — reflection to Command builder calls
+- [ ] Implement `Parser[T]._from_result()` — ParseResult to struct write-back
+- [ ] Implement `Parser[T].parse()` — end-to-end
 - [ ] Auto-naming convention (underscore → hyphen)
 
 ### Phase 2: Hybrid Features
 
-- [ ] Implement `Declaration[T].to_command()` escape hatch
-- [ ] Implement `Declaration[T].parse_split()` dual return
-- [ ] Test: declaration + `mutually_exclusive()` via to_command()
-- [ ] Test: declaration + extra builder args via parse_split
-- [ ] Implement `Declaration[T].configure()` callback (non-capturing, works in 0.26.2)
+- [ ] Implement `Parser[T].to_command()` escape hatch
+- [ ] Implement `Parser[T].parse_split()` dual return
+- [ ] Test: parser + `mutually_exclusive()` via to_command()
+- [ ] Test: parser + extra builder args via parse_split
+- [ ] Implement `Parser[T].configure()` callback (non-capturing, works in 0.26.2)
 
 ### Phase 3: Subcommands
 
-- [ ] Implement `SubDeclaration[..., *Ts]` or `SubDeclaration2/3/...` overloads
+- [ ] Implement `SubParser[..., *Ts]` or `SubParser2/3/...` overloads
 - [ ] Implement `SubResult.get[T]()` typed subcommand access
-- [ ] Test: nested subcommands with declaration
+- [ ] Test: nested subcommands with parser
 
-### Phase 4: Polish
+### Phase 4: Further enhancements
+
+- [ ] Implement `_validate_schema[T]()` compile-time checks (§6.3)
+  - [ ] Duplicate short flag detection
+  - [ ] Invalid short flag length
+  - [ ] Positional ordering enforcement
+  - [ ] Type-metadata mismatch detection
+  - [ ] Choices vs default consistency
+- [ ] Add `depends_on`/`conflicts_with` parameters to `Option` and `Flag` (§6.4)
+  - [ ] Compile-time validation of referenced field names
+  - [ ] Translation to builder `required_together()`/`mutually_exclusive()` in `_build()`
+- [ ] Auto-derive completions from `choices` parameters (§6.5)
+  - [ ] Ensure choices flow to `generate_completion` output
+  - [ ] Explore compile-time completion script generation
+
+### Phase 5: Polish
 
 - [ ] Comprehensive test suite (parallel to existing builder tests)
 - [ ] Examples: simple, hybrid, subcommands

--- a/src/argmojo/__init__.mojo
+++ b/src/argmojo/__init__.mojo
@@ -1,5 +1,11 @@
 """ArgMojo: A command-line argument parser library for Mojo."""
 
+# Builder API
 from .argument import Argument, Arg
 from .command import Command
 from .parse_result import ParseResult
+
+# Declarative API
+from .parsable import Parsable, arg_defaults
+from .argument_wrappers import Option, Flag, Positional, Count
+from .parser import Parser

--- a/src/argmojo/argument_wrappers.mojo
+++ b/src/argmojo/argument_wrappers.mojo
@@ -1,0 +1,377 @@
+"""Declarative wrapper types for CLI arguments.
+
+Four wrapper structs that encode argument metadata as compile-time
+parameters.  Each wraps a runtime ``value`` field and carries all
+configuration (long name, short name, help text, choices, ...) in its
+type signature so that ``Parser[T]._build()`` can translate them
+to builder calls without any runtime metadata tables.
+
+- ``Option[T, ...]``    -- named option (``--output file.txt``, ``-o val``)
+- ``Flag[...]``         -- boolean flag (``--verbose``, ``-v``)
+- ``Positional[T, ...]``-- positional argument (matched by position)
+- ``Count[...]``        -- count flag (``-vvv`` -> 3)
+"""
+
+
+# =======================================================================
+# Option
+# =======================================================================
+
+
+struct Option[
+    T: Defaultable & Copyable & Movable,
+    *,
+    # -- Naming --
+    long: StringLiteral = "",
+    short: StringLiteral = "",
+    help: StringLiteral = "",
+    alias_name: StringLiteral = "",
+    # -- Argument type --
+    negatable: Bool = False,
+    # -- Value defaults & validation --
+    default: StringLiteral = "",
+    required: Bool = False,
+    choices: StringLiteral = "",
+    range_min: Int = 0,
+    range_max: Int = 0,
+    has_range: Bool = False,
+    clamp: Bool = False,
+    # -- Collection modes --
+    append: Bool = False,
+    delimiter: StringLiteral = "",
+    nargs: Int = 0,
+    map_option: Bool = False,
+    # -- Parsing behaviour --
+    require_equals: Bool = False,
+    allow_hyphen: Bool = False,
+    persistent: Bool = False,
+    # -- Display & help --
+    value_name: StringLiteral = "",
+    hidden: Bool = False,
+    deprecated: StringLiteral = "",
+    group: StringLiteral = "",
+    # -- Interactive prompting --
+    prompt: Bool = False,
+    prompt_text: StringLiteral = "",
+    password: Bool = False,
+](Copyable, Movable, Defaultable):
+    """A named option that takes a value.
+
+    ``T`` is the value type stored at runtime (``String``, ``Int``,
+    ``List[String]``, etc.).  All other parameters are keyword-only
+    compile-time metadata consumed by ``Parser[T]._build()``.
+
+    Parameters:
+        T: The value type stored at runtime.
+        long: Long option name (e.g. ``"output"`` for ``--output``). Empty = auto from field name.
+        short: Short option character (e.g. ``"o"`` for ``-o``).
+        help: Help text shown in ``--help`` output.
+        alias_name: Comma-separated alias long names.
+        negatable: If True, generate ``--x`` / ``--no-x`` pair (T must be Bool).
+        default: Default value as a string literal.
+        required: If True, the option must be provided.
+        choices: Comma-separated allowed values.
+        range_min: Minimum numeric value (requires ``has_range=True``).
+        range_max: Maximum numeric value (requires ``has_range=True``).
+        has_range: Enable range validation.
+        clamp: Clamp to range instead of raising an error.
+        append: Collect repeated occurrences into a list.
+        delimiter: Split a single value by this delimiter.
+        nargs: Number of values consumed (0 = single).
+        map_option: Parse as ``key=value`` map entries.
+        require_equals: Require ``--key=value`` syntax.
+        allow_hyphen: Allow hyphen-prefixed values.
+        persistent: Inherited by subcommands.
+        value_name: Display name in help (e.g. ``FILE``).
+        hidden: Hide from help output.
+        deprecated: Deprecation warning message.
+        group: Help group heading.
+        prompt: Interactively prompt if missing.
+        prompt_text: Custom prompt message.
+        password: Mask input when prompting.
+
+    Examples:
+
+    ```mojo
+    from argmojo.argument_wrappers import Option
+
+    # Simple string option: --output / -o
+    var out: Option[String, long="output", short="o", help="Output path"]
+
+    # Required int option with range validation
+    var port: Option[Int, long="port", required=True,
+                     has_range=True, range_min=1, range_max=65535]
+
+    # List-collecting option: --tag x --tag y -> ["x", "y"]
+    var tags: Option[List[String], long="tag", short="t", append=True]
+
+    # Choices with default
+    var fmt: Option[String, long="format", short="f",
+                    choices="json,yaml,csv", default="json"]
+    ```
+    """
+
+    var value: Self.T
+    """The runtime value populated by parsing."""
+
+    fn __init__(out self):
+        """Default-initialise with ``T()``."""
+        self.value = Self.T()
+
+    fn __init__(out self, *, copy: Self):
+        """Copy from an existing instance.
+
+        Args:
+            copy: The Option to copy from.
+        """
+        self.value = copy.value.copy()
+
+    fn __init__(out self, *, deinit take: Self):
+        """Move from an existing instance.
+
+        Args:
+            take: The Option to move from.
+        """
+        self.value = take.value^
+
+
+# =======================================================================
+# Flag
+# =======================================================================
+
+
+struct Flag[
+    *,
+    # -- Naming --
+    long: StringLiteral = "",
+    short: StringLiteral = "",
+    help: StringLiteral = "",
+    # -- Argument type --
+    negatable: Bool = False,
+    # -- Parsing behaviour --
+    persistent: Bool = False,
+    # -- Display & help --
+    hidden: Bool = False,
+    deprecated: StringLiteral = "",
+    group: StringLiteral = "",
+](Copyable, Movable, Defaultable):
+    """A boolean flag (no value; presence means ``True``).
+
+    Provides ``__bool__`` so you can write ``if args.verbose:``
+    instead of ``if args.verbose.value:``.
+
+    Parameters:
+        long: Long flag name. Empty = auto from field name.
+        short: Short flag character.
+        help: Help text shown in ``--help`` output.
+        negatable: If True, generate ``--flag`` / ``--no-flag`` pair.
+        persistent: Inherited by subcommands.
+        hidden: Hide from help output.
+        deprecated: Deprecation warning message.
+        group: Help group heading.
+
+    Examples:
+
+    ```mojo
+    from argmojo.argument_wrappers import Flag
+
+    # Simple flag: --verbose / -v
+    var verbose: Flag[short="v", help="Enable verbose output"]
+
+    # Negatable flag: --color / --no-color
+    var color: Flag[long="color", negatable=True]
+    ```
+    """
+
+    var value: Bool
+    """The runtime value populated by parsing."""
+
+    fn __init__(out self):
+        """Default-initialise to ``False``."""
+        self.value = False
+
+    fn __init__(out self, val: Bool):
+        """Initialise with an explicit value.
+
+        Args:
+            val: The initial boolean value.
+        """
+        self.value = val
+
+    fn __init__(out self, *, copy: Self):
+        """Copy from an existing instance.
+
+        Args:
+            copy: The Flag to copy from.
+        """
+        self.value = copy.value
+
+    fn __init__(out self, *, deinit take: Self):
+        """Move from an existing instance.
+
+        Args:
+            take: The Flag to move from.
+        """
+        self.value = take.value
+
+    fn __bool__(self) -> Bool:
+        """Implicit conversion to ``Bool`` for convenience.
+
+        Allows ``if args.verbose:`` rather than ``if args.verbose.value:``.
+
+        Returns:
+            The flag value.
+        """
+        return self.value
+
+
+# =======================================================================
+# Positional
+# =======================================================================
+
+
+struct Positional[
+    T: Defaultable & Copyable & Movable,
+    *,
+    help: StringLiteral = "",
+    # -- Argument type --
+    remainder: Bool = False,
+    # -- Value defaults & validation --
+    default: StringLiteral = "",
+    required: Bool = False,
+    choices: StringLiteral = "",
+    # -- Display & help --
+    value_name: StringLiteral = "",
+    group: StringLiteral = "",
+](Copyable, Movable, Defaultable):
+    """A positional argument (matched by order, not by name).
+
+    Positionals don't have ``--long`` or ``-short`` names.  Use
+    ``remainder=True`` on the last positional to consume all remaining
+    tokens (like ``--`` in many CLI tools).
+
+    Parameters:
+        T: The value type stored at runtime.
+        help: Help text shown in ``--help`` output.
+        remainder: Consume all remaining tokens.
+        default: Default value as a string literal.
+        required: If True, the positional must be provided.
+        choices: Comma-separated allowed values.
+        value_name: Display name in help.
+        group: Help group heading.
+
+    Examples:
+
+    ```mojo
+    from argmojo.argument_wrappers import Positional
+
+    # Required positional
+    var pattern: Positional[String, help="Search pattern", required=True]
+
+    # Optional positional with default
+    var path: Positional[String, help="File or directory", default="."]
+
+    # Remainder: consumes everything after the named positionals
+    var files: Positional[List[String], help="Input files", remainder=True]
+    ```
+    """
+
+    var value: Self.T
+    """The runtime value populated by parsing."""
+
+    fn __init__(out self):
+        """Default-initialise with ``T()``."""
+        self.value = Self.T()
+
+    fn __init__(out self, *, copy: Self):
+        """Copy from an existing instance.
+
+        Args:
+            copy: The Positional to copy from.
+        """
+        self.value = copy.value.copy()
+
+    fn __init__(out self, *, deinit take: Self):
+        """Move from an existing instance.
+
+        Args:
+            take: The Positional to move from.
+        """
+        self.value = take.value^
+
+
+# =======================================================================
+# Count
+# =======================================================================
+
+
+struct Count[
+    *,
+    # -- Naming --
+    long: StringLiteral = "",
+    short: StringLiteral = "",
+    help: StringLiteral = "",
+    # -- Argument type --
+    max: Int = 0,
+    # -- Parsing behaviour --
+    persistent: Bool = False,
+    # -- Display & help --
+    hidden: Bool = False,
+    group: StringLiteral = "",
+](Copyable, Movable, Defaultable):
+    """A count flag (each occurrence increments the value).
+
+    Commonly used for verbosity: ``-v`` -> 1, ``-vv`` -> 2, ``-vvv`` -> 3.
+    Set ``max`` to cap the count (0 means no ceiling).
+
+    Parameters:
+        long: Long flag name. Empty = auto from field name.
+        short: Short flag character.
+        help: Help text shown in ``--help`` output.
+        persistent: Inherited by subcommands.
+        hidden: Hide from help output.
+        group: Help group heading.
+
+    Examples:
+
+    ```mojo
+    from argmojo.argument_wrappers import Count
+
+    # Verbosity counter: -v, -vv, -vvv (capped at 3)
+    var verbose: Count[short="v", help="Increase verbosity", max=3]
+
+    # Uncapped counter
+    var debug: Count[long="debug", short="d", help="Debug level"]
+    ```
+    """
+
+    var value: Int
+    """The runtime value populated by parsing."""
+
+    fn __init__(out self):
+        """Default-initialise to ``0``."""
+        self.value = 0
+
+    fn __init__(out self, val: Int):
+        """Initialise with an explicit value.
+
+        Args:
+            val: The initial count value.
+        """
+        self.value = val
+
+    fn __init__(out self, *, copy: Self):
+        """Copy from an existing instance.
+
+        Args:
+            copy: The Count to copy from.
+        """
+        self.value = copy.value
+
+    fn __init__(out self, *, deinit take: Self):
+        """Move from an existing instance.
+
+        Args:
+            take: The Count to move from.
+        """
+        self.value = take.value

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -138,7 +138,7 @@ def _read_response_file(
 struct Command(Copyable, Movable, Writable):
     """Defines a CLI command prototype with its arguments and handles parsing.
 
-    Example:
+    Examples:
 
     ```mojo
     from argmojo import Command, Argument
@@ -455,7 +455,7 @@ struct Command(Copyable, Movable, Writable):
         Args:
             argument: The Argument to register.
 
-        Example:
+        Examples:
 
         ```mojo
         from argmojo import Command, Argument
@@ -557,7 +557,7 @@ struct Command(Copyable, Movable, Writable):
             Error if a persistent argument on this command shares a ``long_name``
             or ``short_name`` with any local argument on ``sub``.
 
-        Example:
+        Examples:
 
         ```mojo
         from argmojo import Command, Argument
@@ -661,7 +661,7 @@ struct Command(Copyable, Movable, Writable):
         Raises:
             Error if any inherited argument violates registration guards.
 
-        Example:
+        Examples:
 
         ```mojo
         from argmojo import Command, Argument
@@ -732,7 +732,7 @@ struct Command(Copyable, Movable, Writable):
         Raises:
             Error: If any name in the group is not a registered argument.
 
-        Example:
+        Examples:
 
         ```mojo
         from argmojo import Command, Argument
@@ -782,7 +782,7 @@ struct Command(Copyable, Movable, Writable):
         Raises:
             Error: If any name in the group is not a registered argument.
 
-        Example:
+        Examples:
 
         ```mojo
         from argmojo import Command, Argument
@@ -832,7 +832,7 @@ struct Command(Copyable, Movable, Writable):
         Raises:
             Error: If any name in the group is not a registered argument.
 
-        Example:
+        Examples:
 
         ```mojo
         from argmojo import Command, Argument
@@ -883,7 +883,7 @@ struct Command(Copyable, Movable, Writable):
         Raises:
             Error: If either name is not a registered argument.
 
-        Example:
+        Examples:
 
         ```mojo
         from argmojo import Command, Argument
@@ -936,7 +936,7 @@ struct Command(Copyable, Movable, Writable):
             either argument is unknown, or if the implied argument is
             not a flag or count.
 
-        Example:
+        Examples:
 
         ```mojo
         from argmojo import Command, Argument
@@ -1025,7 +1025,7 @@ struct Command(Copyable, Movable, Writable):
         Args:
             names: The list of alias strings.
 
-        Example:
+        Examples:
 
         ```mojo
         from argmojo import Command
@@ -1046,7 +1046,7 @@ struct Command(Copyable, Movable, Writable):
         dispatchable by exact name or alias.  Useful for internal,
         experimental, or deprecated subcommands.
 
-        Example:
+        Examples:
 
         ```mojo
         from argmojo import Command
@@ -1072,7 +1072,7 @@ struct Command(Copyable, Movable, Writable):
         value (e.g. a search pattern or entity name).  After disabling, use
         ``app <sub> --help`` directly.
 
-        Example:
+        Examples:
 
         ```mojo
         from argmojo import Command
@@ -1104,7 +1104,7 @@ struct Command(Copyable, Movable, Writable):
         that exactly matches a registered subcommand name is dispatched;
         any other token falls through to the positional list.
 
-        Example:
+        Examples:
 
         ```mojo
         from argmojo import Command, Argument
@@ -1131,7 +1131,7 @@ struct Command(Copyable, Movable, Writable):
             Error if any registered argument has ``.prompt()`` enabled,
             since prompting is unreachable when help is shown on no args.
 
-        Example:
+        Examples:
 
         ```mojo
         from argmojo import Command, Argument
@@ -1163,7 +1163,7 @@ struct Command(Copyable, Movable, Writable):
         option (e.g., ``-3`` for ``--triple``) and still need negative-number
         literals to be treated as positionals.
 
-        Example:
+        Examples:
 
         ```mojo
         from argmojo import Command, Argument
@@ -1204,7 +1204,7 @@ struct Command(Copyable, Movable, Writable):
             prefix: The prefix character(s) that introduce a response
                 file (default ``"@"``).
 
-        Example:
+        Examples:
 
         ```mojo
         from argmojo import Command
@@ -1239,7 +1239,7 @@ struct Command(Copyable, Movable, Writable):
         Call this method to disable that correction entirely — useful
         when strict parsing is preferred.
 
-        Example:
+        Examples:
 
         ```mojo
         from argmojo import Command
@@ -1261,7 +1261,7 @@ struct Command(Copyable, Movable, Writable):
         Call this method to disable that behaviour — useful when strict
         error messages are preferred.
 
-        Example:
+        Examples:
 
         ```mojo
         from argmojo import Command
@@ -1289,7 +1289,7 @@ struct Command(Copyable, Movable, Writable):
         Raises:
             Error if a ``--yes`` / ``-y`` argument is already registered.
 
-        Example:
+        Examples:
 
         ```mojo
         from argmojo import Command, Argument
@@ -1336,7 +1336,7 @@ struct Command(Copyable, Movable, Writable):
         Raises:
             Error if a ``--yes`` / ``-y`` argument is already registered.
 
-        Example:
+        Examples:
 
         ```mojo
         from argmojo import Command, Argument
@@ -1379,7 +1379,7 @@ struct Command(Copyable, Movable, Writable):
             text: The custom usage text (e.g. ``"myapp [-v | --version]
                 [-C <path>] <command> [<args>]"``).
 
-        Example:
+        Examples:
 
         ```mojo
         from argmojo import Command
@@ -1402,7 +1402,7 @@ struct Command(Copyable, Movable, Writable):
         Args:
             tip: The tip text to display.
 
-        Example:
+        Examples:
 
         ```mojo
         from argmojo import Command, Argument
@@ -1427,7 +1427,7 @@ struct Command(Copyable, Movable, Writable):
         Parameters:
             name: The colour name.
 
-        Example:
+        Examples:
 
         ```mojo
         from argmojo import Command
@@ -1447,7 +1447,7 @@ struct Command(Copyable, Movable, Writable):
         Parameters:
             name: The colour name.
 
-        Example:
+        Examples:
 
         ```mojo
         from argmojo import Command
@@ -1467,7 +1467,7 @@ struct Command(Copyable, Movable, Writable):
         Parameters:
             name: The colour name.
 
-        Example:
+        Examples:
 
         ```mojo
         from argmojo import Command
@@ -1487,7 +1487,7 @@ struct Command(Copyable, Movable, Writable):
         Parameters:
             name: The colour name.
 
-        Example:
+        Examples:
 
         ```mojo
         from argmojo import Command
@@ -1509,7 +1509,7 @@ struct Command(Copyable, Movable, Writable):
         The ``generate_completion()`` method is still available for
         programmatic use — only the automatic trigger is removed.
 
-        Example:
+        Examples:
 
         ```mojo
         from argmojo import Command
@@ -1538,7 +1538,7 @@ struct Command(Copyable, Movable, Writable):
         Args:
             name: The new trigger name (without ``--`` prefix).
 
-        Example:
+        Examples:
 
         ```mojo
         from argmojo import Command
@@ -4239,7 +4239,7 @@ struct Command(Copyable, Movable, Writable):
         Returns:
             The completion script as a string.
 
-        Example:
+        Examples:
 
         ```mojo
         from argmojo import Command

--- a/src/argmojo/parsable.mojo
+++ b/src/argmojo/parsable.mojo
@@ -1,0 +1,78 @@
+"""Declares the Parsable trait and the arg_defaults helper."""
+
+
+trait Parsable(Defaultable, Movable):
+    """Marker trait for structs that can be parsed from CLI arguments.
+
+    User structs conforming to this trait can be used with
+    ``Parser[T]`` for fully typed, declarative CLI parsing.
+
+    Examples:
+
+    ```mojo
+    from argmojo.parsable import Parsable, arg_defaults
+    from argmojo.argument_wrappers import Option, Flag
+
+    struct MyArgs(Parsable):
+        var output: Option[String, long="output", short="o",
+                           help="Output file"]
+        var verbose: Flag[short="v", help="Enable verbose output"]
+
+        def __init__(out self):
+            self = arg_defaults[Self]()
+
+        @staticmethod
+        def description() -> String:
+            return "My awesome tool."
+    ```
+    """
+
+    @staticmethod
+    def description() -> String:
+        """Return the command description for --help.
+
+        Returns:
+            The description string.
+        """
+        ...
+
+    @staticmethod
+    def version() -> String:
+        """Return the version string for --version.
+
+        Override to change from the default ``"0.1.0"``.
+
+        Returns:
+            The version string.
+        """
+        return String("0.1.0")
+
+    @staticmethod
+    def name() -> String:
+        """Return the command name.
+
+        Override to change from the default (lowercased struct name).
+        An empty string means "use the lowercased struct name".
+
+        Returns:
+            The command name.
+        """
+        return String("")
+
+
+def arg_defaults[T: Parsable]() -> T:
+    """Create a default-initialised instance of T.
+
+    All wrapper types (``Positional``, ``Option``, ``Flag``, ``Count``)
+    implement ``Defaultable``, so ``T()`` initialises every field to its
+    type-specific default (empty string, 0, False, etc.).
+
+    Use this in your struct's ``__init__``.
+
+    Parameters:
+        T: A struct conforming to ``Parsable``.
+
+    Returns:
+        A default-initialised instance of T.
+    """
+    return T()

--- a/src/argmojo/parser.mojo
+++ b/src/argmojo/parser.mojo
@@ -19,15 +19,6 @@ struct Parser[T: Parsable](Movable):
 
     Parameters:
         T: A struct conforming to ``Parsable`` whose fields define the CLI schema.
-
-    Examples:
-
-    ```sh
-    from argmojo.parser import Parser
-
-    var args = Parser[Grep]().parse()
-    print(args.pattern.value)
-    ```
     """
 
     var _command: Command
@@ -38,8 +29,13 @@ struct Parser[T: Parsable](Movable):
 
     fn __init__(out self):
         """Create a Parser and prepare the underlying Command."""
+        var cmd_name = String(Self.T.name())
+        if not cmd_name:
+            cmd_name = String("command")
         self._command = Command(
-            String(Self.T.name()), String(Self.T.description())
+            cmd_name,
+            String(Self.T.description()),
+            version=String(Self.T.version()),
         )
         self._built = False
 
@@ -63,6 +59,10 @@ struct Parser[T: Parsable](Movable):
             return
         self._built = True
         # Placeholder — will be filled with comptime reflection logic.
+        raise Error(
+            "Parser._build() is not yet implemented. "
+            "The reflection-based builder will land in a follow-up PR."
+        )
 
     def _from_result(self, result: ParseResult) raises -> Self.T:
         """Populate a T instance from ParseResult.
@@ -74,7 +74,10 @@ struct Parser[T: Parsable](Movable):
             A populated instance of T.
         """
         # Placeholder — returns default-initialised T for now.
-        return Self.T()
+        raise Error(
+            "Parser._from_result() is not yet implemented. "
+            "The write-back logic will land in a follow-up PR."
+        )
 
     def to_command(mut self) raises -> ref[self._command] Command:
         """Return a mutable reference to the underlying Command.
@@ -84,15 +87,6 @@ struct Parser[T: Parsable](Movable):
 
         Returns:
             A mutable reference to the underlying Command.
-
-        Examples:
-
-        ```sh
-        var parser = Parser[MyArgs]()
-        var cmd = parser.to_command()
-        cmd.mutually_exclusive(["json", "yaml"])
-        var args = parser.parse()
-        ```
         """
         self._build()
         return self._command
@@ -109,21 +103,17 @@ struct Parser[T: Parsable](Movable):
         var result = self._command.parse()
         return self._from_result(result)
 
-    # NOTE: parse_split is disabled for now — Mojo 0.26.2 cannot construct
-    # a Tuple[Self.T, ParseResult] return type when T is trait-constrained.
-    # Uncomment once Mojo supports this.
-    #
-    # def parse_split(mut self) raises -> (Self.T, ParseResult):
-    #     """Build, parse argv, and return both T and the raw ParseResult.
-    #
-    #     Use this when you've added extra arguments via ``to_command()``
-    #     that aren't part of T — the typed struct covers declarative
-    #     fields, the ParseResult covers everything.
-    #
-    #     Returns:
-    #         A tuple of (populated T, raw ParseResult).
-    #     """
-    #     self._build()
-    #     var result = self._command.parse()
-    #     var args = self._from_result(result)
-    #     return (args^, result^)
+    def parse_split(mut self) raises -> Tuple[Self.T, ParseResult]:
+        """Build, parse argv, and return both T and the raw ParseResult.
+
+        Use this when you've added extra arguments via ``to_command()``
+        that aren't part of T — the typed struct covers declarative
+        fields, the ParseResult covers everything.
+
+        Returns:
+            A tuple of (populated T, raw ParseResult).
+        """
+        self._build()
+        var result = self._command.parse()
+        var args = self._from_result(result)
+        return Tuple[Self.T, ParseResult](args^, result^)

--- a/src/argmojo/parser.mojo
+++ b/src/argmojo/parser.mojo
@@ -1,0 +1,129 @@
+"""Declarative orchestrator that bridges wrapper structs to the builder API.
+
+``Parser[T]`` inspects a ``Parsable`` struct via compile-time
+reflection, translates wrapper parameters to ``Command``/``Argument``
+builder calls, and populates the struct from ``ParseResult``.
+
+This file is a skeleton — the reflection-based ``_build()`` and
+``_from_result()`` methods will be implemented in Phase 1 (continued)
+and Phase 2.
+"""
+
+from .command import Command
+from .parsable import Parsable
+from .parse_result import ParseResult
+
+
+struct Parser[T: Parsable](Movable):
+    """Orchestrates declarative CLI parsing for a ``Parsable`` struct.
+
+    Parameters:
+        T: A struct conforming to ``Parsable`` whose fields define the CLI schema.
+
+    Examples:
+
+    ```sh
+    from argmojo.parser import Parser
+
+    var args = Parser[Grep]().parse()
+    print(args.pattern.value)
+    ```
+    """
+
+    var _command: Command
+    """The underlying builder Command, constructed from T's metadata."""
+
+    var _built: Bool
+    """Whether _build() has been called."""
+
+    fn __init__(out self):
+        """Create a Parser and prepare the underlying Command."""
+        self._command = Command(
+            String(Self.T.name()), String(Self.T.description())
+        )
+        self._built = False
+
+    fn __init__(out self, *, deinit take: Self):
+        """Move from an existing instance.
+
+        Args:
+            take: The Parser to move from.
+        """
+        self._command = take._command^
+        self._built = take._built
+
+    def _build(mut self) raises:
+        """Reflect over T's fields and translate to builder calls.
+
+        TODO: Phase 1 implementation — iterate struct_field_names/types,
+        match wrapper types, and call add_argument() with the correct
+        builder chain for each field.
+        """
+        if self._built:
+            return
+        self._built = True
+        # Placeholder — will be filled with comptime reflection logic.
+
+    def _from_result(self, result: ParseResult) raises -> Self.T:
+        """Populate a T instance from ParseResult.
+
+        TODO: Phase 1 implementation — iterate fields, dispatch on
+        wrapper type, and write back typed values.
+
+        Returns:
+            A populated instance of T.
+        """
+        # Placeholder — returns default-initialised T for now.
+        return Self.T()
+
+    def to_command(mut self) raises -> ref[self._command] Command:
+        """Return a mutable reference to the underlying Command.
+
+        Call this before ``parse()`` to apply builder-level
+        customisations (groups, implications, colours, tips, etc.).
+
+        Returns:
+            A mutable reference to the underlying Command.
+
+        Examples:
+
+        ```sh
+        var parser = Parser[MyArgs]()
+        var cmd = parser.to_command()
+        cmd.mutually_exclusive(["json", "yaml"])
+        var args = parser.parse()
+        ```
+        """
+        self._build()
+        return self._command
+
+    def parse(mut self) raises -> Self.T:
+        """Build, parse argv, and return a fully populated T.
+
+        This is the primary entry point for pure-declarative usage.
+
+        Returns:
+            A populated instance of T.
+        """
+        self._build()
+        var result = self._command.parse()
+        return self._from_result(result)
+
+    # NOTE: parse_split is disabled for now — Mojo 0.26.2 cannot construct
+    # a Tuple[Self.T, ParseResult] return type when T is trait-constrained.
+    # Uncomment once Mojo supports this.
+    #
+    # def parse_split(mut self) raises -> (Self.T, ParseResult):
+    #     """Build, parse argv, and return both T and the raw ParseResult.
+    #
+    #     Use this when you've added extra arguments via ``to_command()``
+    #     that aren't part of T — the typed struct covers declarative
+    #     fields, the ParseResult covers everything.
+    #
+    #     Returns:
+    #         A tuple of (populated T, raw ParseResult).
+    #     """
+    #     self._build()
+    #     var result = self._command.parse()
+    #     var args = self._from_result(result)
+    #     return (args^, result^)

--- a/tests/test_wrappers.mojo
+++ b/tests/test_wrappers.mojo
@@ -1,0 +1,156 @@
+"""Tests for declarative wrapper types: Option, Flag, Positional, Count.
+
+Verifies default initialization, copy/move semantics, and Flag.__bool__().
+"""
+
+from std.testing import assert_true, assert_false, assert_equal, TestSuite
+from argmojo import Option, Flag, Positional, Count
+
+
+# ── Option defaults ──────────────────────────────────────────────────────────
+
+
+def test_option_string_default() raises:
+    """Option[String] defaults to empty string."""
+    var opt = Option[String, long="output", short="o", help="Output file"]()
+    assert_equal(opt.value, "")
+
+
+def test_option_int_default() raises:
+    """Option[Int] defaults to 0."""
+    var opt = Option[Int, long="port", help="Port number"]()
+    assert_equal(opt.value, 0)
+
+
+def test_option_string_copy() raises:
+    """Option[String] copy preserves value."""
+    var a = Option[String, long="name"]()
+    a.value = String("hello")
+    var b = Option[String, long="name"](copy=a)
+    assert_equal(b.value, "hello")
+    assert_equal(a.value, "hello")
+
+
+def test_option_int_copy() raises:
+    """Option[Int] copy preserves value."""
+    var a = Option[Int, long="count"]()
+    a.value = 42
+    var b = Option[Int, long="count"](copy=a)
+    assert_equal(b.value, 42)
+
+
+def test_option_move() raises:
+    """Option[String] move transfers ownership."""
+    var a = Option[String, long="path"]()
+    a.value = String("moved")
+    var b = Option[String, long="path"](take=a^)
+    assert_equal(b.value, "moved")
+
+
+# ── Flag defaults & bool ─────────────────────────────────────────────────────
+
+
+def test_flag_default_false() raises:
+    """Flag defaults to False."""
+    var f = Flag[short="v", help="Verbose"]()
+    assert_false(f.value)
+    assert_false(f.__bool__())
+
+
+def test_flag_init_true() raises:
+    """Flag can be initialised to True."""
+    var f = Flag[long="color"](True)
+    assert_true(f.value)
+    assert_true(f.__bool__())
+
+
+def test_flag_bool_conversion() raises:
+    """Flag.__bool__() enables `if flag:` syntax."""
+    var f = Flag[long="debug"]()
+    assert_false(f.__bool__())
+    f.value = True
+    assert_true(f.__bool__())
+
+
+def test_flag_copy() raises:
+    """Flag copy preserves value."""
+    var a = Flag[short="f"](True)
+    var b = Flag[short="f"](copy=a)
+    assert_true(b.value)
+    assert_true(a.value)
+
+
+def test_flag_move() raises:
+    """Flag move transfers ownership."""
+    var a = Flag[long="force"](True)
+    var b = Flag[long="force"](take=a^)
+    assert_true(b.value)
+
+
+# ── Positional defaults ──────────────────────────────────────────────────────
+
+
+def test_positional_string_default() raises:
+    """Positional[String] defaults to empty string."""
+    var p = Positional[String, help="Input file"]()
+    assert_equal(p.value, "")
+
+
+def test_positional_int_default() raises:
+    """Positional[Int] defaults to 0."""
+    var p = Positional[Int, help="Count"]()
+    assert_equal(p.value, 0)
+
+
+def test_positional_copy() raises:
+    """Positional[String] copy preserves value."""
+    var a = Positional[String, help="Path"]()
+    a.value = String("test.txt")
+    var b = Positional[String, help="Path"](copy=a)
+    assert_equal(b.value, "test.txt")
+    assert_equal(a.value, "test.txt")
+
+
+def test_positional_move() raises:
+    """Positional[String] move transfers ownership."""
+    var a = Positional[String, help="Path"]()
+    a.value = String("foo.txt")
+    var b = Positional[String, help="Path"](take=a^)
+    assert_equal(b.value, "foo.txt")
+
+
+# ── Count defaults ───────────────────────────────────────────────────────────
+
+
+def test_count_default_zero() raises:
+    """Count defaults to 0."""
+    var c = Count[short="v", help="Verbosity"]()
+    assert_equal(c.value, 0)
+
+
+def test_count_init_value() raises:
+    """Count can be initialised with an explicit value."""
+    var c = Count[short="d", help="Debug level"](3)
+    assert_equal(c.value, 3)
+
+
+def test_count_copy() raises:
+    """Count copy preserves value."""
+    var a = Count[short="v"](5)
+    var b = Count[short="v"](copy=a)
+    assert_equal(b.value, 5)
+    assert_equal(a.value, 5)
+
+
+def test_count_move() raises:
+    """Count move transfers ownership."""
+    var a = Count[long="debug"](7)
+    var b = Count[long="debug"](take=a^)
+    assert_equal(b.value, 7)
+
+
+# ── Entry point ──────────────────────────────────────────────────────────────
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
This PR introduces the initial scaffolding for ArgMojo’s planned declarative API layer (Swift-style wrapper structs + a `Parsable` marker trait + a `Parser[T]` orchestrator), layered on top of the existing builder `Command`/`Argument` engine.

**Changes:**
- Added declarative wrapper structs: `Option`, `Flag`, `Positional`, `Count`.
- Added `Parsable` trait plus `arg_defaults[T]()` helper, and a new `Parser[T]` skeleton that will later reflect wrappers into builder calls.
- Re-exported declarative API from `argmojo.__init__`, and updated planning docs / docstring wording (“Example” → “Examples”).