### PR TITLE
[core][declarative] Default-initialize all fields via reflection in `__init__` of `Parsable` trait

### DIFF
--- a/examples/jomo.mojo
+++ b/examples/jomo.mojo
@@ -56,14 +56,6 @@ struct Jomo(Parsable):
 
     var verbose: Count[short="v", help="Increase verbosity", persistent=True]
 
-    def __init__(out self):
-        self.verbose = Count[
-            short="v", help="Increase verbosity", persistent=True
-        ]()
-
-    fn __init__(out self, *, deinit take: Self):
-        self.verbose = take.verbose^
-
     @staticmethod
     def description() -> String:
         return String("The Jomo command line interface.")

--- a/src/argmojo/argument_wrappers.mojo
+++ b/src/argmojo/argument_wrappers.mojo
@@ -111,7 +111,8 @@ struct Option[
 
     Parameters:
         T: The value type stored at runtime.
-        long: Long option name (e.g. ``"output"`` for ``--output``). Empty = auto from field name.
+        long: Long option name (e.g. ``"output"`` for ``--output``).
+            Empty = auto from field name.
         short: Short option character (e.g. ``"o"`` for ``-o``).
         help: Help text shown in ``--help`` output.
         alias_name: Comma-separated alias long names.

--- a/src/argmojo/parsable.mojo
+++ b/src/argmojo/parsable.mojo
@@ -1,5 +1,6 @@
 """Declares the Parsable trait, reflection helpers, and convenience functions."""
 
+from std.builtin.constrained import _constrained_field_conforms_to
 from std.reflection import (
     struct_field_count,
     struct_field_names,
@@ -19,6 +20,9 @@ trait Parsable(Defaultable, Movable):
     compile-time reflection over wrapper-typed fields (Option, Flag,
     Positional, Count).
 
+    The default ``__init__`` is provided automatically via reflection,
+    and the compiler synthesises the move ``__init__`` from ``Movable``
+    conformance, so conforming structs do **not** need to define them.
     Users only need to provide ``description()`` (required) and
     optionally override ``version()``, ``name()``, and ``subcommands()``.
 
@@ -33,16 +37,34 @@ trait Parsable(Defaultable, Movable):
                            help="Output file"]
         var verbose: Flag[short="v", help="Enable verbose output"]
 
-        def __init__(out self):
-            self.output = Option[String, long="output", short="o",
-                                 help="Output file"]()
-            self.verbose = Flag[short="v", help="Enable verbose output"]()
-
         @staticmethod
         def description() -> String:
             return "My awesome tool."
     ```
     """
+
+    fn __init__(out self):
+        """Default-initialise all fields via reflection.
+
+        Uses ``__mlir_op.lit.ownership.mark_initialized`` to bypass the
+        compiler's definite-assignment check, then placement-news each
+        field with ``UnsafePointer.init_pointee_move(type_of(field)())``.
+        """
+        __mlir_op.`lit.ownership.mark_initialized`(__get_mvalue_as_litref(self))
+        comptime names = struct_field_names[Self]()
+        comptime types = struct_field_types[Self]()
+        comptime for i in range(names.size):
+            comptime FieldType = types[i]
+            _constrained_field_conforms_to[
+                conforms_to(FieldType, Defaultable & Movable),
+                Parent=Self,
+                FieldIndex=i,
+                ParentConformsTo="Defaultable & Movable",
+            ]()
+            ref field = trait_downcast[Movable & Defaultable](
+                __struct_field_ref(i, self)
+            )
+            UnsafePointer(to=field).init_pointee_move(type_of(field)())
 
     @staticmethod
     def description() -> String:

--- a/src/argmojo/parsable.mojo
+++ b/src/argmojo/parsable.mojo
@@ -49,12 +49,21 @@ trait Parsable(Defaultable, Movable):
         Uses ``__mlir_op.lit.ownership.mark_initialized`` to bypass the
         compiler's definite-assignment check, then placement-news each
         field with ``UnsafePointer.init_pointee_move(type_of(field)())``.
+        Otherwise, the user would have to write a custom ``__init__`` that
+        manually default-constructs each field.
         """
+        # [Mojo Miji]
+        # When Mojo compiles this struct, it calculates the full memory layout
+        # before compiling the __init__. This means that at this point, the
+        # struct's fields are reserved in the memory layout but not yet
+        # initialized. We can safely tell the compiler to treat them as
+        # initialized so that we can reflect over the fields and initialize them
+        # in a loop using unsafe pointer operations.
         __mlir_op.`lit.ownership.mark_initialized`(__get_mvalue_as_litref(self))
-        comptime names = struct_field_names[Self]()
-        comptime types = struct_field_types[Self]()
-        comptime for i in range(names.size):
-            comptime FieldType = types[i]
+        comptime field_count = struct_field_count[Self]()
+        comptime field_types = struct_field_types[Self]()
+        comptime for i in range(field_count):
+            comptime FieldType = field_types[i]
             _constrained_field_conforms_to[
                 conforms_to(FieldType, Defaultable & Movable),
                 Parent=Self,
@@ -64,6 +73,9 @@ trait Parsable(Defaultable, Movable):
             ref field = trait_downcast[Movable & Defaultable](
                 __struct_field_ref(i, self)
             )
+            # [Mojo Miji]
+            # type_of(field)() calls the default constructor for the field's
+            # type, which is an instance of one of the argument wrapper structs.
             UnsafePointer(to=field).init_pointee_move(type_of(field)())
 
     @staticmethod

--- a/tests/test_declarative.mojo
+++ b/tests/test_declarative.mojo
@@ -29,24 +29,6 @@ struct Grep(Parsable):
     var pattern: Positional[String, help="Search pattern", required=True]
     var debug_level: Count[long="debug", short="d", help="Debug level", max=3]
 
-    def __init__(out self):
-        self.output = Option[
-            String, long="output", short="o", help="Output file"
-        ]()
-        self.verbose = Flag[short="v", help="Verbose mode"]()
-        self.pattern = Positional[
-            String, help="Search pattern", required=True
-        ]()
-        self.debug_level = Count[
-            long="debug", short="d", help="Debug level", max=3
-        ]()
-
-    fn __init__(out self, *, deinit take: Self):
-        self.output = take.output^
-        self.verbose = take.verbose^
-        self.pattern = take.pattern^
-        self.debug_level = take.debug_level^
-
     @staticmethod
     def description() -> String:
         return String("Search for patterns in files.")
@@ -127,14 +109,6 @@ def test_from_result() raises:
 struct AutoNameArgs(Parsable):
     var no_color: Flag[help="Disable color"]
     var max_depth: Option[Int, help="Max depth"]
-
-    def __init__(out self):
-        self.no_color = Flag[help="Disable color"]()
-        self.max_depth = Option[Int, help="Max depth"]()
-
-    fn __init__(out self, *, deinit take: Self):
-        self.no_color = take.no_color^
-        self.max_depth = take.max_depth^
 
     @staticmethod
     def description() -> String:


### PR DESCRIPTION
This PR makes `Parsable` structs fully declarative by providing a reflection-based default `__init__` on the `Parsable` trait, allowing conforming structs to omit manual field initialization boilerplate.

**Changes:**
- Add a default `Parsable.__init__` that default-initializes all fields via compile-time reflection.
- Remove now-redundant explicit `__init__` / move-`__init__` implementations from declarative tests.
- Remove now-redundant explicit `__init__` / move-`__init__` implementation from the `examples/jomo.mojo` root args struct.