### PR TITLE
[core][declarative] Add tests for declarative subcommands

### DIFF
--- a/docs/declarative_api_planning.md
+++ b/docs/declarative_api_planning.md
@@ -167,7 +167,7 @@ What I think argmojo can add beyond Swift:
 │  Parsable.parse_split() → (Self, ParseResult)  (dual return)             │
 │  Parsable.parse_args()  → Self      (parse from explicit arg list)       │
 │  Parsable.validate()    → None      (post-parse cross-field validation)  │
-│  (wrapper types are Defaultable — initialise fields explicitly)          │
+│  (wrapper types are auto-initialised by Parsable — no manual __init__)   │
 │                                                                          │
 │  argument_wrappers.mojo — wrapper types:                                 │
 │  Positional[T, ...], Option[T, ...], Flag[...], Count[...]               │

--- a/docs/declarative_api_planning.md
+++ b/docs/declarative_api_planning.md
@@ -26,18 +26,18 @@ I want the declarative API to satisfy five goals:
 
 Available compile-time reflection primitives:
 
-| API                                 | Purpose                                  |
-| ----------------------------------- | ---------------------------------------- |
-| `struct_field_count[T]()`           | Number of fields in struct T             |
-| `struct_field_names[T]()`           | Indexable list of field name strings     |
-| `struct_field_types[T]()`           | Indexable list of field types            |
-| `get_type_name[T]()`                | String name of type T                    |
-| `__struct_field_ref(idx, instance)` | Reference to field by compile-time index |
-| `conforms_to(type, Trait)`          | Compile-time trait conformance check     |
-| `trait_downcast[Trait](value)`      | Cast value to trait-conforming type      |
-| `@fieldwise_init`                   | Auto-generate constructor from fields    |
-| `comptime for idx in range(N)`      | Compile-time loop                        |
-| `comptime if condition`             | Compile-time conditional                 |
+| API                                 | Purpose                                                    |
+| ----------------------------------- | ---------------------------------------------------------- |
+| `struct_field_count[T]()`           | Number of fields in struct T                               |
+| `struct_field_names[T]()`           | Indexable list of field name strings                       |
+| `struct_field_types[T]()`           | Indexable list of field types                              |
+| `get_type_name[T]()`                | String name of type T                                      |
+| `__struct_field_ref(idx, instance)` | Reference to field by compile-time index                   |
+| `conforms_to(type, Trait)`          | Compile-time trait conformance check                       |
+| `trait_downcast[Trait](value)`      | Cast value to trait-conforming type                        |
+| ~~`@fieldwise_init`~~               | ~~Auto-generate constructor from fields~~[^fieldwise_init] |
+| `comptime for idx in range(N)`      | Compile-time loop                                          |
+| `comptime if condition`             | Compile-time conditional                                   |
 
 **Key limitation**: No proc macros, no custom decorators, no `#[derive(...)]`. So all declarative behavior has to be implemented via parametric functions that reflect over user-defined structs.
 
@@ -143,7 +143,7 @@ What I think argmojo can add beyond Swift:
 │      var name: Positional[String, help="Name", required=True]            │
 │      var verbose: Flag[short="v", help="Verbose"]                        │
 │      var output: Option[String, long="output", short="o"]                │
-│      def __init__(out self):  # initialise each field explicitly         │
+│      # No __init__ needed — Parsable auto-initialises all fields         │
 │                                                                          │
 │  # Pure declarative (one line):                                          │
 │  var args = MyArgs.parse()                                               │
@@ -167,7 +167,7 @@ What I think argmojo can add beyond Swift:
 │  Parsable.parse_split() → (Self, ParseResult)  (dual return)             │
 │  Parsable.parse_args()  → Self      (parse from explicit arg list)       │
 │  Parsable.validate()    → None      (post-parse cross-field validation)  │
-│  (wrapper types are Defaultable — initialise fields explicitly)           │
+│  (wrapper types are Defaultable — initialise fields explicitly)          │
 │                                                                          │
 │  argument_wrappers.mojo — wrapper types:                                 │
 │  Positional[T, ...], Option[T, ...], Flag[...], Count[...]               │
@@ -487,9 +487,6 @@ Minimal implementation — you only need to provide `description()`:
 struct MyArgs(Parsable):
     var input: Positional[String, help="Input file", required=True]
 
-    def __init__(out self):
-        self.input = Positional[String, help="Input file", required=True]()
-
     @staticmethod
     def description() -> String:
         return "My awesome tool"
@@ -555,19 +552,15 @@ def _from_result[T: Parsable](result: ParseResult) raises -> T:
     return out
 ```
 
-### 4.4 Explicit Field Initialization
+### 4.4 Field Initialization (Auto-Init)
 
-Each wrapper type (`Positional`, `Option`, `Flag`, `Count`) implements `Defaultable`,
-so the user initialises every field in `__init__` with the wrapper's default constructor:
-
-```mojo
-def __init__(out self):
-    self.pattern = Positional[String, help="Search pattern", required=True]()
-    self.verbose = Flag[short="v", help="Verbose"]()
-    self.output = Option[String, long="output", short="o"]()
-```
-
-This keeps the struct fully self-describing — no external helper needed.
+> **Update**: As of Phase 1 implementation, users **no longer need to write `__init__`**.
+> The `Parsable` trait provides a default `__init__` that uses
+> `__mlir_op.lit.ownership.mark_initialized` + `comptime for` +
+> `UnsafePointer.init_pointee_move(type_of(field)())` to auto-initialise
+> every field via reflection. The compiler auto-synthesises the move init
+> from `Movable` conformance. Users only need to declare fields and
+> provide `description()`.
 
 ### 4.5 Auto-Naming Convention
 
@@ -601,6 +594,10 @@ This generates `.alias_name["out"]().alias_name["dest"]()`.
 
 ## 5. Usage Examples
 
+> **Note**: The examples below have been updated to reflect the current
+> implementation. Users no longer need to write `__init__` — the `Parsable`
+> trait auto-initialises all fields via reflection (see §4.4).
+
 ### 5.1 Pure Declarative (Simple Tool)
 
 ```mojo
