### PR TITLE
[core][declarative] Add more examples of declarative API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ logs/
 /mgit
 /demo
 /yu
+/search
+/deploy
+/convert
 /jomo
 
 # Local notes (not tracked)

--- a/docs/declarative_api_planning.md
+++ b/docs/declarative_api_planning.md
@@ -1360,8 +1360,8 @@ I think this is the right call — these features describe *relationships betwee
 - [ ] Auto-derive completions from `choices` parameters (§6.5)
   - [ ] Ensure choices flow to `generate_completion` output
   - [ ] Explore compile-time completion script generation
-- [] Some command-level features can be exposed via declarative parameters (e.g. `help_on_no_arguments=True`), but others (e.g. `confirmation_option()`) require builder-level access. Document best practices for when to use `to_command()` for command-level behavior.
-- [] Add more built-in types for `Option` (e.g. `Float`) and ensure they work end-to-end with both declarative and builder patterns. This requires more methods in `ParseResult` (e.g. `get_float()`) and corresponding write-back logic in `from_result()`.
+- [ ] Some command-level features can be exposed via declarative parameters (e.g. `help_on_no_arguments=True`), but others (e.g. `confirmation_option()`) require builder-level access. Document best practices for when to use `to_command()` for command-level behavior.
+- [ ] Add more built-in types for `Option` (e.g. `Float`) and ensure they work end-to-end with both declarative and builder patterns. This requires more methods in `ParseResult` (e.g. `get_float()`) and corresponding write-back logic in `from_result()`.
 
 ### Phase 5: Polish
 

--- a/docs/declarative_api_planning.md
+++ b/docs/declarative_api_planning.md
@@ -1021,7 +1021,7 @@ As far as I know, this is a **new pattern** not seen in any CLI library in any l
 The dual-return enables a practical workflow:
 
 1. Start with pure declarative
-2. Need one advanced option? Add it via `to_command()` + `parse_split()`
+2. Need one advanced option? Add it via `to_command()` + `parse_with_command(command: Command)`
 3. No need to convert the struct field (or add a new nested type)
 
 ### 6.3 Innovation #3: Compile-Time Schema Validation

--- a/docs/declarative_api_planning.md
+++ b/docs/declarative_api_planning.md
@@ -429,7 +429,7 @@ trait Parsable(Defaultable, Movable):
         return Tuple[Self, ParseResult](typed^, result^)
 
     @staticmethod
