### PR TITLE
[core][declarative] Consolidate Parsable trait functions into methods

### DIFF
--- a/docs/declarative_api_planning.md
+++ b/docs/declarative_api_planning.md
@@ -393,7 +393,7 @@ trait Parsable(Defaultable, Movable):
         This is the primary entry point."""
         var cmd = Self.to_command()
         var result = cmd.parse()
-        return _from_result[Self](result)
+        return Self.from_result(result)
 
     # ── Hybrid: to_command → customise → from_command ──
 
@@ -406,7 +406,7 @@ trait Parsable(Defaultable, Movable):
         if not cmd_name:
             cmd_name = String("command")
         var cmd = Command(cmd_name, Self.description(), version=Self.version())
-        _reflect_and_register[Self](cmd)
+        Self.register_into_command(cmd)
         Self.subcommands(cmd)   # hook: register child commands
         return cmd^
 
@@ -415,7 +415,7 @@ trait Parsable(Defaultable, Movable):
         """Parse from a pre-configured Command (hybrid mode).
         Use after to_command() + builder customisations."""
         var result = cmd.parse()
-        return _from_result[Self](result)
+        return Self.from_result(result)
 
     # ── Dual return ──
 
@@ -425,7 +425,7 @@ trait Parsable(Defaultable, Movable):
         The struct covers declarative fields; ParseResult covers everything."""
         var cmd = Self.to_command()
         var result = cmd.parse()
-        var typed = _from_result[Self](result)
+        var typed = Self.from_result(result)
         return Tuple[Self, ParseResult](typed^, result^)
 
     @staticmethod
@@ -435,7 +435,7 @@ trait Parsable(Defaultable, Movable):
         the typed Self gives root-level flags, ParseResult gives
         subcommand name + fields for from_result() write-back."""
         var result = cmd.parse()
-        var typed = _from_result[Self](result)
+        var typed = Self.from_result(result)
         return Tuple[Self, ParseResult](typed^, result^)
 
     # ── Subcommand write-back ──
@@ -445,7 +445,7 @@ trait Parsable(Defaultable, Movable):
         """Write-back from an existing ParseResult without re-parsing.
         Used for subcommand dispatch: the parent already parsed,
         this extracts the matched subcommand's fields into Self."""
-        return _from_result[Self](result)
+        ...  # reflection logic inlined (see implementation)
 
     # ── Testing helper ──
 
@@ -454,7 +454,7 @@ trait Parsable(Defaultable, Movable):
         """Parse from an explicit arg list (useful for testing)."""
         var cmd = Self.to_command()
         var result = cmd.parse_arguments(args)
-        return _from_result[Self](result)
+        return Self.from_result(result)
 
     # ── Subcommand tree assembly ──
 
@@ -494,63 +494,14 @@ struct MyArgs(Parsable):
 
 Everything else (`parse()`, `to_command()`, `from_command()`, `from_command_split()`, `from_result()`, `parse_split()`, `parse_args()`, `validate()`, `run()`, `subcommands()`, `version()`, `name()`) comes from trait defaults.
 
-### 4.3 Internal Free Functions
+### 4.3 Implementation Notes
 
-The trait default methods delegate to module-level free functions for the heavy lifting:
+All reflection logic lives directly inside the `Parsable` trait's default methods — there are **no standalone helper functions**:
 
-```mojo
-def _reflect_and_register[T: Parsable](mut cmd: Command) raises:
-    """Reflect over T's fields and register Arguments on cmd."""
-    comptime field_count = struct_field_count[T]()
-    comptime field_names = struct_field_names[T]()
-    comptime field_types = struct_field_types[T]()
+- **`register_into_command(mut cmd)`** — iterates Self's fields via `comptime for` + `struct_field_types[Self]()`, downcasts each `ArgumentLike`-conforming field, and calls `field.add_to_command(name, cmd)`. Called by `to_command()`.
+- **`from_result(result)`** — creates `Self()`, iterates fields, downcasts each `ArgumentLike`-conforming field, and calls `field.read_from_result(name, result)`. Called by `parse()`, `parse_args()`, `from_command()`, `parse_split()`, `from_command_split()`, and directly by users for subcommand dispatch.
 
-    comptime for idx in range(field_count):
-        comptime fname = field_names[idx]
-        comptime ftype = field_types[idx]
-
-        # Dispatch based on wrapper type
-        comptime if _is_option_type(ftype):
-            _register_option(cmd, fname, ftype)
-        elif _is_flag_type(ftype):
-            _register_flag(cmd, fname, ftype)
-        elif _is_positional_type(ftype):
-            _register_positional(cmd, fname, ftype)
-        elif _is_count_type(ftype):
-            _register_count(cmd, fname, ftype)
-        else:
-            # Bare type: treat as named option with field name as long name
-            _register_bare(cmd, fname, ftype)
-
-def _from_result[T: Parsable](result: ParseResult) raises -> T:
-    """Write ParseResult values back into a T instance."""
-    var out = T()
-    comptime field_count = struct_field_count[T]()
-    comptime field_names = struct_field_names[T]()
-    comptime field_types = struct_field_types[T]()
-
-    comptime for idx in range(field_count):
-        comptime fname = field_names[idx]
-        comptime ftype = field_types[idx]
-
-        comptime if _is_flag_type(ftype):
-            ref field = __struct_field_ref(idx, out)
-            field.value = result.get_flag(String(fname))
-        elif _is_count_type(ftype):
-            ref field = __struct_field_ref(idx, out)
-            field.value = result.get_count(String(fname))
-        elif _is_positional_type(ftype):
-            ref field = __struct_field_ref(idx, out)
-            _write_positional_value(field, fname, result)
-        elif _is_option_type(ftype):
-            ref field = __struct_field_ref(idx, out)
-            _write_option_value(field, fname, result)
-        else:
-            ref field = __struct_field_ref(idx, out)
-            _write_bare_value(field, fname, result)
-
-    return out
-```
+This design keeps `parsable.mojo` self-contained: the trait IS the entire declarative API.
 
 ### 4.4 Field Initialization (Auto-Init)
 
@@ -1020,7 +971,7 @@ The dual-return enables a practical workflow:
 
 **What I'm adding**: Since all wrapper metadata lives in compile-time parameters (`StringLiteral`, `Bool`, `Int`), the declarative layer can validate the **entire schema at compile time** using `comptime assert`. Your program won't even compile if the schema is invalid.
 