@@ -616,15 +613,6 @@ struct Grep(Parsable):
     var max_count: Option[Int, short="m", long="max-count", help="Stop after N matches", default="0"]
     var verbose: Count[short="v", help="Increase verbosity", max=3]
     var ext: Option[List[String], short="e", long="ext", help="File extensions", append=True]
-
-    def __init__(out self):
-        self.pattern = Positional[String, help="Search pattern", required=True]()
-        self.path = Positional[String, help="File or directory", default="."]()
-        self.ignore_case = Flag[short="i", help="Case-insensitive search"]()
-        self.count_only = Flag[short="c", long="count", help="Only print match count"]()
-        self.max_count = Option[Int, short="m", long="max-count", help="Stop after N matches", default="0"]()
-        self.verbose = Count[short="v", help="Increase verbosity", max=3]()
-        self.ext = Option[List[String], short="e", long="ext", help="File extensions", append=True]()
 
     @staticmethod
     def description() -> String:
@@ -661,14 +649,6 @@ struct Deploy(Parsable):
     var replicas: Option[Int, long="replicas", short="r", help="Number of replicas",
                       default="3", has_range=True, range_min=1, range_max=100]
 
-    def __init__(out self):
-        self.target = Positional[String, help="Deploy target", required=True, choices="staging,prod"]()
-        self.force = Flag[short="f", help="Force deploy without checks"]()
-        self.dry_run = Flag[long="dry-run", help="Simulate without changes"]()
-        self.tag = Option[String, long="tag", short="t", help="Release tag"]()
-        self.replicas = Option[Int, long="replicas", short="r", help="Number of replicas",
-                          default="3", has_range=True, range_min=1, range_max=100]()
-
     @staticmethod
     def description() -> String:
         return "Deploy application to target environment."
@@ -684,6 +664,8 @@ def main() raises:
 
     # from_command() takes the customised Command and returns typed Deploy
     var args = Deploy.from_command(cmd^)
+```
+
 ### 5.3 Split Parse (Declarative + Extra Builder Fields)
 
 ```mojo
@@ -693,10 +675,6 @@ from argmojo import Parsable, Positional, Option
 struct Convert(Parsable):
     var input: Positional[String, help="Input file", required=True]
     var output: Option[String, long="output", short="o", help="Output file"]
-
-    def __init__(out self):
-        self.input = Positional[String, help="Input file", required=True]()
-        self.output = Option[String, long="output", short="o", help="Output file"]()
 
     @staticmethod
     def description() -> String:
@@ -746,11 +724,6 @@ struct Clone(Parsable):
     var depth: Option[Int, long="depth", help="Clone depth", default="0"]
     var branch: Option[String, short="b", long="branch", help="Branch to clone"]
 
-    def __init__(out self):
-        self.url = Positional[String, help="Repository URL", required=True]()
-        self.depth = Option[Int, long="depth", help="Clone depth", default="0"]()
-        self.branch = Option[String, short="b", long="branch", help="Branch to clone"]()
-
     @staticmethod
     def description() -> String:
         return "Clone a repository."
@@ -767,11 +740,6 @@ struct Push(Parsable):
     var force: Flag[short="f", help="Force push"]
     var tags: Flag[long="tags", help="Push all tags"]
 
-    def __init__(out self):
-        self.remote = Positional[String, help="Remote name", default="origin"]()
-        self.force = Flag[short="f", help="Force push"]()
-        self.tags = Flag[long="tags", help="Push all tags"]()
-
     @staticmethod
     def description() -> String:
         return "Push commits to remote."
@@ -786,9 +754,6 @@ struct Push(Parsable):
 # Root command — has its own flags + declares subcommands
 struct MyGit(Parsable):
     var verbose: Flag[short="v", help="Verbose output", persistent=True]
-
-    def __init__(out self):
-        self.verbose = Flag[short="v", help="Verbose output", persistent=True]()
 
     @staticmethod
     def name() -> String:
@@ -846,10 +811,6 @@ struct AddRemote(Parsable):
     var name_: Positional[String, help="Remote name", required=True]
     var url: Positional[String, help="Remote URL", required=True]
 
-    def __init__(out self):
-        self.name_ = Positional[String, help="Remote name", required=True]()
-        self.url = Positional[String, help="Remote URL", required=True]()
-
     @staticmethod
     def description() -> String: return "Add a remote."
 
@@ -861,9 +822,6 @@ struct AddRemote(Parsable):
 
 struct RemoveRemote(Parsable):
     var name_: Positional[String, help="Remote name", required=True]
-
-    def __init__(out self):
-        self.name_ = Positional[String, help="Remote name", required=True]()
 
     @staticmethod
     def description() -> String: return "Remove a remote."
@@ -877,9 +835,6 @@ struct RemoveRemote(Parsable):
 # Mid-level command — Parsable with its own flags + nested subcommands
 struct Remote(Parsable):
     var timeout: Option[Int, long="timeout", help="Timeout in seconds", default="30"]
-
-    def __init__(out self):
-        self.timeout = Option[Int, long="timeout", help="Timeout in seconds", default="30"]()
 
     @staticmethod
     def name() -> String: return "remote"
@@ -895,9 +850,6 @@ struct Remote(Parsable):
 # Root — references Remote which references AddRemote/RemoveRemote
 struct MyGit(Parsable):
     var verbose: Flag[short="v", help="Verbose output", persistent=True]
-
-    def __init__(out self):
-        self.verbose = Flag[short="v", help="Verbose output", persistent=True]()
 
     @staticmethod
     def name() -> String: return "mgit"
@@ -1379,10 +1331,11 @@ I think this is the right call — these features describe *relationships betwee
 - [x] Implement `run(self)` on `Parsable` trait (default no-op)
 - [x] Implement `from_command_split()` as free function
 - [x] Implement `from_result()` as free function (public write-back)
