### PR TITLE
[core][declarative] Use `rebind` instead of `UnsafePointer` in argument wrapper write-back logic

### DIFF
--- a/src/argmojo/argument_wrappers.mojo
+++ b/src/argmojo/argument_wrappers.mojo
@@ -482,16 +482,13 @@ struct Positional[
         comptime type_name = get_type_name[Self.T]()
         comptime if type_name == "List[String]":
             var lst = result.get_list(field_name)
-            var tmp = rebind[Self.T](lst^).copy()
-            self.value = tmp^
+            self.value = rebind[Self.T](lst^).copy()
         elif type_name == "Int":
             var v = result.get_int(field_name)
-            var tmp = rebind[Self.T](v).copy()
-            self.value = tmp^
+            self.value = rebind[Self.T](v).copy()
         elif type_name == "String":
             var s = result.get_string(field_name)
-            var tmp = rebind[Self.T](s^).copy()
-            self.value = tmp^
+            self.value = rebind[Self.T](s^).copy()
         else:
             comptime assert False, (
                 "Unsupported Positional[T] type in read_from_result: "

--- a/src/argmojo/argument_wrappers.mojo
+++ b/src/argmojo/argument_wrappers.mojo
@@ -246,17 +246,13 @@ struct Option[
             return
         comptime type_name = get_type_name[Self.T]()
         comptime if type_name == "List[String]":
-            var lst = result.get_list(field_name)
-            self.value = rebind[Self.T](lst^).copy()
+            self.value = rebind[Self.T](result.get_list(field_name)).copy()
         elif type_name == "Dict[String, String]":
-            var m = result.get_map(field_name)
-            self.value = rebind[Self.T](m^).copy()
+            self.value = rebind[Self.T](result.get_map(field_name)).copy()
         elif type_name == "Int":
-            var v = result.get_int(field_name)
-            self.value = rebind[Self.T](v).copy()
+            self.value = rebind[Self.T](result.get_int(field_name)).copy()
         elif type_name == "String":
-            var s = result.get_string(field_name)
-            self.value = rebind[Self.T](s^).copy()
+            self.value = rebind[Self.T](result.get_string(field_name)).copy()
         else:
             comptime assert False, (
                 "Unsupported Option[T] type in read_from_result: "
@@ -481,14 +477,11 @@ struct Positional[
             return
         comptime type_name = get_type_name[Self.T]()
         comptime if type_name == "List[String]":
-            var lst = result.get_list(field_name)
-            self.value = rebind[Self.T](lst^).copy()
+            self.value = rebind[Self.T](result.get_list(field_name)).copy()
         elif type_name == "Int":
-            var v = result.get_int(field_name)
-            self.value = rebind[Self.T](v).copy()
+            self.value = rebind[Self.T](result.get_int(field_name)).copy()
         elif type_name == "String":
-            var s = result.get_string(field_name)
-            self.value = rebind[Self.T](s^).copy()
+            self.value = rebind[Self.T](result.get_string(field_name)).copy()
         else:
             comptime assert False, (
                 "Unsupported Positional[T] type in read_from_result: "

--- a/src/argmojo/argument_wrappers.mojo
+++ b/src/argmojo/argument_wrappers.mojo
@@ -20,7 +20,6 @@ reflection hooks:
   from a ``ParseResult``.
 """
 
-from std.memory import UnsafePointer
 from std.reflection import get_type_name
 from .argument import Argument
 from .parse_result import ParseResult
@@ -245,27 +244,19 @@ struct Option[
     ) raises:
         if not result.has(field_name):
             return
-        comptime tname = get_type_name[Self.T]()
-        comptime if tname == "List[String]":
+        comptime type_name = get_type_name[Self.T]()
+        comptime if type_name == "List[String]":
             var lst = result.get_list(field_name)
-            var dest = UnsafePointer(to=self.value)
-            dest.destroy_pointee()
-            dest.bitcast[List[String]]().init_pointee_move(lst^)
-        elif tname == "Dict[String, String]":
+            self.value = rebind[Self.T](lst^).copy()
+        elif type_name == "Dict[String, String]":
             var m = result.get_map(field_name)
-            var dest = UnsafePointer(to=self.value)
-            dest.destroy_pointee()
-            dest.bitcast[Dict[String, String]]().init_pointee_move(m^)
-        elif tname == "Int":
+            self.value = rebind[Self.T](m^).copy()
+        elif type_name == "Int":
             var v = result.get_int(field_name)
-            var dest = UnsafePointer(to=self.value)
-            dest.destroy_pointee()
-            dest.bitcast[Int]().init_pointee_move(v)
-        elif tname == "String":
+            self.value = rebind[Self.T](v).copy()
+        elif type_name == "String":
             var s = result.get_string(field_name)
-            var dest = UnsafePointer(to=self.value)
-            dest.destroy_pointee()
-            dest.bitcast[String]().init_pointee_move(s^)
+            self.value = rebind[Self.T](s^).copy()
         else:
             comptime assert False, (
                 "Unsupported Option[T] type in read_from_result: "
@@ -488,22 +479,19 @@ struct Positional[
     ) raises:
         if not result.has(field_name):
             return
-        comptime tname = get_type_name[Self.T]()
-        comptime if tname == "List[String]":
+        comptime type_name = get_type_name[Self.T]()
+        comptime if type_name == "List[String]":
             var lst = result.get_list(field_name)
-            var dest = UnsafePointer(to=self.value)
-            dest.destroy_pointee()
-            dest.bitcast[List[String]]().init_pointee_move(lst^)
-        elif tname == "Int":
+            var tmp = rebind[Self.T](lst^).copy()
+            self.value = tmp^
+        elif type_name == "Int":
             var v = result.get_int(field_name)
-            var dest = UnsafePointer(to=self.value)
-            dest.destroy_pointee()
-            dest.bitcast[Int]().init_pointee_move(v)
-        elif tname == "String":
+            var tmp = rebind[Self.T](v).copy()
+            self.value = tmp^
+        elif type_name == "String":
             var s = result.get_string(field_name)
-            var dest = UnsafePointer(to=self.value)
-            dest.destroy_pointee()
-            dest.bitcast[String]().init_pointee_move(s^)
+            var tmp = rebind[Self.T](s^).copy()
+            self.value = tmp^
         else:
             comptime assert False, (
                 "Unsupported Positional[T] type in read_from_result: "


### PR DESCRIPTION
This PR updates the declarative argument wrapper write-back logic to avoid `UnsafePointer` usage, switching `Option[T]` and `Positional[T]` to assign parsed values via `rebind`-based conversions.

**Changes:**
- Removed the `UnsafePointer` import and the manual destroy/init_pointee_move overwrite pattern.
- Updated `Option.read_from_result` and `Positional.read_from_result` to assign to `self.value` using `rebind`.
- Renamed the local compile-time variable from `tname` to `type_name` for clarity.