-Concrete checks in `_reflect_and_register[]`:
+Concrete checks in `register_into_command()`:
 
 ```mojo
 @parameter
@@ -1076,7 +1027,7 @@ struct MyArgs(Parsable):
     var yaml: Flag[long="yaml", conflicts_with="json"]
 ```
 
-**Translation in `_reflect_and_register()`**:
+**Translation in `register_into_command()`**:
 
 | Declarative parameter        | Builder call generated                                   |
 | ---------------------------- | -------------------------------------------------------- |
@@ -1086,14 +1037,14 @@ struct MyArgs(Parsable):
 **Compile-time name validation**: Since `depends_on` and `conflicts_with` are `StringLiteral` parameters, and all field names are known at compile time via `struct_field_names`, I can verify at compile time that every referenced name actually exists in the struct:
 
 ```mojo
-# In _reflect_and_register(), at comptime:
+# In register_into_command(), at comptime:
 # depends_on="password" → verify "password" is in struct_field_names[T]()
 # If not → comptime assert failure with a clear error message
 ```
 
 This catches typos like `depends_on="passwrod"` at compile time — something no other CLI library can do.
 
-**Symmetry note**: `depends_on` is symmetric by convention (if A depends on B, B depends on A). A single `depends_on="password"` on `username` generates `required_together(["username", "password"])`. If both sides declare it, deduplication in `_reflect_and_register()` prevents double-registration.
+**Symmetry note**: `depends_on` is symmetric by convention (if A depends on B, B depends on A). A single `depends_on="password"` on `username` generates `required_together(["username", "password"])`. If both sides declare it, deduplication in `register_into_command()` prevents double-registration.
 
 ### 6.5 Innovation #5: Compile-Time Derived Completions from `choices`
 