-- [ ] Test: flat subcommands with `subcommands()` hook
-- [ ] Test: nested subcommands (2+ levels) with mid-level flags and recursive `subcommands()`
-- [ ] Test: root-level customization via `to_command()` + `from_command_split()`
-- [ ] Test: `run()` dispatch pattern
+- [x] Test: flat subcommands with `subcommands()` hook (6 tests in `test_subcommands_declarative.mojo`)
+- [x] Test: nested subcommands (2+ levels) with mid-level flags and recursive `subcommands()` (6 tests)
+- [x] Test: root-level customization via `to_command()` + dual return + `from_result()` (4 tests)
+- [x] Test: `run()` dispatch pattern — root no-op, leaf field access, full dispatch, nested dispatch (5 tests)
+- [x] Test: `parse_args` free function with subcommands (2 tests)
 
 ### Phase 4: Further enhancements
 
@@ -1406,3 +1359,5 @@ I think this is the right call — these features describe *relationships betwee
 - [ ] Examples: simple pure-declarative, more hybrid patterns
 - [ ] User manual additions
 - [ ] README update with declarative examples
+
+[^fieldwise_init]: removed — compiler auto-synthesises move init from `Movable` conformance; the `Parsable` trait now provides a reflection-based default `__init__` via `mark_initialized` + `comptime for`.

--- a/examples/jomo.mojo
+++ b/examples/jomo.mojo
@@ -73,7 +73,7 @@ struct Jomo(Parsable):
     def subcommands(mut cmd: Command) raises:
         """Register subcommands — mix of declarative and builder."""
         # Builder subcommands (share compilation/target option helpers)
-        # `build_run()` and `build_build()` returns Command instances
+        # `build_run()` and `build_build()` return Command instances
         # that are defined with builder-style APIs (not Parsable structs).
         cmd.add_subcommand(build_run())
         cmd.add_subcommand(build_build())

--- a/examples/jomo.mojo
+++ b/examples/jomo.mojo
@@ -9,15 +9,15 @@ Simulates the interface of the ``mojo`` command-line tool:
     jomo doc src/mylib/__init__.mojo
 
 No actual compilation happens — only argument parsing and a summary.
-This demo starts simple and will grow as more declarative features land.
 
 Showcases:
   - Declarative root struct with ``Parsable`` trait
-  - Global options via ``Option`` and ``Flag`` wrappers
-  - Auto-naming (underscore → hyphen in long names)
-  - The ``subcommands()`` hook to register builder-API child commands
-  - Hybrid approach: declarative root + builder subcommands
-  - ``parse_split`` for subcommand dispatch
+  - Declarative subcommand structs (``format``, ``doc``, ``package``)
+  - Builder subcommands (``run``, ``build``) for shared compilation options
+  - Hybrid: declarative root + both declarative and builder children
+  - ``subcommands()`` hook with ``ChildParsable.to_command()``
+  - ``from_result[T]()`` write-back for typed subcommand dispatch
+  - ``run()`` dispatch pattern
 
 Try these (build first with: pixi run mojo build -I src -o jomo examples/jomo.mojo):
 