-    def from_command_split(owned cmd: Command) raises -> Tuple[Self, ParseResult]:
+    def parse_with_command(owned cmd: Command) raises -> Tuple[Self, ParseResult]:
         """Parse from a pre-configured Command and return BOTH typed Self
         AND raw ParseResult. Essential for subcommand dispatch:
         the typed Self gives root-level flags, ParseResult gives
@@ -492,14 +492,14 @@ struct MyArgs(Parsable):
         return "My awesome tool"
 ```
 
-Everything else (`parse()`, `to_command()`, `from_command()`, `from_command_split()`, `from_result()`, `parse_split()`, `parse_args()`, `validate()`, `run()`, `subcommands()`, `version()`, `name()`) comes from trait defaults.
+Everything else (`parse()`, `to_command()`, `from_command()`, `parse_with_command()`, `from_result()`, `parse_split()`, `parse_args()`, `validate()`, `run()`, `subcommands()`, `version()`, `name()`) comes from trait defaults.
 
 ### 4.3 Implementation Notes
 
 All reflection logic lives directly inside the `Parsable` trait's default methods — there are **no standalone helper functions**:
 
 - **`register_into_command(mut cmd)`** — iterates Self's fields via `comptime for` + `struct_field_types[Self]()`, downcasts each `ArgumentLike`-conforming field, and calls `field.add_to_command(name, cmd)`. Called by `to_command()`.
-- **`from_result(result)`** — creates `Self()`, iterates fields, downcasts each `ArgumentLike`-conforming field, and calls `field.read_from_result(name, result)`. Called by `parse()`, `parse_args()`, `from_command()`, `parse_split()`, `from_command_split()`, and directly by users for subcommand dispatch.
+- **`from_result(result)`** — creates `Self()`, iterates fields, downcasts each `ArgumentLike`-conforming field, and calls `field.read_from_result(name, result)`. Called by `parse()`, `parse_args()`, `from_command()`, `parse_split()`, `parse_with_command()`, and directly by users for subcommand dispatch.
 
 This design keeps `parsable.mojo` self-contained: the trait IS the entire declarative API.
 
@@ -549,21 +549,36 @@ This generates `.alias_name["out"]().alias_name["dest"]()`.
 > implementation. Users no longer need to write `__init__` — the `Parsable`
 > trait auto-initialises all fields via reflection (see §4.4).
 
-### 5.1 Pure Declarative (Simple Tool)
+### 5.1 Pure Declarative (simple tool)
 
 ```mojo
 from argmojo import Parsable, Option, Flag, Positional, Count
 
-struct Grep(Parsable):
+
+struct Search(Parsable):
     """Search for patterns in files."""
 
     var pattern: Positional[String, help="Search pattern", required=True]
     var path: Positional[String, help="File or directory", default="."]
     var ignore_case: Flag[short="i", help="Case-insensitive search"]
     var count_only: Flag[short="c", long="count", help="Only print match count"]
-    var max_count: Option[Int, short="m", long="max-count", help="Stop after N matches", default="0"]
-    var verbose: Count[short="v", help="Increase verbosity", max=3]
-    var ext: Option[List[String], short="e", long="ext", help="File extensions", append=True]
+    var max_count: Option[
+        Int,
+        short="m",
+        long="max-count",
+        help="Stop after N matches",
+        default="0",
+        range_max=100,  # The max value of matches
+        clamp=True,  # The value will be clamped to the range if it exceeds the limits
+    ]
+    var verbose: Count[
+        short="v",
+        help="Increase verbosity",
+        max=3,  # The max level of verbosity, e.g. -vvvv will be treated as -vvv
+    ]
+    var ext: Option[
+        List[String], short="e", long="ext", help="File extensions", append=True
+    ]
 
     @staticmethod
     def description() -> String:
@@ -573,55 +588,85 @@ struct Grep(Parsable):
     def version() -> String:
         return "1.0.0"
 
-def main() raises:
-    var args = Grep.parse()            # One line. No wrapper struct.
 
-    print("Pattern:", args.pattern.value)
-    print("Path:", args.path.value)
-    if args.ignore_case:           # Flag.__bool__() works
-        print("Case insensitive mode")
-    if args.verbose.value > 0:
-        print("Verbosity level:", args.verbose.value)
-    for e in args.ext.value:
-        print("Extension:", e[])
+def main() raises:
+    # Just one line to parse the arguments into a typed struct
+    var args = Search.parse()
+
+    # Print the parsed arguments
+    print("pattern:", args.pattern.value)
+    print("path:", args.path.value)
+    print("ignore_case:", args.ignore_case.value)
+    print("count_only:", args.count_only.value)
+    print("max_count:", args.max_count.value)
+    print("verbose:", args.verbose.value)
+    print("ext:", args.ext.value)
 ```
 
-### 5.2 Declarative + Builder Hybrid (Complex Tool)
+### 5.2 Declarative + Builder Hybrid (granular control with Command API)
 
 ```mojo
 from argmojo import Command, Argument
 from argmojo import Parsable, Option, Flag, Positional
 
+
 struct Deploy(Parsable):
-    var target: Positional[String, help="Deploy target", required=True, choices="staging,prod"]
+    var target: Positional[
+        String, help="Deploy target", required=True, choices="staging,prod"
+    ]
     var force: Flag[short="f", help="Force deploy without checks"]
+    var validated: Flag[
+        long="validated", help="Only deploy if validation passes"
+    ]
     var dry_run: Flag[long="dry-run", help="Simulate without changes"]
     var tag: Option[String, long="tag", short="t", help="Release tag"]
-    var replicas: Option[Int, long="replicas", short="r", help="Number of replicas",
-                      default="3", has_range=True, range_min=1, range_max=100]
+    var replicas: Option[
+        Int,
+        long="replicas",
+        short="r",
+        help="Number of replicas",
+        default="3",
+        has_range=True,
+        range_min=1,
+        range_max=100,
+        clamp=True,
+    ]
 
     @staticmethod
     def description() -> String:
         return "Deploy application to target environment."
 
-def main() raises:
-    # to_command() returns an owned Command — customise it freely
-    var cmd = Deploy.to_command()
-    cmd.mutually_exclusive(["force", "dry-run"])
-    cmd.implies("force", "tag")       # force requires a tag
-    cmd.confirmation_option["Deploy to production?"]()
-    cmd.header_color["CYAN"]()
-    cmd.add_tip("Use --dry-run to preview changes first")
 
-    # from_command() takes the customised Command and returns typed Deploy
-    var args = Deploy.from_command(cmd^)
+def main() raises:
+    # to_command() returns an owned Command for further customization
+    var command = Deploy.to_command()
+
+    # Add more granular control with Command API
+    command.mutually_exclusive(["force", "dry_run"])
+    command.implies("force", "validated")  # force implies validated
+    command.confirmation_option["Deploy to production?"]()
+    command.add_tip("Use --dry-run to preview changes first")
+    command.header_color["CYAN"]()
+    command.help_on_no_arguments()  # Show help if no arguments are provided
+
+    # from_command() parses the customized command and returns a populated Deploy instance
+    var deploy = Deploy.from_command(command^)
+
+    # Print the parsed arguments
+    print("target:", deploy.target.value)
+    print("force:", deploy.force.value)
+    print("validated:", deploy.validated.value)
+    print("dry_run:", deploy.dry_run.value)
+    print("tag:", deploy.tag.value)
+    print("replicas:", deploy.replicas.value)
 ```
 
-### 5.3 Split Parse (Declarative + Extra Builder Fields)
+### 5.3 Split Parse (declarative + extra builder fields)
 
 ```mojo
 from argmojo import Command, Argument
 from argmojo import Parsable, Positional, Option
+
 
 struct Convert(Parsable):
     var input: Positional[String, help="Input file", required=True]
@@ -631,25 +676,36 @@ struct Convert(Parsable):
     def description() -> String:
         return "File format converter."
 
+
 def main() raises:
-    # to_command() → customise → parse_split()
-    var cmd = Convert.to_command()
-    cmd.add_argument(
+    # to_command() returns an owned Command for further customization
+    var command = Convert.to_command()
+
+    # Add more arguments that are too complex for the declarative API
+    command.add_argument(
         Argument("format", help="Output format")
-        .long["format"]().short["f"]()
-        .choice["json"]().choice["yaml"]().choice["toml"]()
+        .long["format"]()
+        .short["f"]()
+        .choice["json"]()
+        .choice["yaml"]()
+        .choice["toml"]()
         .default["json"]()
     )
-    cmd.add_argument(
+    command.add_argument(
         Argument("indent", help="Indent level")
         .long["indent"]()
-        .range[0, 8]().default["2"]()
+        .range[0, 8]()
+        .default["2"]()
     )
 
-    # parse_split returns BOTH the typed struct AND the raw ParseResult
-    var result = Convert.parse_split()
-    var args = result[0]       # typed Convert
-    var raw  = result[1]       # untyped ParseResult
+    # Add more granular control with Command API
+    command.header_color["GREEN"]()  # Set the help header color to green
+    command.help_on_no_arguments()  # Show help if no arguments are provided
+
+    # parse_with_command() returns BOTH the typed struct AND the raw ParseResult
+    var result = Convert.parse_with_command(command^)
+    ref args = result[0]  # typed Convert
+    ref raw = result[1]  # untyped ParseResult
 
     # Declarative fields: typed access
     print("Input:", args.input.value)
@@ -658,6 +714,9 @@ def main() raises:
     # Builder fields: ParseResult access
     var format = raw.get_string("format")
     var indent = raw.get_int("indent")
+
+    print("Format:", format)
+    print("Indent:", indent)
 ```
 
 ### 5.4 Subcommands with Declarative
@@ -737,7 +796,7 @@ Compare this to the earlier design that required manual tree assembly in `main()
 
 #### 5.4.1 With Builder Customization
 
-When you need root-level builder config (colors, tips, etc.), use `to_command()` + `from_command_split()`:
+When you need root-level builder config (colors, tips, etc.), use `to_command()` + `parse_with_command()`:
 
 ```mojo
 def main() raises:
@@ -745,7 +804,7 @@ def main() raises:
     cmd.header_color["CYAN"]()
     cmd.add_tip("Run 'mgit help <command>' for details")
 
-    var (git_args, result) = MyGit.from_command_split(cmd^)
+    var (git_args, result) = MyGit.parse_with_command(cmd^)
 
     if result.subcommand == "clone":
         Clone.from_result(result).run()
@@ -1166,7 +1225,7 @@ def run(self) raises:
 
 # Parse + split for dispatch
 @staticmethod
-def from_command_split(owned cmd: Command) raises -> Tuple[Self, ParseResult]:
+def parse_with_command(owned cmd: Command) raises -> Tuple[Self, ParseResult]:
     """Parse cmd and return both typed Self (root flags)
     and raw ParseResult (for subcommand dispatch)."""
 
@@ -1187,7 +1246,7 @@ if result.subcommand == "clone":
 # With customization — to_command() already includes subcommands
 var cmd = MyGit.to_command()
 cmd.header_color["CYAN"]()
-var (git_args, result) = MyGit.from_command_split(cmd^)
+var (git_args, result) = MyGit.parse_with_command(cmd^)
 ```
 
 **Comparison with alternatives**:
@@ -1259,7 +1318,7 @@ I think this is the right call — these features describe *relationships betwee
 - [x] Implement `Positional`, `Option`, `Flag`, `Count` wrapper structs — in `argument_wrappers.mojo`
 - [x] Implement `ArgumentLike` trait with `add_to_command()` and `read_from_result()` methods
 - [x] Implement `Parsable` trait with default methods (`description`, `version`, `name`, `subcommands`, `run`)
-- [x] ~~Implement convenience functions as free functions: `to_command`, `parse`, `parse_args`, `parse_split`, `from_command`, `from_command_split`, `from_result`~~ — removed; these duplicated the Parsable trait static methods. All public access is now via `T.to_command()`, `T.parse()`, `T.parse_args()`, etc.
+- [x] ~~Implement convenience functions as free functions: `to_command`, `parse`, `parse_args`, `parse_split`, `from_command`, `parse_with_command`, `from_result`~~ — removed; these duplicated the Parsable trait static methods. All public access is now via `T.to_command()`, `T.parse()`, `T.parse_args()`, etc.
 - [x] ~~Implement `_reflect_and_register[T]()` and `_from_result[T]()`~~ — merged into trait methods `register_into_command()` and `from_result()`. No standalone helper functions remain.
 - [x] Auto-naming convention (underscore → hyphen)
 - [x] 4 passing tests: `test_to_command`, `test_parse_args`, `test_from_result`, `test_auto_naming`
@@ -1273,13 +1332,13 @@ I think this is the right call — these features describe *relationships betwee
 - [x] Test: extra builder args accessible via ParseResult + `from_result()`
 - [x] ~~Test free functions: `to_command[T]()`, `parse_args[T]()`, `from_result[T]()`~~ — converted to trait static method tests (`T.to_command()`, `T.parse_args()`, `T.from_result()`)
 - [x] Document the `configure()` free function pattern (via test helper + test)
-- Note: `from_command()`, `parse_split()`, `from_command_split()` call `cmd.parse()` (reads `sys.argv()`), so they cannot be unit-tested with synthetic args. Their logic is identical to `to_command()` + `parse_arguments()` + `from_result()` which **is** tested.
+- Note: `from_command()`, `parse_split()`, `parse_with_command()` call `cmd.parse()` (reads `sys.argv()`), so they cannot be unit-tested with synthetic args. Their logic is identical to `to_command()` + `parse_arguments()` + `from_result()` which **is** tested.
 
 ### Phase 3: Subcommands
 
 - [x] Implement `subcommands(mut cmd)` hook on `Parsable` trait + auto-call in `to_command()`
 - [x] Implement `run(self)` on `Parsable` trait (default no-op)
-- [x] Implement `from_command_split()` as trait static method
+- [x] Implement `parse_with_command()` as trait static method
 - [x] Implement `from_result()` as trait static method (public write-back)
 - [x] Test: flat subcommands with `subcommands()` hook (6 tests in `test_subcommands_declarative.mojo`)
 - [x] Test: nested subcommands (2+ levels) with mid-level flags and recursive `subcommands()` (6 tests)
@@ -1301,6 +1360,8 @@ I think this is the right call — these features describe *relationships betwee
 - [ ] Auto-derive completions from `choices` parameters (§6.5)
   - [ ] Ensure choices flow to `generate_completion` output
   - [ ] Explore compile-time completion script generation
+- [] Some command-level features can be exposed via declarative parameters (e.g. `help_on_no_arguments=True`), but others (e.g. `confirmation_option()`) require builder-level access. Document best practices for when to use `to_command()` for command-level behavior.
+- [] Add more built-in types for `Option` (e.g. `Float`) and ensure they work end-to-end with both declarative and builder patterns. This requires more methods in `ParseResult` (e.g. `get_float()`) and corresponding write-back logic in `from_result()`.
 
 ### Phase 5: Polish
 

--- a/examples/declarative/convert.mojo
+++ b/examples/declarative/convert.mojo
@@ -1,0 +1,64 @@
+"""Example: Split Parse (declarative + extra builder fields)
+
+Try it out with:
+
+```sh
+pixi run mojo build -I src ./examples/declarative/convert.mojo
+./convert func.txt -o output.txt --format yaml --indent 4
+./convert
+```
+"""
+
+from argmojo import Command, Argument
+from argmojo import Parsable, Positional, Option
+
+
+struct Convert(Parsable):
+    var input: Positional[String, help="Input file", required=True]
+    var output: Option[String, long="output", short="o", help="Output file"]
+
+    @staticmethod
+    def description() -> String:
+        return "File format converter."
+
+
+def main() raises:
+    # to_command() returns an owned Command for further customization
+    var command = Convert.to_command()
+
+    # Add more arguments that are too complex for the declarative API
+    command.add_argument(
+        Argument("format", help="Output format")
+        .long["format"]()
+        .short["f"]()
+        .choice["json"]()
+        .choice["yaml"]()
+        .choice["toml"]()
+        .default["json"]()
+    )
+    command.add_argument(
+        Argument("indent", help="Indent level")
+        .long["indent"]()
+        .range[0, 8]()
+        .default["2"]()
+    )
+
+    # Add more granular control with Command API
+    command.header_color["GREEN"]()  # Set the help header color to green
+    command.help_on_no_arguments()  # Show help if no arguments are provided
+
+    # parse_with_command() returns BOTH the typed struct AND the raw ParseResult
+    var result = Convert.parse_with_command(command^)
+    ref args = result[0]  # typed Convert
+    ref raw = result[1]  # untyped ParseResult
+
+    # Declarative fields: typed access
+    print("Input:", args.input.value)
+    print("Output:", args.output.value)
+
+    # Builder fields: ParseResult access
+    var format = raw.get_string("format")
+    var indent = raw.get_int("indent")
+
+    print("Format:", format)
+    print("Indent:", indent)

--- a/examples/declarative/deploy.mojo
+++ b/examples/declarative/deploy.mojo
@@ -1,0 +1,64 @@
+"""Example: Declarative + Builder Hybrid (granular control with Command API)
+
+Try it out with:
+
+```sh
+pixi run mojo build -I src ./examples/declarative/deploy.mojo
+./deploy "./file" --force --tag "v1.0" --replicas 1000
+./deploy --help
+```
+"""
+
+from argmojo import Command, Argument
+from argmojo import Parsable, Option, Flag, Positional
+
+
+struct Deploy(Parsable):
+    var target: Positional[
+        String, help="Deploy target", required=True, choices="staging,prod"
+    ]
+    var force: Flag[short="f", help="Force deploy without checks"]
+    var validated: Flag[
+        long="validated", help="Only deploy if validation passes"
+    ]
+    var dry_run: Flag[long="dry-run", help="Simulate without changes"]
+    var tag: Option[String, long="tag", short="t", help="Release tag"]
+    var replicas: Option[
+        Int,
+        long="replicas",
+        short="r",
+        help="Number of replicas",
+        default="3",
+        has_range=True,
+        range_min=1,
+        range_max=100,
+        clamp=True,
+    ]
+
+    @staticmethod
+    def description() -> String:
+        return "Deploy application to target environment."
+
+
+def main() raises:
+    # to_command() returns an owned Command for further customization
+    var command = Deploy.to_command()
+
+    # Add more granular control with Command API
+    command.mutually_exclusive(["force", "dry_run"])
+    command.implies("force", "validated")  # force implies validated
+    command.confirmation_option["Deploy to production?"]()
+    command.add_tip("Use --dry-run to preview changes first")
+    command.header_color["CYAN"]()
+    command.help_on_no_arguments()  # Show help if no arguments are provided
+
+    # from_command() parses the customized command and returns a populated Deploy instance
+    var deploy = Deploy.from_command(command^)
+
+    # Print the parsed arguments
+    print("target:", deploy.target.value)
+    print("force:", deploy.force.value)
+    print("validated:", deploy.validated.value)
+    print("dry_run:", deploy.dry_run.value)
+    print("tag:", deploy.tag.value)
+    print("replicas:", deploy.replicas.value)

--- a/examples/declarative/deploy.mojo
+++ b/examples/declarative/deploy.mojo
@@ -47,7 +47,6 @@ def main() raises:
     # Add more granular control with Command API
     command.mutually_exclusive(["force", "dry_run"])
     command.implies("force", "validated")  # force implies validated
-    command.confirmation_option["Deploy to production?"]()
     command.add_tip("Use --dry-run to preview changes first")
     command.header_color["CYAN"]()
     command.help_on_no_arguments()  # Show help if no arguments are provided

--- a/examples/declarative/jomo.mojo
+++ b/examples/declarative/jomo.mojo
@@ -1,4 +1,4 @@
-"""Example: a Mojo CLI lookalike using the declarative API.
+"""Example: Subcommands with Declarative
 
 Simulates the interface of the ``mojo`` command-line tool:
 

--- a/examples/declarative/search.mojo
+++ b/examples/declarative/search.mojo
@@ -1,0 +1,60 @@
+"""Example: Pure Declarative (simple tool)
+
+Try it out with:
+
+```sh
+pixi run mojo build -I src ./examples/declarative/search.mojo
+./search "text" ./ --ignore-case --max-count 1000 -vvvvvvv --ext "txt" --ext "md"
+./search --help
+```
+"""
+
+from argmojo import Parsable, Option, Flag, Positional, Count
+
+
+struct Search(Parsable):
+    """Search for patterns in files."""
+
+    var pattern: Positional[String, help="Search pattern", required=True]
+    var path: Positional[String, help="File or directory", default="."]
+    var ignore_case: Flag[short="i", help="Case-insensitive search"]
+    var count_only: Flag[short="c", long="count", help="Only print match count"]
+    var max_count: Option[
+        Int,
+        short="m",
+        long="max-count",
+        help="Stop after N matches",
+        default="0",
+        range_max=100,  # The max value of matches
+        clamp=True,  # The value will be clamped to the range if it exceeds the limits
+    ]
+    var verbose: Count[
+        short="v",
+        help="Increase verbosity",
+        max=3,  # The max level of verbosity, e.g. -vvvv will be treated as -vvv
+    ]
+    var ext: Option[
+        List[String], short="e", long="ext", help="File extensions", append=True
+    ]
+
+    @staticmethod
+    def description() -> String:
+        return "Search for patterns in files."
+
+    @staticmethod
+    def version() -> String:
+        return "1.0.0"
+
+
+def main() raises:
+    # Just one line to parse the arguments into a typed struct
+    var args = Search.parse()
+
+    # Print the parsed arguments
+    print("pattern:", args.pattern.value)
+    print("path:", args.path.value)
+    print("ignore_case:", args.ignore_case.value)
+    print("count_only:", args.count_only.value)
+    print("max_count:", args.max_count.value)
+    print("verbose:", args.verbose.value)
+    print("ext:", args.ext.value)

--- a/examples/declarative/search.mojo
+++ b/examples/declarative/search.mojo
@@ -25,6 +25,7 @@ struct Search(Parsable):
         long="max-count",
         help="Stop after N matches",
         default="0",
+        has_range=True,
         range_max=100,  # The max value of matches
         clamp=True,  # The value will be clamped to the range if it exceeds the limits
     ]

--- a/pixi.toml
+++ b/pixi.toml
@@ -83,7 +83,10 @@ debug = """pixi run package \
 && mojo run -I src -D ASSERT=all examples/mgit.mojo -- --help \
 && mojo run -I src -D ASSERT=all examples/demo.mojo -- --help \
 && mojo run -I src -D ASSERT=all examples/yu.mojo -- --help \
