### PR TITLE
[core][declarative] Update `to_command` so that it returns a list of `Command`

### DIFF
--- a/examples/declarative/jomo.mojo
+++ b/examples/declarative/jomo.mojo
@@ -70,11 +70,21 @@ struct Jomo(Parsable):
 
     @staticmethod
     def subcommands() raises -> List[Command]:
-        """Declarative subcommands — just list them."""
+        """Declarative subcommands — configure and return them."""
         var subs = List[Command]()
-        subs.append(JomoFormat.to_command())
-        subs.append(JomoDoc.to_command())
-        subs.append(JomoPackage.to_command())
+
+        var format_cmd = JomoFormat.to_command()
+        format_cmd.help_on_no_arguments()
+        subs.append(format_cmd^)
+
+        var doc_cmd = JomoDoc.to_command()
+        doc_cmd.help_on_no_arguments()
+        subs.append(doc_cmd^)
+
+        var package_cmd = JomoPackage.to_command()
+        package_cmd.help_on_no_arguments()
+        subs.append(package_cmd^)
+
         return subs^
 
     def run(self) raises:

--- a/examples/declarative/jomo.mojo
+++ b/examples/declarative/jomo.mojo
@@ -15,7 +15,8 @@ Showcases:
   - Declarative subcommand structs (``format``, ``doc``, ``package``)
   - Builder subcommands (``run``, ``build``) for shared compilation options
   - Hybrid: declarative root + both declarative and builder children
-  - ``subcommands()`` hook with ``ChildParsable.to_command()``
+  - ``subcommands()`` returning ``List[Command]`` for declarative children
+  - Builder subcommands added in ``main()`` via ``command.add_subcommand()``
   - ``T.from_parse_result()`` write-back for typed subcommand dispatch
   - ``run()`` dispatch pattern
 
@@ -68,23 +69,13 @@ struct Jomo(Parsable):
         return String("jomo")
 
     @staticmethod
-    def subcommands(mut cmd: Command) raises:
-        """Register subcommands — mix of declarative and builder."""
-        # Builder subcommands (share compilation/target option helpers)
-        # `build_run()` and `build_build()` return Command instances
-        # that are defined with builder-style APIs (not Parsable structs).
-        cmd.add_subcommand(build_run())
-        cmd.add_subcommand(build_build())
-        # Declarative subcommands
-        var pkg = JomoPackage.to_command()
-        pkg.help_on_no_arguments()
-        cmd.add_subcommand(pkg^)
-        var fmt = JomoFormat.to_command()
-        fmt.help_on_no_arguments()
-        cmd.add_subcommand(fmt^)
-        var doc = JomoDoc.to_command()
-        doc.help_on_no_arguments()
-        cmd.add_subcommand(doc^)
+    def subcommands() raises -> List[Command]:
+        """Declarative subcommands — just list them."""
+        var subs = List[Command]()
+        subs.append(JomoFormat.to_command())
+        subs.append(JomoDoc.to_command())
+        subs.append(JomoPackage.to_command())
+        return subs^
 
     def run(self) raises:
         print("Jomo -- run a subcommand. Try: jomo --help")
@@ -217,9 +208,9 @@ struct JomoPackage(Parsable):
 # =====================================================================
 
 
-def shared_compilation_options(mut cmd: Command) raises:
+def shared_compilation_options(mut command: Command) raises:
     """Add options shared by `run` and `build`."""