@@ -1117,7 +1068,7 @@ struct MyArgs(Parsable):
     # ^ completions for --format automatically include "json", "yaml", "csv"
 ```
 
-**How it works**: During `_reflect_and_register()`, when a field has a non-empty `choices` parameter, the generated completion script automatically includes those values as completions for that argument's value. The builder's `generate_completion["fish"]()` / `generate_completion["zsh"]()` / `generate_completion["bash"]()` already reads `_choice_values` — the declarative layer simply ensures they're populated.
+**How it works**: During `register_into_command()`, when a field has a non-empty `choices` parameter, the generated completion script automatically includes those values as completions for that argument's value. The builder's `generate_completion["fish"]()` / `generate_completion["zsh"]()` / `generate_completion["bash"]()` already reads `_choice_values` — the declarative layer simply ensures they're populated.
 
 **Compile-time generation**: Since all choices are `StringLiteral` values known at compile time, the entire completion script could be generated as a compile-time constant:
 
@@ -1308,9 +1259,8 @@ I think this is the right call — these features describe *relationships betwee
 - [x] Implement `Positional`, `Option`, `Flag`, `Count` wrapper structs — in `argument_wrappers.mojo`
 - [x] Implement `ArgumentLike` trait with `add_to_command()` and `read_from_result()` methods
 - [x] Implement `Parsable` trait with default methods (`description`, `version`, `name`, `subcommands`, `run`)
-- [x] Implement convenience functions as free functions: `to_command`, `parse`, `parse_args`, `parse_split`, `from_command`, `from_command_split`, `from_result`
-- [x] Implement `_reflect_and_register[T]()` — reflection to Command builder calls
-- [x] Implement `_from_result[T]()` — ParseResult to struct write-back
+- [x] ~~Implement convenience functions as free functions: `to_command`, `parse`, `parse_args`, `parse_split`, `from_command`, `from_command_split`, `from_result`~~ — removed; these duplicated the Parsable trait static methods. All public access is now via `T.to_command()`, `T.parse()`, `T.parse_args()`, etc.
+- [x] ~~Implement `_reflect_and_register[T]()` and `_from_result[T]()`~~ — merged into trait methods `register_into_command()` and `from_result()`. No standalone helper functions remain.
 - [x] Auto-naming convention (underscore → hyphen)
 - [x] 4 passing tests: `test_to_command`, `test_parse_args`, `test_from_result`, `test_auto_naming`
 - [x] `jomo.mojo` demo — Mojo CLI lookalike using declarative root struct + builder subcommands
@@ -1321,7 +1271,7 @@ I think this is the right call — these features describe *relationships betwee
 - [x] Test dual-return pattern (typed struct + raw ParseResult from same parse)
 - [x] Test: `mutually_exclusive()` via `to_command()`
 - [x] Test: extra builder args accessible via ParseResult + `from_result()`
-- [x] Test free functions: `to_command[T]()`, `parse_args[T]()`, `from_result[T]()`
+- [x] ~~Test free functions: `to_command[T]()`, `parse_args[T]()`, `from_result[T]()`~~ — converted to trait static method tests (`T.to_command()`, `T.parse_args()`, `T.from_result()`)
 - [x] Document the `configure()` free function pattern (via test helper + test)
 - Note: `from_command()`, `parse_split()`, `from_command_split()` call `cmd.parse()` (reads `sys.argv()`), so they cannot be unit-tested with synthetic args. Their logic is identical to `to_command()` + `parse_arguments()` + `from_result()` which **is** tested.
 
@@ -1329,13 +1279,13 @@ I think this is the right call — these features describe *relationships betwee
 
 - [x] Implement `subcommands(mut cmd)` hook on `Parsable` trait + auto-call in `to_command()`
 - [x] Implement `run(self)` on `Parsable` trait (default no-op)
-- [x] Implement `from_command_split()` as free function
-- [x] Implement `from_result()` as free function (public write-back)
+- [x] Implement `from_command_split()` as trait static method
+- [x] Implement `from_result()` as trait static method (public write-back)
 - [x] Test: flat subcommands with `subcommands()` hook (6 tests in `test_subcommands_declarative.mojo`)
 - [x] Test: nested subcommands (2+ levels) with mid-level flags and recursive `subcommands()` (6 tests)
 - [x] Test: root-level customization via `to_command()` + dual return + `from_result()` (4 tests)
 - [x] Test: `run()` dispatch pattern — root no-op, leaf field access, full dispatch, nested dispatch (5 tests)
-- [x] Test: `parse_args` free function with subcommands (2 tests)
+- [x] Test: `parse_args` trait static method with subcommands (2 tests)
 
 ### Phase 4: Further enhancements
 
@@ -1347,7 +1297,7 @@ I think this is the right call — these features describe *relationships betwee
   - [ ] Choices vs default consistency
 - [ ] Add `depends_on`/`conflicts_with` parameters to `Option` and `Flag` (§6.4)
   - [ ] Compile-time validation of referenced field names
-  - [ ] Translation to builder `required_together()`/`mutually_exclusive()` in `_reflect_and_register()`
+  - [ ] Translation to builder `required_together()`/`mutually_exclusive()` in `register_into_command()`
 - [ ] Auto-derive completions from `choices` parameters (§6.5)
   - [ ] Ensure choices flow to `generate_completion` output
   - [ ] Explore compile-time completion script generation

--- a/examples/jomo.mojo
+++ b/examples/jomo.mojo
@@ -16,7 +16,7 @@ Showcases:
   - Builder subcommands (``run``, ``build``) for shared compilation options
   - Hybrid: declarative root + both declarative and builder children
   - ``subcommands()`` hook with ``ChildParsable.to_command()``
-  - ``from_result[T]()`` write-back for typed subcommand dispatch
+  - ``T.from_result()`` write-back for typed subcommand dispatch
   - ``run()`` dispatch pattern
 
 Try these (build first with: pixi run mojo build -I src -o jomo examples/jomo.mojo):
@@ -42,8 +42,6 @@ from argmojo import (
     Flag,
     Positional,
     Count,
-    to_command,
-    from_result,
 )
 
 
@@ -355,13 +353,13 @@ def build_build() raises -> Command:
 
 def main() raises:
     # Build the command tree: declarative root + mixed subcommands.
-    var cmd = to_command[Jomo]()
+    var cmd = Jomo.to_command()
 
     # Parse argv.
     var result = cmd.parse()
 
     # Populate the declarative root struct.
-    var jomo = from_result[Jomo](result)
+    var jomo = Jomo.from_result(result)
 
     # Show verbosity if set.
     if jomo.verbose.value > 0:
@@ -373,11 +371,11 @@ def main() raises:
 
         # Declarative subcommands — typed dispatch via from_result + run().
         if result.subcommand == "format":
-            from_result[JomoFormat](sub).run()
+            JomoFormat.from_result(sub).run()
         elif result.subcommand == "doc":
-            from_result[JomoDoc](sub).run()
+            JomoDoc.from_result(sub).run()
         elif result.subcommand == "package":
-            from_result[JomoPackage](sub).run()
+            JomoPackage.from_result(sub).run()
         else:
             # Builder subcommands (run, build) — use raw ParseResult.
             sub.print_summary()

--- a/src/argmojo/__init__.mojo
+++ b/src/argmojo/__init__.mojo
@@ -6,14 +6,5 @@ from .command import Command
 from .parse_result import ParseResult
 
 # Declarative API
-from .parsable import (
-    Parsable,
-    to_command,
-    parse,
-    parse_args,
-    parse_split,
-    from_command,
-    from_command_split,
-    from_result,
-)
+from .parsable import Parsable
 from .argument_wrappers import Option, Flag, Positional, Count, ArgumentLike

--- a/src/argmojo/argument_wrappers.mojo
+++ b/src/argmojo/argument_wrappers.mojo
@@ -3,7 +3,7 @@
 Four wrapper structs that encode argument metadata as compile-time
 parameters.  Each wraps a runtime ``value`` field and carries all
 configuration (long name, short name, help text, choices, ...) in its
-type signature so that reflection-based ``_reflect_and_register`` can
+type signature so that reflection-based ``register_into_command`` can
 translate them to builder calls without any runtime metadata tables.
 
 - ``Option[T, ...]``    -- named option (``--output file.txt``, ``-o val``)
@@ -107,7 +107,7 @@ struct Option[
 
     ``T`` is the value type stored at runtime (``String``, ``Int``,
     ``List[String]``, etc.).  All other parameters are keyword-only
-    compile-time metadata consumed by ``_reflect_and_register``.
+    compile-time metadata consumed by ``register_into_command``.
 
     Parameters:
         T: The value type stored at runtime.

--- a/src/argmojo/parsable.mojo
+++ b/src/argmojo/parsable.mojo
@@ -1,4 +1,4 @@
-"""Declares the Parsable trait, reflection helpers, and convenience functions."""
+"""Declares the Parsable trait and its reflection-based default methods."""
 
 from std.builtin.constrained import _constrained_field_conforms_to
 from std.reflection import (
@@ -141,7 +141,7 @@ trait Parsable(Defaultable, Movable):
         """
         var cmd = Self.to_command()
         var result = cmd.parse()
-        return _from_result[Self](result)
+        return Self.from_result(result)
 
     @staticmethod
     def parse_args(args: List[String]) raises -> Self:
@@ -157,7 +157,7 @@ trait Parsable(Defaultable, Movable):
         """
         var cmd = Self.to_command()
         var result = cmd.parse_arguments(args)
-        return _from_result[Self](result)
+        return Self.from_result(result)
 
     # ── Hybrid: to_command → customise → from_command ──
 
@@ -180,7 +180,7 @@ trait Parsable(Defaultable, Movable):
             String(Self.description()),
             version=String(Self.version()),
         )
-        _reflect_and_register[Self](cmd)
+        Self.register_into_command(cmd)
         Self.subcommands(cmd)
         return cmd^
 
@@ -197,7 +197,7 @@ trait Parsable(Defaultable, Movable):
             A populated instance of Self.
         """
         var result = cmd.parse()
-        return _from_result[Self](result)
+        return Self.from_result(result)
 
     # ── Dual return ──
 
@@ -212,7 +212,7 @@ trait Parsable(Defaultable, Movable):
         """
         var cmd = Self.to_command()
         var result = cmd.parse()
-        var args = _from_result[Self](result)
+        var args = Self.from_result(result)
         return Tuple[Self, ParseResult](args^, result^)
 
     @staticmethod
@@ -229,7 +229,7 @@ trait Parsable(Defaultable, Movable):
             A tuple of (populated Self, raw ParseResult).
         """
         var result = cmd.parse()
-        var args = _from_result[Self](result)
+        var args = Self.from_result(result)
         return Tuple[Self, ParseResult](args^, result^)
 
     # ── Subcommand write-back ──
@@ -247,199 +247,46 @@ trait Parsable(Defaultable, Movable):
         Returns:
             A populated instance of Self.
         """
-        return _from_result[Self](result)
+        var out = Self()
+        comptime field_count = struct_field_count[Self]()
+        comptime field_types = struct_field_types[Self]()
+        comptime field_names = struct_field_names[Self]()
 
+        comptime for idx in range(field_count):
+            comptime ftype = field_types[idx]
+            comptime if conforms_to(ftype, ArgumentLike):
+                ref field = __struct_field_ref(idx, out)
+                comptime fname = field_names[idx]
+                trait_downcast[ArgumentLike](field).read_from_result(
+                    String(fname), result
+                )
 
-# =======================================================================
-# Reflection helpers
-# =======================================================================
+        return out^
 
+    # ── Reflection: register fields into Command ──
 
-def _reflect_and_register[T: Parsable](mut cmd: Command) raises:
-    """Iterate T's fields via reflection and register ArgumentLike-conforming
-    ones as Arguments on cmd.
+    @staticmethod
+    def register_into_command(mut cmd: Command) raises:
+        """Iterate Self's fields via reflection and register
+        ArgumentLike-conforming ones as Arguments on cmd.
 
-    Parameters:
-        T: A struct conforming to Parsable.
+        Called automatically by ``to_command()``.  Exposed so that
+        advanced users can build a Command manually and still benefit
+        from declarative field registration.
 
-    Args:
-        cmd: The Command to register arguments on.
-    """
-    var instance = T()
-    comptime field_count = struct_field_count[T]()
-    comptime field_types = struct_field_types[T]()
-    comptime field_names = struct_field_names[T]()
+        Args:
+            cmd: The Command to register arguments on.
+        """
+        var instance = Self()
+        comptime field_count = struct_field_count[Self]()
+        comptime field_types = struct_field_types[Self]()
+        comptime field_names = struct_field_names[Self]()
 
-    comptime for idx in range(field_count):
-        comptime ftype = field_types[idx]
-        comptime if conforms_to(ftype, ArgumentLike):
-            ref field = __struct_field_ref(idx, instance)
-            comptime fname = field_names[idx]
-            trait_downcast[ArgumentLike](field).add_to_command(
-                String(fname), cmd
-            )
-
-
-def _from_result[T: Parsable](result: ParseResult) raises -> T:
-    """Create a T instance and populate ArgumentLike-conforming fields from
-    the given ParseResult.
-
-    Parameters:
-        T: A struct conforming to Parsable.
-
-    Args:
-        result: The ParseResult containing parsed values.
-
-    Returns:
-        A populated instance of T.
-    """
-    var out = T()
-    comptime field_count = struct_field_count[T]()
-    comptime field_types = struct_field_types[T]()
-    comptime field_names = struct_field_names[T]()
-
-    comptime for idx in range(field_count):
-        comptime ftype = field_types[idx]
-        comptime if conforms_to(ftype, ArgumentLike):
-            ref field = __struct_field_ref(idx, out)
-            comptime fname = field_names[idx]
-            trait_downcast[ArgumentLike](field).read_from_result(
-                String(fname), result
-            )
-
-    return out^
-
-
-# =======================================================================
-# Parsable convenience functions
-# =======================================================================
-
-
-def to_command[T: Parsable]() raises -> Command:
-    """Build a Command from T's metadata and fields.
-
-    Reflects over T's fields, registers them as arguments, and
-    calls ``T.subcommands()`` to wire child commands.
-
-    Parameters:
-        T: A struct conforming to Parsable.
-
-    Returns:
-        A fully configured Command.
-    """
-    var cmd_name = String(T.name())
-    if not cmd_name:
-        cmd_name = String("command")
-    var cmd = Command(
-        cmd_name,
-        String(T.description()),
-        version=String(T.version()),
-    )
-    _reflect_and_register[T](cmd)
-    T.subcommands(cmd)
-    return cmd^
-
-
-def parse[T: Parsable]() raises -> T:
-    """Build, parse argv, and return a populated T.
-
-    This is the primary entry point for pure-declarative usage.
-
-    Parameters:
-        T: A struct conforming to Parsable.
-
-    Returns:
-        A populated instance of T.
-    """
-    var cmd = to_command[T]()
-    var result = cmd.parse()
-    return _from_result[T](result)
-
-
-def parse_args[T: Parsable](args: List[String]) raises -> T:
-    """Build, parse the given argument list, and return a populated T.
-
-    Parameters:
-        T: A struct conforming to Parsable.
-
-    Args:
-        args: The raw argument strings (including program name at index 0).
-
-    Returns:
-        A populated instance of T.
-    """
-    var cmd = to_command[T]()
-    var result = cmd.parse_arguments(args)
-    return _from_result[T](result)
-
-
-def parse_split[T: Parsable]() raises -> Tuple[T, ParseResult]:
-    """Build, parse argv, and return both T and raw ParseResult.
-
-    Use when you need both typed fields and subcommand dispatch.
-
-    Parameters:
-        T: A struct conforming to Parsable.
-
-    Returns:
-        A tuple of (populated T, raw ParseResult).
-    """
-    var cmd = to_command[T]()
-    var result = cmd.parse()
-    var args = _from_result[T](result)
-    return Tuple[T, ParseResult](args^, result^)
-
-
-def from_command[T: Parsable](var cmd: Command) raises -> T:
-    """Parse using a pre-configured Command and return a populated T.
-
-    Use when you've customised the Command via ``to_command()`` before parsing.
-
-    Parameters:
-        T: A struct conforming to Parsable.
-
-    Args:
-        cmd: A Command (typically from ``to_command[T]()``).
-
-    Returns:
-        A populated instance of T.
-    """
-    var result = cmd.parse()
-    return _from_result[T](result)
-
-
-def from_command_split[
-    T: Parsable
-](var cmd: Command) raises -> Tuple[T, ParseResult]:
-    """Parse using a pre-configured Command and return both T and ParseResult.
-
-    Parameters:
-        T: A struct conforming to Parsable.
-
-    Args:
-        cmd: A Command (typically from ``to_command[T]()``).
-
-    Returns:
-        A tuple of (populated T, raw ParseResult).
-    """
-    var result = cmd.parse()
-    var args = _from_result[T](result)
-    return Tuple[T, ParseResult](args^, result^)
-
-
-def from_result[T: Parsable](result: ParseResult) raises -> T:
-    """Populate T from an existing ParseResult (no parsing).
-
-    Useful for subcommand dispatch — after the parent parses,
-    extract child fields from the subcommand result.
-
-    Parameters:
-        T: A struct conforming to Parsable.
-
-    Args:
-        result: The ParseResult containing parsed values.
-
-    Returns:
-        A populated instance of T.
-    """
-    return _from_result[T](result)
+        comptime for idx in range(field_count):
+            comptime ftype = field_types[idx]
+            comptime if conforms_to(ftype, ArgumentLike):
+                ref field = __struct_field_ref(idx, instance)
+                comptime fname = field_names[idx]
+                trait_downcast[ArgumentLike](field).add_to_command(
+                    String(fname), cmd
+                )

--- a/tests/test_declarative.mojo
+++ b/tests/test_declarative.mojo
@@ -1,7 +1,7 @@
 """End-to-end test for the declarative Parsable API (Phase 1).
 
-Tests _reflect_and_register / _from_result via the public
-to_command / parse_args / from_result functions.
+Tests register_into_command / from_result via the Parsable trait
+static methods: to_command(), parse_args(), from_result().
 """
 from std.testing import assert_true, assert_false, assert_equal, TestSuite
 
@@ -12,9 +12,6 @@ from argmojo import (
     Flag,
     Positional,
     Count,
-    to_command,
-    parse_args,
-    from_result,
 )
 
 
@@ -45,7 +42,7 @@ struct Grep(Parsable):
 
 def test_to_command() raises:
     """Test that to_command registers all arguments correctly."""
-    var cmd = to_command[Grep]()
+    var cmd = Grep.to_command()
 
     # Should have 4 arguments.
     assert_true(
@@ -80,7 +77,7 @@ def test_parse_args() raises:
     args.append(String("-ddd"))
     args.append(String("hello.*world"))
 
-    var grep = parse_args[Grep](args)
+    var grep = Grep.parse_args(args)
 
     assert_true(grep.output.value == "result.txt", "output value")
     assert_true(grep.verbose.value, "verbose value")
@@ -91,7 +88,7 @@ def test_parse_args() raises:
 def test_from_result() raises:
     """Test from_result writes back from an existing ParseResult."""
 
-    var cmd = to_command[Grep]()
+    var cmd = Grep.to_command()
     var args = List[String]()
     args.append(String("grep"))
     args.append(String("--output"))
@@ -99,7 +96,7 @@ def test_from_result() raises:
     args.append(String("pattern_str"))
 
     var result = cmd.parse_arguments(args)
-    var grep = from_result[Grep](result)
+    var grep = Grep.from_result(result)
 
     assert_true(grep.output.value == "out.txt", "output")
     assert_true(not grep.verbose.value, "verbose should be false")
@@ -118,7 +115,7 @@ struct AutoNameArgs(Parsable):
 def test_auto_naming() raises:
     """Test that underscore field names auto-convert to hyphen long names."""
 
-    var cmd = to_command[AutoNameArgs]()
+    var cmd = AutoNameArgs.to_command()
 
     assert_true(cmd.args[0]._long_name == "no-color", "no_color -> no-color")
     assert_true(cmd.args[1]._long_name == "max-depth", "max_depth -> max-depth")
@@ -158,7 +155,7 @@ def test_trait_methods() raises:
 def test_split_return() raises:
     """Test the split-return pattern: both typed struct AND raw ParseResult."""
 
-    var cmd = to_command[Grep]()
+    var cmd = Grep.to_command()
     var args = List[String]()
     args.append(String("grep"))
     args.append(String("--output"))
@@ -171,7 +168,7 @@ def test_split_return() raises:
     var result = cmd.parse_arguments(args)
 
     # Typed write-back (same as what parse_split returns as element 0).
-    var grep = from_result[Grep](result)
+    var grep = Grep.from_result(result)
 
     # Verify typed access.
     assert_true(grep.output.value == "split.txt", "split typed output")

--- a/tests/test_hybrid.mojo
+++ b/tests/test_hybrid.mojo
@@ -6,7 +6,7 @@ parse_args(), ParseResult, and from_result().
 
 Covers:
   - to_command() + builder modifications + parse_arguments() + from_result()
-  - Free functions: to_command[T](), parse_args[T](), from_result[T]()
+  - Trait static methods: T.to_command(), T.parse_args(), T.from_result()
   - mutually_exclusive() via to_command()
   - required_together() via to_command()
   - implies() via to_command()
@@ -28,9 +28,6 @@ from argmojo import (
     Option,
     Flag,
     Positional,
-    to_command,
-    parse_args,
-    from_result,
 )
 
 
@@ -426,13 +423,13 @@ def test_configure_exclusive_enforced() raises:
 
 
 # =======================================================================
-# 8. Free functions: to_command[T](), parse_args[T](), from_result[T]()
+# 8. Trait static methods: T.to_command(), T.parse_args(), T.from_result()
 # =======================================================================
 
 
 def test_free_to_command() raises:
-    """Free function to_command[T]() builds Command with all arguments."""
-    var cmd = to_command[Deploy]()
+    """Trait static method T.to_command() builds Command with all arguments."""
+    var cmd = Deploy.to_command()
 
     # Same result as Deploy.to_command() — 5 args registered.
     assert_true(
@@ -441,7 +438,7 @@ def test_free_to_command() raises:
 
 
 def test_free_parse_args() raises:
-    """Free function parse_args[T]() parses an argument list into a typed struct.
+    """Trait static method T.parse_args() parses an argument list into a typed struct.
     """
     var args: List[String] = [
         "command",
@@ -452,7 +449,7 @@ def test_free_parse_args() raises:
         "7",
         "staging",
     ]
-    var deploy = parse_args[Deploy](args)
+    var deploy = Deploy.parse_args(args)
 
     assert_equal(deploy.target.value, "staging")
     assert_equal(deploy.tag.value, "v3.0")
@@ -461,22 +458,22 @@ def test_free_parse_args() raises:
 
 
 def test_free_from_result() raises:
-    """Free function from_result[T]() populates struct from ParseResult."""
-    var cmd = to_command[AuthArgs]()
+    """Trait static method T.from_result() populates struct from ParseResult."""
+    var cmd = AuthArgs.to_command()
     var args: List[String] = ["command", "-u", "alice", "--token", "tok123"]
     var result = cmd.parse_arguments(args)
 
-    # Use the free function, not the trait method.
-    var auth = from_result[AuthArgs](result)
+    # Use the trait static method.
+    var auth = AuthArgs.from_result(result)
     assert_equal(auth.username.value, "alice")
     assert_equal(auth.token.value, "tok123")
     assert_equal(auth.password.value, "")
 
 
 def test_free_functions_with_builder_mods() raises:
-    """Free functions + builder mods: to_command → customise → parse → from_result.
+    """Trait methods + builder mods: to_command → customise → parse → from_result.
     """
-    var cmd = to_command[Deploy]()
+    var cmd = Deploy.to_command()
     var group: List[String] = ["force", "dry_run"]
     cmd.mutually_exclusive(group^)
     cmd.add_tip("Use --dry-run to preview")
@@ -484,7 +481,7 @@ def test_free_functions_with_builder_mods() raises:
     var args: List[String] = ["command", "--dry-run", "--replicas", "2", "prod"]
     var result = cmd.parse_arguments(args)
 
-    var deploy = from_result[Deploy](result)
+    var deploy = Deploy.from_result(result)
     assert_equal(deploy.target.value, "prod")
     assert_true(deploy.dry_run.value, msg="dry_run should be True")
     assert_false(deploy.force.value, msg="force should be False")
@@ -494,7 +491,7 @@ def test_free_functions_with_builder_mods() raises:
 def test_dual_return_typed_and_raw() raises:
     """Dual return pattern: both typed struct AND raw ParseResult from same parse.
     """
-    var cmd = to_command[Convert]()
+    var cmd = Convert.to_command()
     cmd.add_argument(
         Argument("format", help="Output format")
         .long["format"]()
@@ -511,8 +508,8 @@ def test_dual_return_typed_and_raw() raises:
     ]
     var result = cmd.parse_arguments(args)
 
-    # Typed access via free function.
-    var conv = from_result[Convert](result)
+    # Typed access via trait static method.
+    var conv = Convert.from_result(result)
     assert_equal(conv.input.value, "input.json")
     assert_equal(conv.output.value, "out.yaml")
 

--- a/tests/test_hybrid.mojo
+++ b/tests/test_hybrid.mojo
@@ -427,7 +427,7 @@ def test_configure_exclusive_enforced() raises:
 # =======================================================================
 
 
-def test_free_to_command() raises:
+def test_to_command() raises:
     """Trait static method T.to_command() builds Command with all arguments."""
     var cmd = Deploy.to_command()
 
@@ -437,7 +437,7 @@ def test_free_to_command() raises:
     )
 
 
-def test_free_parse_args() raises:
+def test_parse_args() raises:
     """Trait static method T.parse_args() parses an argument list into a typed struct.
     """
     var args: List[String] = [
@@ -457,7 +457,7 @@ def test_free_parse_args() raises:
     assert_equal(deploy.replicas.value, 7)
 
 
-def test_free_from_result() raises:
+def test_from_result() raises:
     """Trait static method T.from_result() populates struct from ParseResult."""
     var cmd = AuthArgs.to_command()
     var args: List[String] = ["command", "-u", "alice", "--token", "tok123"]
@@ -470,7 +470,7 @@ def test_free_from_result() raises:
     assert_equal(auth.password.value, "")
 
 
-def test_free_functions_with_builder_mods() raises:
+def test_methods_with_builder_mods() raises:
     """Trait methods + builder mods: to_command → customise → parse → from_result.
     """
     var cmd = Deploy.to_command()

--- a/tests/test_subcommands_declarative.mojo
+++ b/tests/test_subcommands_declarative.mojo
@@ -295,7 +295,7 @@ def test_flat_root_config_with_search() raises:
     assert_equal(search.pattern.value, "pattern")
 
 
-def test_flat_free_function_to_command() raises:
+def test_flat_root_to_command() raises:
     """Use trait static method AppRoot.to_command() to build Command."""
     var cmd = AppRoot.to_command()
     var args: List[String] = ["app", "search", "test"]
@@ -628,7 +628,7 @@ def test_run_root_noop_when_subcommand_dispatched() raises:
 
 
 def test_parse_args_with_subcommands() raises:
-    """Free function parse_args works when subcommands are registered."""
+    """Method parse_args works when subcommands are registered."""
     var args: List[String] = ["app", "-v", "search", "hello"]
     var root = AppRoot.parse_args(args)
     assert_true(root.verbose.value)
@@ -637,7 +637,7 @@ def test_parse_args_with_subcommands() raises:
 
 
 def test_parse_args_nested() raises:
-    """Free function parse_args works through nested subcommand dispatch."""
+    """Method parse_args works through nested subcommand dispatch."""
     var args: List[String] = [
         "git",
         "-v",

--- a/tests/test_subcommands_declarative.mojo
+++ b/tests/test_subcommands_declarative.mojo
@@ -5,7 +5,7 @@ Tests Parsable structs as subcommand participants:
   - Nested subcommands (2+ levels) with mid-level flags
   - Root customization + dual return (typed Self + raw ParseResult)
   - run() dispatch pattern for leaf command execution
-  - from_result[Child]() write-back from subcommand ParseResult
+  - Child.from_result() write-back from subcommand ParseResult
 
 Note: from_command(), parse_split(), and from_command_split() call
 cmd.parse() which reads sys.argv(), so they cannot be exercised in
@@ -23,9 +23,6 @@ from argmojo import (
     Flag,
     Positional,
     Count,
-    to_command,
-    parse_args,
-    from_result,
 )
 
 
@@ -233,14 +230,14 @@ def test_flat_dispatch_search() raises:
         "hello",
     ]
     var result = cmd.parse_arguments(args)
-    var root = from_result[AppRoot](result)
+    var root = AppRoot.from_result(result)
 
     assert_true(root.verbose.value)
     assert_equal(result.subcommand, "search")
     assert_true(result.has_subcommand_result())
 
     var sub = result.get_subcommand_result()
-    var search = from_result[SearchCmd](sub)
+    var search = SearchCmd.from_result(sub)
     assert_equal(search.pattern.value, "hello")
     assert_true(search.case_sensitive.value)
 
@@ -253,7 +250,7 @@ def test_flat_dispatch_list() raises:
 
     assert_equal(result.subcommand, "list")
     var sub = result.get_subcommand_result()
-    var lst = from_result[ListCmd](sub)
+    var lst = ListCmd.from_result(sub)
     assert_true(lst.all.value)
     assert_equal(lst.format.value, "json")
 
@@ -266,7 +263,7 @@ def test_flat_dispatch_list_default_format() raises:
 
     assert_equal(result.subcommand, "list")
     var sub = result.get_subcommand_result()
-    var lst = from_result[ListCmd](sub)
+    var lst = ListCmd.from_result(sub)
     assert_false(lst.all.value)
     assert_equal(lst.format.value, "table")
 
@@ -276,7 +273,7 @@ def test_flat_root_only_no_subcommand() raises:
     var cmd = AppRoot.to_command()
     var args: List[String] = ["app", "--verbose", "-c", "myconfig.toml"]
     var result = cmd.parse_arguments(args)
-    var root = from_result[AppRoot](result)
+    var root = AppRoot.from_result(result)
 
     assert_true(root.verbose.value)
     assert_equal(root.config.value, "myconfig.toml")
@@ -289,25 +286,24 @@ def test_flat_root_config_with_search() raises:
     var cmd = AppRoot.to_command()
     var args: List[String] = ["app", "-c", "prod.toml", "search", "pattern"]
     var result = cmd.parse_arguments(args)
-    var root = from_result[AppRoot](result)
+    var root = AppRoot.from_result(result)
 
     assert_equal(root.config.value, "prod.toml")
     assert_equal(result.subcommand, "search")
     var sub = result.get_subcommand_result()
-    var search = from_result[SearchCmd](sub)
+    var search = SearchCmd.from_result(sub)
     assert_equal(search.pattern.value, "pattern")
 
 
 def test_flat_free_function_to_command() raises:
-    """Use free function to_command[AppRoot]() instead of AppRoot.to_command().
-    """
-    var cmd = to_command[AppRoot]()
+    """Use trait static method AppRoot.to_command() to build Command."""
+    var cmd = AppRoot.to_command()
     var args: List[String] = ["app", "search", "test"]
     var result = cmd.parse_arguments(args)
 
     assert_equal(result.subcommand, "search")
     var sub = result.get_subcommand_result()
-    var search = from_result[SearchCmd](sub)
+    var search = SearchCmd.from_result(sub)
     assert_equal(search.pattern.value, "test")
 
 
@@ -328,7 +324,7 @@ def test_nested_remote_add() raises:
         "https://example.com",
     ]
     var result = cmd.parse_arguments(args)
-    var root = from_result[GitApp](result)
+    var root = GitApp.from_result(result)
 
     assert_true(root.verbose.value)
     assert_equal(result.subcommand, "remote")
@@ -336,14 +332,14 @@ def test_nested_remote_add() raises:
 
     # Level 2: remote
     var remote_result = result.get_subcommand_result()
-    var remote = from_result[RemoteCmd](remote_result)
+    var remote = RemoteCmd.from_result(remote_result)
     assert_false(remote.verbose.value)  # remote's own verbose not set
     assert_equal(remote_result.subcommand, "add")
     assert_true(remote_result.has_subcommand_result())
 
     # Level 3: add
     var add_result = remote_result.get_subcommand_result()
-    var add_cmd = from_result[RemoteAddCmd](add_result)
+    var add_cmd = RemoteAddCmd.from_result(add_result)
     assert_equal(add_cmd.rname.value, "origin")
     assert_equal(add_cmd.url.value, "https://example.com")
     assert_false(add_cmd.fetch.value)
@@ -364,7 +360,7 @@ def test_nested_remote_add_with_fetch() raises:
 
     var remote_result = result.get_subcommand_result()
     var add_result = remote_result.get_subcommand_result()
-    var add_cmd = from_result[RemoteAddCmd](add_result)
+    var add_cmd = RemoteAddCmd.from_result(add_result)
     assert_equal(add_cmd.rname.value, "origin")
     assert_equal(add_cmd.url.value, "https://example.com")
     assert_true(add_cmd.fetch.value)
@@ -384,11 +380,11 @@ def test_nested_mid_level_flag() raises:
     var result = cmd.parse_arguments(args)
 
     var remote_result = result.get_subcommand_result()
-    var remote = from_result[RemoteCmd](remote_result)
+    var remote = RemoteCmd.from_result(remote_result)
     assert_true(remote.verbose.value)  # mid-level flag set
 
     var add_result = remote_result.get_subcommand_result()
-    var add_cmd = from_result[RemoteAddCmd](add_result)
+    var add_cmd = RemoteAddCmd.from_result(add_result)
     assert_equal(add_cmd.rname.value, "origin")
 
 
@@ -403,7 +399,7 @@ def test_nested_remote_remove() raises:
     assert_equal(remote_result.subcommand, "remove")
 
     var rm_result = remote_result.get_subcommand_result()
-    var rm_cmd = from_result[RemoteRemoveCmd](rm_result)
+    var rm_cmd = RemoteRemoveCmd.from_result(rm_result)
     assert_equal(rm_cmd.rname.value, "origin")
     assert_true(rm_cmd.force.value)
 
@@ -416,7 +412,7 @@ def test_nested_remote_remove_no_force() raises:
 
     var remote_result = result.get_subcommand_result()
     var rm_result = remote_result.get_subcommand_result()
-    var rm_cmd = from_result[RemoteRemoveCmd](rm_result)
+    var rm_cmd = RemoteRemoveCmd.from_result(rm_result)
     assert_equal(rm_cmd.rname.value, "origin")
     assert_false(rm_cmd.force.value)
 
@@ -434,15 +430,15 @@ def test_nested_root_and_mid_verbose() raises:
         "https://example.com",
     ]
     var result = cmd.parse_arguments(args)
-    var root = from_result[GitApp](result)
+    var root = GitApp.from_result(result)
     assert_true(root.verbose.value)
 
     var remote_result = result.get_subcommand_result()
-    var remote = from_result[RemoteCmd](remote_result)
+    var remote = RemoteCmd.from_result(remote_result)
     assert_true(remote.verbose.value)
 
     var add_result = remote_result.get_subcommand_result()
-    var add_cmd = from_result[RemoteAddCmd](add_result)
+    var add_cmd = RemoteAddCmd.from_result(add_result)
     assert_equal(add_cmd.rname.value, "origin")
 
 
@@ -474,7 +470,7 @@ def test_dual_return_root_and_subcommand() raises:
     var result = cmd.parse_arguments(args)
 
     # Typed root
-    var root = from_result[AppRoot](result)
+    var root = AppRoot.from_result(result)
     assert_true(root.verbose.value)
 
     # Raw result for subcommand dispatch
@@ -483,7 +479,7 @@ def test_dual_return_root_and_subcommand() raises:
     var sub = result.get_subcommand_result()
 
     # Typed child from raw sub-result
-    var search = from_result[SearchCmd](sub)
+    var search = SearchCmd.from_result(sub)
     assert_equal(search.pattern.value, "hello")
 
 
@@ -503,30 +499,31 @@ def test_dual_return_nested() raises:
     var result = cmd.parse_arguments(args)
 
     # Root typed
-    var root = from_result[GitApp](result)
+    var root = GitApp.from_result(result)
     assert_true(root.verbose.value)
 
     # Mid-level typed
     var remote_result = result.get_subcommand_result()
-    var remote = from_result[RemoteCmd](remote_result)
+    var remote = RemoteCmd.from_result(remote_result)
     assert_true(remote.verbose.value)
 
     # Leaf typed
     var add_result = remote_result.get_subcommand_result()
-    var add_cmd = from_result[RemoteAddCmd](add_result)
+    var add_cmd = RemoteAddCmd.from_result(add_result)
     assert_equal(add_cmd.rname.value, "origin")
     assert_equal(add_cmd.url.value, "https://x.com")
     assert_true(add_cmd.fetch.value)
 
 
 def test_from_result_child_only() raises:
-    """Extract child directly from sub-result via from_result[ChildParsable]."""
+    """Extract child directly from sub-result via ChildParsable.from_result().
+    """
     var cmd = AppRoot.to_command()
     var args: List[String] = ["app", "list", "--all", "-f", "csv"]
     var result = cmd.parse_arguments(args)
 
     var sub = result.get_subcommand_result()
-    var lst = from_result[ListCmd](sub)
+    var lst = ListCmd.from_result(sub)
     assert_true(lst.all.value)
     assert_equal(lst.format.value, "csv")
 
@@ -541,7 +538,7 @@ def test_run_default_noop() raises:
     var cmd = AppRoot.to_command()
     var args: List[String] = ["app", "--verbose"]
     var result = cmd.parse_arguments(args)
-    var root = from_result[AppRoot](result)
+    var root = AppRoot.from_result(result)
     root.run()  # Should complete without error
 
 
@@ -552,7 +549,7 @@ def test_run_leaf_reads_fields() raises:
     var result = cmd.parse_arguments(args)
 
     var sub = result.get_subcommand_result()
-    var leaf = from_result[RunLeafCmd](sub)
+    var leaf = RunLeafCmd.from_result(sub)
     assert_equal(leaf.target.value, "myapp")
     assert_true(leaf.release.value)
     leaf.run()  # Should not raise — target is non-empty
@@ -580,13 +577,13 @@ def test_run_dispatch_full_pattern() raises:
     var result = cmd.parse_arguments(args)
 
     # Step 3: root typed
-    var root = from_result[RunTestRoot](result)
+    var root = RunTestRoot.from_result(result)
     assert_true(root.debug.value)
 
     # Step 4-5: dispatch
     assert_equal(result.subcommand, "build")
     var sub = result.get_subcommand_result()
-    var build = from_result[RunLeafCmd](sub)
+    var build = RunLeafCmd.from_result(sub)
 
     # Step 6: run
     assert_equal(build.target.value, "myapp")
@@ -609,7 +606,7 @@ def test_run_nested_dispatch() raises:
     # Navigate to leaf
     var remote_result = result.get_subcommand_result()
     var add_result = remote_result.get_subcommand_result()
-    var add_cmd = from_result[RemoteAddCmd](add_result)
+    var add_cmd = RemoteAddCmd.from_result(add_result)
 
     # Leaf run() validates rname and url are non-empty
     add_cmd.run()
@@ -621,7 +618,7 @@ def test_run_root_noop_when_subcommand_dispatched() raises:
     var args: List[String] = ["runner", "--debug", "build", "myapp"]
     var result = cmd.parse_arguments(args)
 
-    var root = from_result[RunTestRoot](result)
+    var root = RunTestRoot.from_result(result)
     root.run()  # Root's run() is a no-op, doesn't interfere
 
 
@@ -633,7 +630,7 @@ def test_run_root_noop_when_subcommand_dispatched() raises:
 def test_parse_args_with_subcommands() raises:
     """Free function parse_args works when subcommands are registered."""
     var args: List[String] = ["app", "-v", "search", "hello"]
-    var root = parse_args[AppRoot](args)
+    var root = AppRoot.parse_args(args)
     assert_true(root.verbose.value)
     # parse_args returns only typed root — subcommand info is in raw result
     # (This tests that parse_args doesn't crash with subcommands)
@@ -649,7 +646,7 @@ def test_parse_args_nested() raises:
         "origin",
         "https://x.com",
     ]
-    var root = parse_args[GitApp](args)
+    var root = GitApp.parse_args(args)
     assert_true(root.verbose.value)
 
 


### PR DESCRIPTION
This PR consolidates the declarative API around `Parsable` trait static methods by removing the legacy module-level convenience functions and updating call sites across tests, examples, and docs.

**Changes:**
- Inline reflection logic into `Parsable.register_into_command()` / `Parsable.from_result()` and route other trait methods through them.
- Remove declarative free functions from `argmojo`’s public exports.
- Update tests/examples/docs to use `T.to_command()`, `T.parse_args()`, `T.from_result()`.