-&& mojo run -I src -D ASSERT=all examples/jomo.mojo -- --help \
+&& mojo run -I src -D ASSERT=all examples/declarative/search.mojo -- --help \
+&& mojo run -I src -D ASSERT=all examples/declarative/deploy.mojo -- --help \
+&& mojo run -I src -D ASSERT=all examples/declarative/convert.mojo -- --help \
+&& mojo run -I src -D ASSERT=all examples/declarative/jomo.mojo -- --help \
 """
 
 # run (debug mode) example binaries (parallel, fail if any run fails)
@@ -96,17 +99,20 @@ d = """pixi run package && bash -c '\
   mojo run -I src -D ASSERT=all examples/mgit.mojo  -- --help & pids+=($!); \
   mojo run -I src -D ASSERT=all examples/demo.mojo  -- --help & pids+=($!); \
   mojo run -I src -D ASSERT=all examples/yu.mojo    -- --help & pids+=($!); \
+  mojo run -I src -D ASSERT=all examples/declarative/search.mojo -- --help & pids+=($!); \
+  mojo run -I src -D ASSERT=all examples/declarative/deploy.mojo -- --help & pids+=($!); \ 
+  mojo run -I src -D ASSERT=all examples/declarative/convert.mojo -- --help & pids+=($!); \
+  mojo run -I src -D ASSERT=all examples/declarative/jomo.mojo -- --help & pids+=($!); \
   rc=0; for p in "${pids[@]}"; do wait "$p" || rc=1; done; exit $rc'
 """
 
 # clean build artifacts
-clean = "rm -f argmojo.mojopkg mgrep mgit demo yu jomo"
+clean = "rm -f argmojo.mojopkg mgrep mgit demo yu search deploy convert jomo"
 
 # Run all
 all = """
 pixi run format \
 && pixi run package \