@@ -40,6 +40,7 @@ from argmojo import (
     Parsable,
     Option,
     Flag,
+    Positional,
     Count,
     to_command,
     from_result,
@@ -70,23 +71,155 @@ struct Jomo(Parsable):
 
     @staticmethod
     def subcommands(mut cmd: Command) raises:
-        """Register all subcommands using the builder API."""
-        cmd.add_subcommand(_build_run())
-        cmd.add_subcommand(_build_build())
-        cmd.add_subcommand(_build_package())
-        cmd.add_subcommand(_build_format())
-        cmd.add_subcommand(_build_doc())
+        """Register subcommands — mix of declarative and builder."""
+        # Builder subcommands (share compilation/target option helpers)
+        # `build_run()` and `build_build()` returns Command instances
+        # that are defined with builder-style APIs (not Parsable structs).
+        cmd.add_subcommand(build_run())
+        cmd.add_subcommand(build_build())
+        # Declarative subcommands
+        var pkg = JomoPackage.to_command()
+        pkg.help_on_no_arguments()
+        cmd.add_subcommand(pkg^)
+        var fmt = JomoFormat.to_command()
+        fmt.help_on_no_arguments()
+        cmd.add_subcommand(fmt^)
+        var doc = JomoDoc.to_command()
+        doc.help_on_no_arguments()
+        cmd.add_subcommand(doc^)
 
     def run(self) raises:
         print("Jomo -- run a subcommand. Try: jomo --help")
 
 
 # =====================================================================
-# Subcommands (builder API — declarative subcommands are Phase 2)
+# Declarative subcommands: format, doc, package (Parsable structs)
 # =====================================================================
 
 
-def _shared_compilation_options(mut cmd: Command) raises:
+struct JomoFormat(Parsable):
+    """Format Mojo source files."""
+
+    var line_length: Option[
+        Int,
+        long="line-length",
+        short="l",
+        help="Max character line length",
+        default="80",
+        has_range=True,
+        range_min=1,
+        range_max=200,
+        value_name="INTEGER",
+        group="Format options",
+    ]
+    var quiet: Flag[
+        long="quiet",
+        short="q",
+        help="Disables non-error messages",
+        group="Diagnostic options",
+    ]
+    var source: Positional[
+        String,
+        help="Mojo source file to format",
+        required=True,
+        value_name="SOURCE",
+    ]
+
+    @staticmethod
+    def name() -> String:
+        return "format"
+
+    @staticmethod
+    def description() -> String:
+        return "Formats Mojo source files."
+
+    def run(self) raises:
+        print("Formatting:", self.source.value)
+        print("  line-length:", self.line_length.value)
+        if self.quiet.value:
+            print("  (quiet mode)")
+
+
+struct JomoDoc(Parsable):
+    """Compile docstrings from a Mojo file."""
+
+    var path: Positional[
+        String,
+        help="Path to the Mojo source file",
+        required=True,
+        value_name="PATH",
+    ]
+    var output: Option[
+        String,
+        long="output",
+        short="o",
+        help="Output path for generated docs",
+        value_name="PATH",
+        group="Output options",
+    ]
+
+    @staticmethod
+    def name() -> String:
+        return "doc"
+
+    @staticmethod
+    def description() -> String:
+        return "Compiles docstrings from a Mojo file."
+
+    def run(self) raises:
+        print("Generating docs for:", self.path.value)
+        if self.output.value:
+            print("  output:", self.output.value)
+
+
+struct JomoPackage(Parsable):
+    """Compile a Mojo package."""
+
+    var path: Positional[
+        String,
+        help="Path to the package directory",
+        required=True,
+        value_name="PATH",
+    ]
+    var output: Option[
+        String,
+        long="output",
+        short="o",
+        help="Output path (.mojopkg)",
+        value_name="PATH",
+        group="Output options",
+    ]
+    var include_path: Option[
+        List[String],
+        long="include-path",
+        short="I",
+        help="Append to the module search path",
+        append=True,
+        value_name="PATH",
+    ]
+
+    @staticmethod
+    def name() -> String:
+        return "package"
+
+    @staticmethod
+    def description() -> String:
+        return "Compiles a Mojo package."
+
+    def run(self) raises:
+        print("Packaging:", self.path.value)
+        if self.output.value:
+            print("  output:", self.output.value)
+        for i in range(len(self.include_path.value)):
+            print("  include:", self.include_path.value[i])
+
+
+# =====================================================================
+# Builder subcommands: run, build (share compilation/target options)
+# =====================================================================
+
+
+def shared_compilation_options(mut cmd: Command) raises:
     """Add options shared by `run` and `build`."""
     cmd.add_argument(
         Argument("optimization-level", help="Optimization level (0-3)")
@@ -137,7 +270,7 @@ def _shared_compilation_options(mut cmd: Command) raises:
     )
 
 
-def _shared_target_options(mut cmd: Command) raises:
+def shared_target_options(mut cmd: Command) raises:
     """Add target options shared by `run` and `build`."""
     cmd.add_argument(
         Argument("target-triple", help="Compilation target triple")
@@ -159,10 +292,10 @@ def _shared_target_options(mut cmd: Command) raises:
     )
 
 
-def _build_run() raises -> Command:
+def build_run() raises -> Command:
     var cmd = Command("run", "Builds and executes a Mojo file.")
-    _shared_compilation_options(cmd)
-    _shared_target_options(cmd)
+    shared_compilation_options(cmd)
+    shared_target_options(cmd)
     cmd.add_argument(
         Argument("path", help="Path to the Mojo source file")
         .positional()
@@ -179,10 +312,10 @@ def _build_run() raises -> Command:
     return cmd^
 
 
-def _build_build() raises -> Command:
+def build_build() raises -> Command:
     var cmd = Command("build", "Builds an executable from a Mojo file.")
-    _shared_compilation_options(cmd)
-    _shared_target_options(cmd)
+    shared_compilation_options(cmd)
+    shared_target_options(cmd)
     cmd.add_argument(
         Argument("output", help="Output path for the executable")
         .long["output"]()
@@ -215,86 +348,13 @@ def _build_build() raises -> Command:
     return cmd^
 
 
-def _build_package() raises -> Command:
-    var cmd = Command("package", "Compiles a Mojo package.")
-    cmd.add_argument(
-        Argument("path", help="Path to the package directory")
-        .positional()
-        .required()
-        .value_name["PATH"]()
-    )
-    cmd.add_argument(
-        Argument("output", help="Output path (.mojopkg)")
-        .long["output"]()
-        .short["o"]()
-        .value_name["PATH"]()
-        .group["Output options"]()
-    )
-    cmd.add_argument(
-        Argument("include-path", help="Append to the module search path")
-        .long["include-path"]()
-        .short["I"]()
-        .append()
-        .value_name["PATH"]()
-    )
-    cmd.help_on_no_arguments()
-    return cmd^
-
-
-def _build_format() raises -> Command:
-    var cmd = Command("format", "Formats Mojo source files.")
-    cmd.add_argument(
-        Argument("line-length", help="Max character line length")
-        .long["line-length"]()
-        .short["l"]()
-        .default["80"]()
-        .range[1, 200]()
-        .value_name["INTEGER"]()
-        .group["Format options"]()
-    )
-    cmd.add_argument(
-        Argument("quiet", help="Disables non-error messages")
-        .long["quiet"]()
-        .short["q"]()
-        .flag()
-        .group["Diagnostic options"]()
-    )
-    cmd.add_argument(
-        Argument("source", help="Mojo source file to format")
-        .positional()
-        .required()
-        .value_name["SOURCE"]()
-    )
-    cmd.help_on_no_arguments()
-    return cmd^
-
-
-def _build_doc() raises -> Command:
-    var cmd = Command("doc", "Compiles docstrings from a Mojo file.")
-    cmd.add_argument(
-        Argument("path", help="Path to the Mojo source file")
-        .positional()
-        .required()
-        .value_name["PATH"]()
-    )
-    cmd.add_argument(
-        Argument("output", help="Output path for generated docs")
-        .long["output"]()
-        .short["o"]()
-        .value_name["PATH"]()
-        .group["Output options"]()
-    )
-    cmd.help_on_no_arguments()
-    return cmd^
-
-
 # =====================================================================
 # Entry point
 # =====================================================================
 
 
 def main() raises:
-    # Build the command tree: declarative root + builder subcommands.
+    # Build the command tree: declarative root + mixed subcommands.
     var cmd = to_command[Jomo]()
 
     # Parse argv.
@@ -303,8 +363,23 @@ def main() raises:
     # Populate the declarative root struct.
     var jomo = from_result[Jomo](result)
 
-    # Show what we got.
+    # Show verbosity if set.
     if jomo.verbose.value > 0:
         print("Verbosity level:", jomo.verbose.value)
 
-    result.print_summary()
+    # Dispatch subcommands.
+    if result.has_subcommand_result():
+        var sub = result.get_subcommand_result()
+
+        # Declarative subcommands — typed dispatch via from_result + run().
+        if result.subcommand == "format":
+            from_result[JomoFormat](sub).run()
+        elif result.subcommand == "doc":
+            from_result[JomoDoc](sub).run()
+        elif result.subcommand == "package":
+            from_result[JomoPackage](sub).run()
+        else:
+            # Builder subcommands (run, build) — use raw ParseResult.
+            sub.print_summary()
+    else:
+        jomo.run()

--- a/pixi.toml
+++ b/pixi.toml
@@ -38,7 +38,8 @@ test = """\
     && mojo run -I src -D ASSERT=all tests/test_completion.mojo \
     && mojo run -I src -D ASSERT=all tests/test_interactive.mojo < /dev/null \
     && mojo run -I src -D ASSERT=all tests/test_declarative.mojo \
-    && mojo run -I src -D ASSERT=all tests/test_hybrid.mojo"""
+    && mojo run -I src -D ASSERT=all tests/test_hybrid.mojo \
+    && mojo run -I src -D ASSERT=all tests/test_subcommands_declarative.mojo"""
 # NOTE: test_response_file.mojo is excluded — response file expansion
 # is temporarily disabled to work around a Mojo compiler deadlock
 # with -D ASSERT=all.  Re-enable when the compiler bug is fixed.
@@ -58,6 +59,7 @@ t = """\
   mojo run -I src -D ASSERT=all tests/test_interactive.mojo < /dev/null & pids+=($!); \
   mojo run -I src -D ASSERT=all tests/test_declarative.mojo &             pids+=($!); \
   mojo run -I src -D ASSERT=all tests/test_hybrid.mojo &                  pids+=($!); \
+  mojo run -I src -D ASSERT=all tests/test_subcommands_declarative.mojo & pids+=($!); \
   rc=0; for p in "${pids[@]}"; do wait "$p" || rc=1; done; exit $rc'
 """
 

--- a/tests/test_subcommands_declarative.mojo
+++ b/tests/test_subcommands_declarative.mojo
@@ -1,4 +1,4 @@
-"""Phase 3 declarative subcommand tests.
+"""Declarative subcommand tests.
 
 Tests Parsable structs as subcommand participants:
   - Flat subcommands: parent Parsable + Parsable children via subcommands() hook

--- a/tests/test_subcommands_declarative.mojo
+++ b/tests/test_subcommands_declarative.mojo
@@ -1,0 +1,662 @@
+"""Phase 3 declarative subcommand tests.
+
+Tests Parsable structs as subcommand participants:
+  - Flat subcommands: parent Parsable + Parsable children via subcommands() hook
+  - Nested subcommands (2+ levels) with mid-level flags
+  - Root customization + dual return (typed Self + raw ParseResult)
+  - run() dispatch pattern for leaf command execution
+  - from_result[Child]() write-back from subcommand ParseResult
+
+Note: from_command(), parse_split(), and from_command_split() call
+cmd.parse() which reads sys.argv(), so they cannot be exercised in
+unit tests with synthetic argument lists.  The testable equivalents
+(to_command + parse_arguments + from_result) exercise identical logic.
+"""
+
+from std.testing import assert_true, assert_false, assert_equal, TestSuite
+
+from argmojo import (
+    Argument,
+    Command,
+    Parsable,
+    Option,
+    Flag,
+    Positional,
+    Count,
+    to_command,
+    parse_args,
+    from_result,
+)
+
+
+# =====================================================================
+# Section 1: Flat subcommand structs
+# =====================================================================
+
+
+struct SearchCmd(Parsable):
+    """Declarative child: search subcommand."""
+
+    var pattern: Positional[String, help="Search pattern", required=True]
+    var case_sensitive: Flag[long="case-sensitive", help="Case sensitive"]
+
+    @staticmethod
+    def name() -> String:
+        return "search"
+
+    @staticmethod
+    def description() -> String:
+        return "Search for patterns"
+
+    def run(self) raises:
+        """Verify we can read parsed fields."""
+        if not self.pattern.value:
+            raise Error("No pattern provided")
+
+
+struct ListCmd(Parsable):
+    """Declarative child: list subcommand."""
+
+    var all: Flag[long="all", short="a", help="Show all items"]
+    var format: Option[
+        String, long="format", short="f", help="Output format", default="table"
+    ]
+
+    @staticmethod
+    def name() -> String:
+        return "list"
+
+    @staticmethod
+    def description() -> String:
+        return "List items"
+
+
+struct AppRoot(Parsable):
+    """Declarative root with two Parsable child subcommands."""
+
+    var verbose: Flag[short="v", help="Verbose output"]
+    var config: Option[String, long="config", short="c", help="Config file"]
+
+    @staticmethod
+    def name() -> String:
+        return "app"
+
+    @staticmethod
+    def description() -> String:
+        return "My CLI application"
+
+    @staticmethod
+    def subcommands(mut cmd: Command) raises:
+        cmd.add_subcommand(SearchCmd.to_command())
+        cmd.add_subcommand(ListCmd.to_command())
+
+
+# =====================================================================
+# Section 2: Nested subcommand structs (2+ levels)
+# =====================================================================
+
+
+struct RemoteAddCmd(Parsable):
+    """Leaf: git remote add <name> <url>."""
+
+    var rname: Positional[String, help="Remote name", required=True]
+    var url: Positional[String, help="Remote URL", required=True]
+    var fetch: Flag[long="fetch", short="f", help="Fetch after adding"]
+
+    @staticmethod
+    def name() -> String:
+        return "add"
+
+    @staticmethod
+    def description() -> String:
+        return "Add a remote"
+
+    def run(self) raises:
+        if not self.rname.value:
+            raise Error("No remote name")
+        if not self.url.value:
+            raise Error("No remote URL")
+
+
+struct RemoteRemoveCmd(Parsable):
+    """Leaf: git remote remove <name>."""
+
+    var rname: Positional[String, help="Remote name", required=True]
+    var force: Flag[long="force", help="Force removal"]
+
+    @staticmethod
+    def name() -> String:
+        return "remove"
+
+    @staticmethod
+    def description() -> String:
+        return "Remove a remote"
+
+
+struct RemoteCmd(Parsable):
+    """Mid-level: git remote [--verbose] <add|remove>."""
+
+    var verbose: Flag[long="verbose", short="v", help="Be verbose"]
+
+    @staticmethod
+    def name() -> String:
+        return "remote"
+
+    @staticmethod
+    def description() -> String:
+        return "Manage remotes"
+
+    @staticmethod
+    def subcommands(mut cmd: Command) raises:
+        cmd.add_subcommand(RemoteAddCmd.to_command())
+        cmd.add_subcommand(RemoteRemoveCmd.to_command())
+
+
+struct GitApp(Parsable):
+    """Root: git [--verbose] <remote>."""
+
+    var verbose: Flag[short="v", help="Verbose"]
+
+    @staticmethod
+    def name() -> String:
+        return "git"
+
+    @staticmethod
+    def description() -> String:
+        return "Git-like tool"
+
+    @staticmethod
+    def subcommands(mut cmd: Command) raises:
+        cmd.add_subcommand(RemoteCmd.to_command())
+
+
+# =====================================================================
+# Section 3: run() dispatch struct
+# =====================================================================
+
+
+struct RunTestRoot(Parsable):
+    """Root command whose run() is a no-op."""
+
+    var debug: Flag[long="debug", short="d", help="Debug mode"]
+
+    @staticmethod
+    def name() -> String:
+        return "runner"
+
+    @staticmethod
+    def description() -> String:
+        return "Run-dispatch test"
+
+    @staticmethod
+    def subcommands(mut cmd: Command) raises:
+        cmd.add_subcommand(RunLeafCmd.to_command())
+
+    def run(self) raises:
+        """Root run does nothing (like printing help)."""
+        pass
+
+
+struct RunLeafCmd(Parsable):
+    """Leaf whose run() validates a parsed field."""
+
+    var target: Positional[String, help="Build target", required=True]
+    var release: Flag[long="release", short="r", help="Release mode"]
+
+    @staticmethod
+    def name() -> String:
+        return "build"
+
+    @staticmethod
+    def description() -> String:
+        return "Build a target"
+
+    def run(self) raises:
+        """Verifiable: raises if target is empty."""
+        if not self.target.value:
+            raise Error("target must not be empty")
+
+
+# =====================================================================
+# Section 1 Tests: Flat declarative subcommands
+# =====================================================================
+
+
+def test_flat_dispatch_search() raises:
+    """Dispatch to 'search' subcommand with root flag."""
+    var cmd = AppRoot.to_command()
+    var args: List[String] = [
+        "app",
+        "--verbose",
+        "search",
+        "--case-sensitive",
+        "hello",
+    ]
+    var result = cmd.parse_arguments(args)
+    var root = from_result[AppRoot](result)
+
+    assert_true(root.verbose.value)
+    assert_equal(result.subcommand, "search")
+    assert_true(result.has_subcommand_result())
+
+    var sub = result.get_subcommand_result()
+    var search = from_result[SearchCmd](sub)
+    assert_equal(search.pattern.value, "hello")
+    assert_true(search.case_sensitive.value)
+
+
+def test_flat_dispatch_list() raises:
+    """Dispatch to 'list' subcommand with its own flags."""
+    var cmd = AppRoot.to_command()
+    var args: List[String] = ["app", "list", "--all", "-f", "json"]
+    var result = cmd.parse_arguments(args)
+
+    assert_equal(result.subcommand, "list")
+    var sub = result.get_subcommand_result()
+    var lst = from_result[ListCmd](sub)
+    assert_true(lst.all.value)
+    assert_equal(lst.format.value, "json")
+
+
+def test_flat_dispatch_list_default_format() raises:
+    """List subcommand with default format value."""
+    var cmd = AppRoot.to_command()
+    var args: List[String] = ["app", "list"]
+    var result = cmd.parse_arguments(args)
+
+    assert_equal(result.subcommand, "list")
+    var sub = result.get_subcommand_result()
+    var lst = from_result[ListCmd](sub)
+    assert_false(lst.all.value)
+    assert_equal(lst.format.value, "table")
+
+
+def test_flat_root_only_no_subcommand() raises:
+    """Root flags only, no subcommand dispatched."""
+    var cmd = AppRoot.to_command()
+    var args: List[String] = ["app", "--verbose", "-c", "myconfig.toml"]
+    var result = cmd.parse_arguments(args)
+    var root = from_result[AppRoot](result)
+
+    assert_true(root.verbose.value)
+    assert_equal(root.config.value, "myconfig.toml")
+    assert_equal(result.subcommand, "")
+    assert_false(result.has_subcommand_result())
+
+
+def test_flat_root_config_with_search() raises:
+    """Root config option + search subcommand."""
+    var cmd = AppRoot.to_command()
+    var args: List[String] = ["app", "-c", "prod.toml", "search", "pattern"]
+    var result = cmd.parse_arguments(args)
+    var root = from_result[AppRoot](result)
+
+    assert_equal(root.config.value, "prod.toml")
+    assert_equal(result.subcommand, "search")
+    var sub = result.get_subcommand_result()
+    var search = from_result[SearchCmd](sub)
+    assert_equal(search.pattern.value, "pattern")
+
+
+def test_flat_free_function_to_command() raises:
+    """Use free function to_command[AppRoot]() instead of AppRoot.to_command().
+    """
+    var cmd = to_command[AppRoot]()
+    var args: List[String] = ["app", "search", "test"]
+    var result = cmd.parse_arguments(args)
+
+    assert_equal(result.subcommand, "search")
+    var sub = result.get_subcommand_result()
+    var search = from_result[SearchCmd](sub)
+    assert_equal(search.pattern.value, "test")
+
+
+# =====================================================================
+# Section 2 Tests: Nested subcommands (2+ levels)
+# =====================================================================
+
+
+def test_nested_remote_add() raises:
+    """Nested: git --verbose remote add origin https://example.com."""
+    var cmd = GitApp.to_command()
+    var args: List[String] = [
+        "git",
+        "--verbose",
+        "remote",
+        "add",
+        "origin",
+        "https://example.com",
+    ]
+    var result = cmd.parse_arguments(args)
+    var root = from_result[GitApp](result)
+
+    assert_true(root.verbose.value)
+    assert_equal(result.subcommand, "remote")
+    assert_true(result.has_subcommand_result())
+
+    # Level 2: remote
+    var remote_result = result.get_subcommand_result()
+    var remote = from_result[RemoteCmd](remote_result)
+    assert_false(remote.verbose.value)  # remote's own verbose not set
+    assert_equal(remote_result.subcommand, "add")
+    assert_true(remote_result.has_subcommand_result())
+
+    # Level 3: add
+    var add_result = remote_result.get_subcommand_result()
+    var add_cmd = from_result[RemoteAddCmd](add_result)
+    assert_equal(add_cmd.rname.value, "origin")
+    assert_equal(add_cmd.url.value, "https://example.com")
+    assert_false(add_cmd.fetch.value)
+
+
+def test_nested_remote_add_with_fetch() raises:
+    """Nested: git remote add --fetch origin https://example.com."""
+    var cmd = GitApp.to_command()
+    var args: List[String] = [
+        "git",
+        "remote",
+        "add",
+        "--fetch",
+        "origin",
+        "https://example.com",
+    ]
+    var result = cmd.parse_arguments(args)
+
+    var remote_result = result.get_subcommand_result()
+    var add_result = remote_result.get_subcommand_result()
+    var add_cmd = from_result[RemoteAddCmd](add_result)
+    assert_equal(add_cmd.rname.value, "origin")
+    assert_equal(add_cmd.url.value, "https://example.com")
+    assert_true(add_cmd.fetch.value)
+
+
+def test_nested_mid_level_flag() raises:
+    """Mid-level flag: git remote --verbose add origin https://example.com."""
+    var cmd = GitApp.to_command()
+    var args: List[String] = [
+        "git",
+        "remote",
+        "--verbose",
+        "add",
+        "origin",
+        "https://example.com",
+    ]
+    var result = cmd.parse_arguments(args)
+
+    var remote_result = result.get_subcommand_result()
+    var remote = from_result[RemoteCmd](remote_result)
+    assert_true(remote.verbose.value)  # mid-level flag set
+
+    var add_result = remote_result.get_subcommand_result()
+    var add_cmd = from_result[RemoteAddCmd](add_result)
+    assert_equal(add_cmd.rname.value, "origin")
+
+
+def test_nested_remote_remove() raises:
+    """Nested: git remote remove --force origin."""
+    var cmd = GitApp.to_command()
+    var args: List[String] = ["git", "remote", "remove", "--force", "origin"]
+    var result = cmd.parse_arguments(args)
+
+    assert_equal(result.subcommand, "remote")
+    var remote_result = result.get_subcommand_result()
+    assert_equal(remote_result.subcommand, "remove")
+
+    var rm_result = remote_result.get_subcommand_result()
+    var rm_cmd = from_result[RemoteRemoveCmd](rm_result)
+    assert_equal(rm_cmd.rname.value, "origin")
+    assert_true(rm_cmd.force.value)
+
+
+def test_nested_remote_remove_no_force() raises:
+    """Nested: git remote remove origin (no --force)."""
+    var cmd = GitApp.to_command()
+    var args: List[String] = ["git", "remote", "remove", "origin"]
+    var result = cmd.parse_arguments(args)
+
+    var remote_result = result.get_subcommand_result()
+    var rm_result = remote_result.get_subcommand_result()
+    var rm_cmd = from_result[RemoteRemoveCmd](rm_result)
+    assert_equal(rm_cmd.rname.value, "origin")
+    assert_false(rm_cmd.force.value)
+
+
+def test_nested_root_and_mid_verbose() raises:
+    """Both levels verbose: git -v remote -v add origin https://example.com."""
+    var cmd = GitApp.to_command()
+    var args: List[String] = [
+        "git",
+        "-v",
+        "remote",
+        "-v",
+        "add",
+        "origin",
+        "https://example.com",
+    ]
+    var result = cmd.parse_arguments(args)
+    var root = from_result[GitApp](result)
+    assert_true(root.verbose.value)
+
+    var remote_result = result.get_subcommand_result()
+    var remote = from_result[RemoteCmd](remote_result)
+    assert_true(remote.verbose.value)
+
+    var add_result = remote_result.get_subcommand_result()
+    var add_cmd = from_result[RemoteAddCmd](add_result)
+    assert_equal(add_cmd.rname.value, "origin")
+
+
+# =====================================================================
+# Section 3 Tests: Root customization + dual return
+# =====================================================================
+
+
+def test_root_customization_builder_child() raises:
+    """Root to_command() + add extra builder subcommand + parse."""
+    var cmd = AppRoot.to_command()
+    # Add an extra builder-only subcommand beyond the declarative ones
+    var info = Command("info", "Show information")
+    info.add_argument(Argument("topic", help="Info topic").positional())
+    cmd.add_subcommand(info^)
+
+    var args: List[String] = ["app", "info", "version"]
+    var result = cmd.parse_arguments(args)
+
+    assert_equal(result.subcommand, "info")
+    var sub = result.get_subcommand_result()
+    assert_equal(sub.get_string("topic"), "version")
+
+
+def test_dual_return_root_and_subcommand() raises:
+    """Simulate parse_split: get typed root + raw result for dispatch."""
+    var cmd = AppRoot.to_command()
+    var args: List[String] = ["app", "--verbose", "search", "hello"]
+    var result = cmd.parse_arguments(args)
+
+    # Typed root
+    var root = from_result[AppRoot](result)
+    assert_true(root.verbose.value)
+
+    # Raw result for subcommand dispatch
+    assert_equal(result.subcommand, "search")
+    assert_true(result.has_subcommand_result())
+    var sub = result.get_subcommand_result()
+
+    # Typed child from raw sub-result
+    var search = from_result[SearchCmd](sub)
+    assert_equal(search.pattern.value, "hello")
+
+
+def test_dual_return_nested() raises:
+    """Dual return through nested subcommands."""
+    var cmd = GitApp.to_command()
+    var args: List[String] = [
+        "git",
+        "-v",
+        "remote",
+        "-v",
+        "add",
+        "--fetch",
+        "origin",
+        "https://x.com",
+    ]
+    var result = cmd.parse_arguments(args)
+
+    # Root typed
+    var root = from_result[GitApp](result)
+    assert_true(root.verbose.value)
+
+    # Mid-level typed
+    var remote_result = result.get_subcommand_result()
+    var remote = from_result[RemoteCmd](remote_result)
+    assert_true(remote.verbose.value)
+
+    # Leaf typed
+    var add_result = remote_result.get_subcommand_result()
+    var add_cmd = from_result[RemoteAddCmd](add_result)
+    assert_equal(add_cmd.rname.value, "origin")
+    assert_equal(add_cmd.url.value, "https://x.com")
+    assert_true(add_cmd.fetch.value)
+
+
+def test_from_result_child_only() raises:
+    """Extract child directly from sub-result via from_result[ChildParsable]."""
+    var cmd = AppRoot.to_command()
+    var args: List[String] = ["app", "list", "--all", "-f", "csv"]
+    var result = cmd.parse_arguments(args)
+
+    var sub = result.get_subcommand_result()
+    var lst = from_result[ListCmd](sub)
+    assert_true(lst.all.value)
+    assert_equal(lst.format.value, "csv")
+
+
+# =====================================================================
+# Section 4 Tests: run() dispatch pattern
+# =====================================================================
+
+
+def test_run_default_noop() raises:
+    """Default run() does nothing and does not raise."""
+    var cmd = AppRoot.to_command()
+    var args: List[String] = ["app", "--verbose"]
+    var result = cmd.parse_arguments(args)
+    var root = from_result[AppRoot](result)
+    root.run()  # Should complete without error
+
+
+def test_run_leaf_reads_fields() raises:
+    """Leaf run() can read parsed fields."""
+    var cmd = RunTestRoot.to_command()
+    var args: List[String] = ["runner", "build", "--release", "myapp"]
+    var result = cmd.parse_arguments(args)
+
+    var sub = result.get_subcommand_result()
+    var leaf = from_result[RunLeafCmd](sub)
+    assert_equal(leaf.target.value, "myapp")
+    assert_true(leaf.release.value)
+    leaf.run()  # Should not raise — target is non-empty
+
+
+def test_run_dispatch_full_pattern() raises:
+    """Full dispatch: parse root → check subcommand → from_result → run().
+
+    This is the canonical pattern for declarative subcommand dispatch:
+    1. Build root Command via to_command()
+    2. Parse arguments
+    3. Extract root typed fields via from_result
+    4. Check result.subcommand
+    5. Extract child typed fields via from_result on sub-result
+    6. Call child.run()
+    """
+    var cmd = RunTestRoot.to_command()
+    var args: List[String] = [
+        "runner",
+        "--debug",
+        "build",
+        "--release",
+        "myapp",
+    ]
+    var result = cmd.parse_arguments(args)
+
+    # Step 3: root typed
+    var root = from_result[RunTestRoot](result)
+    assert_true(root.debug.value)
+
+    # Step 4-5: dispatch
+    assert_equal(result.subcommand, "build")
+    var sub = result.get_subcommand_result()
+    var build = from_result[RunLeafCmd](sub)
+
+    # Step 6: run
+    assert_equal(build.target.value, "myapp")
+    assert_true(build.release.value)
+    build.run()  # Validates target is non-empty
+
+
+def test_run_nested_dispatch() raises:
+    """Nested dispatch: root → mid → leaf.run()."""
+    var cmd = GitApp.to_command()
+    var args: List[String] = [
+        "git",
+        "remote",
+        "add",
+        "origin",
+        "https://example.com",
+    ]
+    var result = cmd.parse_arguments(args)
+
+    # Navigate to leaf
+    var remote_result = result.get_subcommand_result()
+    var add_result = remote_result.get_subcommand_result()
+    var add_cmd = from_result[RemoteAddCmd](add_result)
+
+    # Leaf run() validates rname and url are non-empty
+    add_cmd.run()
+
+
+def test_run_root_noop_when_subcommand_dispatched() raises:
+    """Root run() is no-op even when a subcommand was dispatched."""
+    var cmd = RunTestRoot.to_command()
+    var args: List[String] = ["runner", "--debug", "build", "myapp"]
+    var result = cmd.parse_arguments(args)
+
+    var root = from_result[RunTestRoot](result)
+    root.run()  # Root's run() is a no-op, doesn't interfere
+
+
+# =====================================================================
+# Section 5 Tests: Declarative child with parse_args free function
+# =====================================================================
+
+
+def test_parse_args_with_subcommands() raises:
+    """Free function parse_args works when subcommands are registered."""
+    var args: List[String] = ["app", "-v", "search", "hello"]
+    var root = parse_args[AppRoot](args)
+    assert_true(root.verbose.value)
+    # parse_args returns only typed root — subcommand info is in raw result
+    # (This tests that parse_args doesn't crash with subcommands)
+
+
+def test_parse_args_nested() raises:
+    """Free function parse_args works through nested subcommand dispatch."""
+    var args: List[String] = [
+        "git",
+        "-v",
+        "remote",
+        "add",
+        "origin",
+        "https://x.com",
+    ]
+    var root = parse_args[GitApp](args)
+    assert_true(root.verbose.value)
+
+
+# =====================================================================
+# Entry point
+# =====================================================================
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
This PR adds coverage for declarative subcommand behavior in ArgMojo’s `Parsable` API, and updates supporting docs/examples to reflect declarative subcommand structs and typed dispatch patterns.

**Changes:**
- Add a new test module covering flat + nested declarative subcommands, dual-return dispatch, and `run()` dispatch patterns.
- Wire the new test module into `pixi` serial and parallel test tasks.
- Update `examples/jomo.mojo` and planning docs to reflect current declarative subcommand + `from_result[T]()` dispatch guidance.