-    cmd.add_argument(
+    command.add_argument(
         Argument("optimization-level", help="Optimization level (0-3)")
         .long["optimization-level"]()
         .short["O"]()
@@ -228,7 +219,7 @@ def shared_compilation_options(mut cmd: Command) raises:
         .value_name["LEVEL"]()
         .group["Compilation options"]()
     )
-    cmd.add_argument(
+    command.add_argument(
         Argument("include-path", help="Append to the module search path")
         .long["include-path"]()
         .short["I"]()
@@ -236,7 +227,7 @@ def shared_compilation_options(mut cmd: Command) raises:
         .value_name["PATH"]()
         .group["Compilation options"]()
     )
-    cmd.add_argument(
+    command.add_argument(
         Argument("define", help="Define a compile-time key=value (-D key=val)")
         .long["define"]()
         .short["D"]()
@@ -244,7 +235,7 @@ def shared_compilation_options(mut cmd: Command) raises:
         .value_name["KEY=VALUE"]()
         .group["Compilation options"]()
     )
-    cmd.add_argument(
+    command.add_argument(
         Argument(
             "debug-level", help="Debug info level: none, line-tables, full"
         )
@@ -257,7 +248,7 @@ def shared_compilation_options(mut cmd: Command) raises:
         .value_name["LEVEL"]()
         .group["Compilation options"]()
     )
-    cmd.add_argument(
+    command.add_argument(
         Argument("num-threads", help="Max threads for compilation (0 = all)")
         .long["num-threads"]()
         .short["j"]()
@@ -268,21 +259,21 @@ def shared_compilation_options(mut cmd: Command) raises:
     )
 
 
-def shared_target_options(mut cmd: Command) raises:
+def shared_target_options(mut command: Command) raises:
     """Add target options shared by `run` and `build`."""
-    cmd.add_argument(
+    command.add_argument(
         Argument("target-triple", help="Compilation target triple")
         .long["target-triple"]()
         .value_name["TRIPLE"]()
         .group["Target options"]()
     )
-    cmd.add_argument(
+    command.add_argument(
         Argument("target-cpu", help="Compilation target CPU")
         .long["target-cpu"]()
         .value_name["CPU"]()
         .group["Target options"]()
     )
-    cmd.add_argument(
+    command.add_argument(
         Argument("target-features", help="Compilation target CPU features")
         .long["target-features"]()
         .value_name["FEATURES"]()
@@ -291,37 +282,37 @@ def shared_target_options(mut cmd: Command) raises:
 
 
 def build_run() raises -> Command:
-    var cmd = Command("run", "Builds and executes a Mojo file.")
-    shared_compilation_options(cmd)
-    shared_target_options(cmd)
-    cmd.add_argument(
+    var command = Command("run", "Builds and executes a Mojo file.")
+    shared_compilation_options(command)
+    shared_target_options(command)
+    command.add_argument(
         Argument("path", help="Path to the Mojo source file")
         .positional()
         .required()
         .value_name["PATH"]()
     )
-    cmd.add_argument(
+    command.add_argument(
         Argument("args", help="Arguments passed to the Mojo program")
         .positional()
         .remainder()
         .value_name["ARGS"]()
     )
-    cmd.help_on_no_arguments()
-    return cmd^
+    command.help_on_no_arguments()
+    return command^
 
 
 def build_build() raises -> Command:
-    var cmd = Command("build", "Builds an executable from a Mojo file.")
-    shared_compilation_options(cmd)
-    shared_target_options(cmd)
-    cmd.add_argument(
+    var command = Command("build", "Builds an executable from a Mojo file.")
+    shared_compilation_options(command)
+    shared_target_options(command)
+    command.add_argument(
         Argument("output", help="Output path for the executable")
         .long["output"]()
         .short["o"]()
         .value_name["PATH"]()
         .group["Output options"]()
     )
-    cmd.add_argument(
+    command.add_argument(
         Argument(
             "emit", help="Output file type: exe, shared-lib, object, llvm, asm"
         )
@@ -336,14 +327,14 @@ def build_build() raises -> Command:
         .value_name["FILE_TYPE"]()
         .group["Output options"]()
     )
-    cmd.add_argument(
+    command.add_argument(
         Argument("path", help="Path to the Mojo source file")
         .positional()
         .required()
         .value_name["PATH"]()
     )
-    cmd.help_on_no_arguments()
-    return cmd^
+    command.help_on_no_arguments()
+    return command^
 
 
 # =====================================================================
@@ -353,31 +344,35 @@ def build_build() raises -> Command:
 
 def main() raises:
     # Build the command tree: declarative root + mixed subcommands.
-    var cmd = Jomo.to_command()
+    var command = Jomo.to_command()
+
+    # Builder subcommands — added here, not in subcommands().
+    command.add_subcommand(build_run())
+    command.add_subcommand(build_build())
 
     # Parse argv.
-    var result = cmd.parse()
+    var parse_result = command.parse()
 
     # Populate the declarative root struct.
-    var jomo = Jomo.from_parse_result(result)
+    var jomo = Jomo.from_parse_result(parse_result)
 
     # Show verbosity if set.
     if jomo.verbose.value > 0:
         print("Verbosity level:", jomo.verbose.value)
 
     # Dispatch subcommands.
-    if result.has_subcommand_result():
-        var sub = result.get_subcommand_result()
+    if parse_result.has_subcommand_result():
+        var subcommand_parse_result = parse_result.get_subcommand_result()
 
         # Declarative subcommands — typed dispatch via from_parse_result + run().
-        if result.subcommand == "format":
-            JomoFormat.from_parse_result(sub).run()
-        elif result.subcommand == "doc":
-            JomoDoc.from_parse_result(sub).run()
-        elif result.subcommand == "package":
-            JomoPackage.from_parse_result(sub).run()
+        if parse_result.subcommand == "format":
+            JomoFormat.from_parse_result(subcommand_parse_result).run()
+        elif parse_result.subcommand == "doc":
+            JomoDoc.from_parse_result(subcommand_parse_result).run()
+        elif parse_result.subcommand == "package":
+            JomoPackage.from_parse_result(subcommand_parse_result).run()
         else:
             # Builder subcommands (run, build) — use raw ParseResult.
-            sub.print_summary()
+            subcommand_parse_result.print_summary()
     else:
         jomo.run()

--- a/src/argmojo/parsable.mojo
+++ b/src/argmojo/parsable.mojo
@@ -115,7 +115,7 @@ trait Parsable(Defaultable, Movable):
         """Return a list of child subcommands.
 
         Called automatically by ``to_command()`` to register children.
-        Override to declare declarative subcommands::
+        Override to declare declarative subcommands:
 
         ```sh
         @staticmethod
@@ -213,8 +213,8 @@ trait Parsable(Defaultable, Movable):
                 )
 
         var subs = Self.subcommands()
-        for i in range(len(subs)):
-            cmd.add_subcommand(subs[i].copy())
+        while len(subs) > 0:
+            cmd.add_subcommand(subs.pop(0))
         return cmd^
 
     @staticmethod

--- a/src/argmojo/parsable.mojo
+++ b/src/argmojo/parsable.mojo
@@ -111,15 +111,29 @@ trait Parsable(Defaultable, Movable):
         return String("")
 
     @staticmethod
-    def subcommands(mut cmd: Command) raises:
-        """Register child subcommands onto the given Command via builder API.
+    def subcommands() raises -> List[Command]:
+        """Return a list of child subcommands.
 
-        Called automatically by ``to_command()``.  The default does nothing.
+        Called automatically by ``to_command()`` to register children.
+        Override to declare declarative subcommands::
 
-        Args:
-            cmd: The parent Command to add subcommands to.
+        ```sh
+        @staticmethod
+        def subcommands() raises -> List[Command]:
+            var subs = List[Command]()
+            subs.append(ChildA.to_command())
+            subs.append(ChildB.to_command())
+            return subs^
+        ```
+
+        For builder subcommands or per-child customization, use
+        ``to_command()`` in ``main()`` and call ``cmd.add_subcommand()``
+        directly.
+
+        Returns:
+            A list of Command instances (empty by default).
         """
-        pass
+        return List[Command]()
 
     def run(self) raises:
         """Execute this command's logic after parsing.
@@ -198,7 +212,9 @@ trait Parsable(Defaultable, Movable):
                     String(fname), cmd
                 )
 
-        Self.subcommands(cmd)
+        var subs = Self.subcommands()
+        for i in range(len(subs)):
+            cmd.add_subcommand(subs[i].copy())
         return cmd^
 
     @staticmethod

--- a/tests/test_subcommands_declarative.mojo
+++ b/tests/test_subcommands_declarative.mojo
@@ -83,9 +83,11 @@ struct AppRoot(Parsable):
         return "My CLI application"
 
     @staticmethod
-    def subcommands(mut cmd: Command) raises:
-        cmd.add_subcommand(SearchCmd.to_command())
-        cmd.add_subcommand(ListCmd.to_command())
+    def subcommands() raises -> List[Command]:
+        var subs = List[Command]()
+        subs.append(SearchCmd.to_command())
+        subs.append(ListCmd.to_command())
+        return subs^
 
 
 # =====================================================================
@@ -144,9 +146,11 @@ struct RemoteCmd(Parsable):
         return "Manage remotes"
 
     @staticmethod
-    def subcommands(mut cmd: Command) raises:
-        cmd.add_subcommand(RemoteAddCmd.to_command())
-        cmd.add_subcommand(RemoteRemoveCmd.to_command())
+    def subcommands() raises -> List[Command]:
+        var subs = List[Command]()
+        subs.append(RemoteAddCmd.to_command())
+        subs.append(RemoteRemoveCmd.to_command())
+        return subs^
 
 
 struct GitApp(Parsable):
@@ -163,8 +167,10 @@ struct GitApp(Parsable):
         return "Git-like tool"
 
     @staticmethod
-    def subcommands(mut cmd: Command) raises:
-        cmd.add_subcommand(RemoteCmd.to_command())
+    def subcommands() raises -> List[Command]:
+        var subs = List[Command]()
+        subs.append(RemoteCmd.to_command())
+        return subs^
 
 
 # =====================================================================
@@ -186,8 +192,10 @@ struct RunTestRoot(Parsable):
         return "Run-dispatch test"
 
     @staticmethod
-    def subcommands(mut cmd: Command) raises:
-        cmd.add_subcommand(RunLeafCmd.to_command())
+    def subcommands() raises -> List[Command]:
+        var subs = List[Command]()
+        subs.append(RunLeafCmd.to_command())
+        return subs^
 
     def run(self) raises:
         """Root run does nothing (like printing help)."""


### PR DESCRIPTION
This PR updates the declarative subcommand hook in `Parsable` to return a `List[Command]`, allowing `to_command()` to register child commands from a returned list instead of mutating a parent `Command` in-place.

**Changes:**
- Changed `Parsable.subcommands()` signature to `@staticmethod def subcommands() -> List[Command]` (default: empty list) and updated `to_command()` to register returned subcommands.
- Updated declarative subcommand tests to use the new `subcommands()` return style.
- Updated the `examples/declarative/jomo.mojo` example to align with the new hook and moved builder subcommand registration into `main()`.