-&& pixi run doc \
 && pixi run t \
 && pixi run d \
 && pixi run clean"""

--- a/pixi.toml
+++ b/pixi.toml
@@ -100,7 +100,7 @@ d = """pixi run package && bash -c '\
   mojo run -I src -D ASSERT=all examples/demo.mojo  -- --help & pids+=($!); \
   mojo run -I src -D ASSERT=all examples/yu.mojo    -- --help & pids+=($!); \
   mojo run -I src -D ASSERT=all examples/declarative/search.mojo -- --help & pids+=($!); \
-  mojo run -I src -D ASSERT=all examples/declarative/deploy.mojo -- --help & pids+=($!); \ 
+  mojo run -I src -D ASSERT=all examples/declarative/deploy.mojo -- --help & pids+=($!); \
   mojo run -I src -D ASSERT=all examples/declarative/convert.mojo -- --help & pids+=($!); \
   mojo run -I src -D ASSERT=all examples/declarative/jomo.mojo -- --help & pids+=($!); \
   rc=0; for p in "${pids[@]}"; do wait "$p" || rc=1; done; exit $rc'
@@ -113,6 +113,7 @@ clean = "rm -f argmojo.mojopkg mgrep mgit demo yu search deploy convert jomo"
 all = """
 pixi run format \
 && pixi run package \
+&& pixi run doc \
 && pixi run t \
 && pixi run d \
 && pixi run clean"""

--- a/src/argmojo/argument_wrappers.mojo
+++ b/src/argmojo/argument_wrappers.mojo
@@ -37,7 +37,7 @@ trait ArgumentLike:
     Implemented by Option, Flag, Positional, and Count.
     """
 
-    fn add_to_command(self, field_name: String, mut cmd: Command) raises:
+    def add_to_command(self, field_name: String, mut cmd: Command) raises:
         """Translate compile-time parameters into an Argument and add to cmd.
 
         Args:
@@ -46,7 +46,7 @@ trait ArgumentLike:
         """
         ...
 
-    fn read_from_result(
+    def read_from_result(
         mut self, field_name: String, result: ParseResult
     ) raises:
         """Populate self.value from a ParseResult.
@@ -162,11 +162,11 @@ struct Option[
     var value: Self.T
     """The runtime value populated by parsing."""
 
-    fn __init__(out self):
+    def __init__(out self):
         """Default-initialise with ``T()``."""
         self.value = Self.T()
 
-    fn __init__(out self, *, copy: Self):
+    def __init__(out self, *, copy: Self):
         """Copy from an existing instance.
 
         Args:
@@ -174,7 +174,7 @@ struct Option[
         """
         self.value = copy.value.copy()
 
-    fn __init__(out self, *, deinit take: Self):
+    def __init__(out self, *, deinit take: Self):
         """Move from an existing instance.
 
         Args:
@@ -182,7 +182,7 @@ struct Option[
         """
         self.value = take.value^
 
-    fn add_to_command(self, field_name: String, mut cmd: Command) raises:
+    def add_to_command(self, field_name: String, mut cmd: Command) raises:
         var long_name = String(Self.long) if Self.long else field_name.replace(
             "_", "-"
         )
@@ -240,7 +240,7 @@ struct Option[
             arg._hide_input = True
         cmd.add_argument(arg^)
 
-    fn read_from_result(
+    def read_from_result(
         mut self, field_name: String, result: ParseResult
     ) raises:
         if not result.has(field_name):
@@ -314,11 +314,11 @@ struct Flag[
     var value: Bool
     """The runtime value populated by parsing."""
 
-    fn __init__(out self):
+    def __init__(out self):
         """Default-initialise to ``False``."""
         self.value = False
 
-    fn __init__(out self, val: Bool):
+    def __init__(out self, val: Bool):
         """Initialise with an explicit value.
 
         Args:
@@ -326,7 +326,7 @@ struct Flag[
         """
         self.value = val
 
-    fn __init__(out self, *, copy: Self):
+    def __init__(out self, *, copy: Self):
         """Copy from an existing instance.
 
         Args:
@@ -334,7 +334,7 @@ struct Flag[
         """
         self.value = copy.value
 
-    fn __init__(out self, *, deinit take: Self):
+    def __init__(out self, *, deinit take: Self):
         """Move from an existing instance.
 
         Args:
@@ -342,7 +342,7 @@ struct Flag[
         """
         self.value = take.value
 
-    fn __bool__(self) -> Bool:
+    def __bool__(self) -> Bool:
         """Implicit conversion to ``Bool`` for convenience.
 
         Allows ``if args.verbose:`` rather than ``if args.verbose.value:``.
@@ -352,7 +352,7 @@ struct Flag[
         """
         return self.value
 
-    fn add_to_command(self, field_name: String, mut cmd: Command) raises:
+    def add_to_command(self, field_name: String, mut cmd: Command) raises:
         var long_name = String(Self.long) if Self.long else field_name.replace(
             "_", "-"
         )
@@ -372,7 +372,7 @@ struct Flag[
             arg._group = String(Self.group)
         cmd.add_argument(arg^)
 
-    fn read_from_result(
+    def read_from_result(
         mut self, field_name: String, result: ParseResult
     ) raises:
         self.value = result.get_flag(field_name)
@@ -432,11 +432,11 @@ struct Positional[
     var value: Self.T
     """The runtime value populated by parsing."""
 
-    fn __init__(out self):
+    def __init__(out self):
         """Default-initialise with ``T()``."""
         self.value = Self.T()
 
-    fn __init__(out self, *, copy: Self):
+    def __init__(out self, *, copy: Self):
         """Copy from an existing instance.
 
         Args:
@@ -444,7 +444,7 @@ struct Positional[
         """
         self.value = copy.value.copy()
 
-    fn __init__(out self, *, deinit take: Self):
+    def __init__(out self, *, deinit take: Self):
         """Move from an existing instance.
 
         Args:
@@ -452,7 +452,7 @@ struct Positional[
         """
         self.value = take.value^
 
-    fn add_to_command(self, field_name: String, mut cmd: Command) raises:
+    def add_to_command(self, field_name: String, mut cmd: Command) raises:
         var arg = Argument(field_name, help=String(Self.help)).positional()
         comptime if Self.remainder:
             arg._is_remainder = True
@@ -471,7 +471,7 @@ struct Positional[
             arg._group = String(Self.group)
         cmd.add_argument(arg^)
 
-    fn read_from_result(
+    def read_from_result(
         mut self, field_name: String, result: ParseResult
     ) raises:
         if not result.has(field_name):
@@ -539,11 +539,11 @@ struct Count[
     var value: Int
     """The runtime value populated by parsing."""
 
-    fn __init__(out self):
+    def __init__(out self):
         """Default-initialise to ``0``."""
         self.value = 0
 
-    fn __init__(out self, val: Int):
+    def __init__(out self, val: Int):
         """Initialise with an explicit value.
 
         Args:
@@ -551,7 +551,7 @@ struct Count[
         """
         self.value = val
 
-    fn __init__(out self, *, copy: Self):
+    def __init__(out self, *, copy: Self):
         """Copy from an existing instance.
 
         Args:
@@ -559,7 +559,7 @@ struct Count[
         """
         self.value = copy.value
 
-    fn __init__(out self, *, deinit take: Self):
+    def __init__(out self, *, deinit take: Self):
         """Move from an existing instance.
 
         Args:
@@ -567,7 +567,7 @@ struct Count[
         """
         self.value = take.value
 
-    fn add_to_command(self, field_name: String, mut cmd: Command) raises:
+    def add_to_command(self, field_name: String, mut cmd: Command) raises:
         var long_name = String(Self.long) if Self.long else field_name.replace(
             "_", "-"
         )
@@ -586,7 +586,7 @@ struct Count[
             arg._group = String(Self.group)
         cmd.add_argument(arg^)
 
-    fn read_from_result(
+    def read_from_result(
         mut self, field_name: String, result: ParseResult
     ) raises:
         self.value = result.get_count(field_name)

--- a/src/argmojo/parsable.mojo
+++ b/src/argmojo/parsable.mojo
@@ -43,7 +43,7 @@ trait Parsable(Defaultable, Movable):
     ```
     """
 
-    fn __init__(out self):
+    def __init__(out self):
         """Default-initialise all fields via reflection.
 
         Uses ``__mlir_op.lit.ownership.mark_initialized`` to bypass the
@@ -167,7 +167,7 @@ trait Parsable(Defaultable, Movable):
 
         Automatically calls ``subcommands()`` to register child commands.
         Users can modify the returned Command with builder methods
-        before calling ``from_command()`` or ``from_command_split()``.
+        before calling ``from_command()`` or ``parse_with_command()``.
 
         Returns:
             A fully configured Command.
@@ -216,7 +216,7 @@ trait Parsable(Defaultable, Movable):
         return Tuple[Self, ParseResult](args^, result^)
 
     @staticmethod
-    def from_command_split(var cmd: Command) raises -> Tuple[Self, ParseResult]:
+    def parse_with_command(var cmd: Command) raises -> Tuple[Self, ParseResult]:
         """Parse using a pre-configured Command and return both Self and ParseResult.
 
         Essential for subcommand dispatch: the typed Self gives

--- a/tests/test_hybrid.mojo
+++ b/tests/test_hybrid.mojo
@@ -341,7 +341,7 @@ def test_extra_builder_args_defaults() raises:
 
 
 # =======================================================================
-# 6. parse_with_command free function
+# 6. parse_with_command trait static method pattern
 # =======================================================================
 
 

--- a/tests/test_hybrid.mojo
+++ b/tests/test_hybrid.mojo
@@ -13,7 +13,7 @@ Covers:
   - Extra builder args accessible via ParseResult
   - configure() free function pattern
 
-Note: from_command(), parse_split(), and from_command_split() call
+Note: from_command(), parse_split(), and parse_with_command() call
 cmd.parse() which reads sys.argv(), so they cannot be exercised in
 unit tests with synthetic argument lists.  Their logic is identical
 to to_command() + parse_arguments() + from_result() which IS tested.
@@ -341,12 +341,12 @@ def test_extra_builder_args_defaults() raises:
 
 
 # =======================================================================
-# 6. from_command_split free function
+# 6. parse_with_command free function
 # =======================================================================
 
 
-def test_from_command_split_manual() raises:
-    """Simulate from_command_split: to_command → customise → parse → both."""
+def test_parse_with_command_manual() raises:
+    """Simulate parse_with_command: to_command → customise → parse → both."""
     var cmd = Deploy.to_command()
     cmd.add_tip("Verify before deploying")
 

--- a/tests/test_subcommands_declarative.mojo
+++ b/tests/test_subcommands_declarative.mojo
@@ -7,7 +7,7 @@ Tests Parsable structs as subcommand participants:
   - run() dispatch pattern for leaf command execution
   - Child.from_result() write-back from subcommand ParseResult
 
-Note: from_command(), parse_split(), and from_command_split() call
+Note: from_command(), parse_split(), and parse_with_command() call
 cmd.parse() which reads sys.argv(), so they cannot be exercised in
 unit tests with synthetic argument lists.  The testable equivalents
 (to_command + parse_arguments + from_result) exercise identical logic.


### PR DESCRIPTION
This PR expands the declarative API “examples surface” (new example CLIs + updated planning docs/tests) and updates the declarative API naming around dual-return parsing (`parse_with_command`).

**Changes:**
- Added new declarative example programs (`search`, `deploy`, `convert`) and wired them into pixi debug/run + clean + gitignore.
- Renamed the Parsable dual-return API from `from_command_split` to `parse_with_command` and updated references in tests/docs.
- Updated several trait/struct method declarations from `fn` to `def` for consistency with the rest of the codebase.