### PR TITLE
[declarative][doc] Standardize `Parsable` parsing method names + Update documents for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ argmojo/
 │   └── declarative/                   # Declarative API examples
 │       ├── search.mojo                # Pure declarative (simple tool)
 │       ├── deploy.mojo                # Hybrid (declarative + builder)
-│       ├── convert.mojo               # Split parse (dual return)
+│       ├── convert.mojo               # Full parse (dual return)
 │       └── jomo.mojo                  # Subcommands (Mojo CLI lookalike)
 ├── src/
 │   └── argmojo/                       # Main package

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A feature-rich command-line argument parser library for Mojo, with both builder 
 
 ## Overview
 
-ArgMojo provides two complementary styles for defining and parsing command-line arguments in Mojo: a **builder API** for maximum control (`Command` + `Argument` chains) and an optional **struct-based declarative API** inspired by Swift's [swift-argument-parser](https://github.com/apple/swift-argument-parser) (define a `Parsable` struct, call `MyArgs.parse()`, get typed results). Both styles can be mixed freely — declare 80% of your arguments in a struct, then reach for builder methods for the rest.
+ArgMojo provides two complementary styles for defining and parsing command-line arguments in Mojo: a **builder API** for maximum control (`Command` + `Argument` chains) and an optional **struct-based declarative API** inspired by Swift's [swift-argument-parser](https://github.com/apple/swift-argument-parser) (define a `Parsable` struct, call `MyArgs.parse()`, get typed results). You can mix both freely — put most of your arguments in a struct and drop down to builder methods whenever you need finer control.
 
 ArgMojo currently supports:
 
@@ -208,7 +208,16 @@ cmd.implies("force", "validated")
 var deploy = Deploy.parse_from_command(cmd^)     # Command → typed struct
 ```
 
-See `examples/declarative/` for more patterns: pure declarative, hybrid, split parse, and subcommands.
+The `Parsable` trait provides four parsing methods:
+
+|                  | `sys.argv()`     | from `Command`                  |
+| ---------------- | ---------------- | ------------------------------- |
+| returns `Self`   | `parse()`        | `parse_from_command(cmd^)`      |
+| returns `Tuple`  | `parse_full()`   | `parse_full_from_command(cmd^)` |
+
+Plus: `parse_args(args)` for testing, `to_command()` to reflect a struct into a `Command`, and `from_parse_result(result)` for subcommand write-back.
+
+See `examples/declarative/` for more patterns: pure declarative, hybrid, full parse, and subcommands.
 
 ## Usage Examples
 
@@ -225,7 +234,7 @@ ArgMojo ships with two complete example CLIs:
 | **Declarative examples**    |                                     |                                                                                                                                                                                                                                                                                                                                   |
 | `search` — pure declarative | `examples/declarative/search.mojo`  | Positional args, flags, count flags, choices, range clamping, append/collect — all via `Parsable` struct                                                                                                                                                                                                                          |
 | `deploy` — hybrid           | `examples/declarative/deploy.mojo`  | Declarative struct + builder customisation (`mutually_exclusive`, `implies`, tips, colours)                                                                                                                                                                                                                                       |
-| `convert` — split parse     | `examples/declarative/convert.mojo` | Declarative fields + extra builder args; `parse_with_command()` dual return                                                                                                                                                                                                                                                       |
+| `convert` — full parse      | `examples/declarative/convert.mojo` | Declarative fields + extra builder args; `parse_full_from_command()` dual return                                                                                                                                                                                                                                                  |
 | `jomo` — subcommands        | `examples/declarative/jomo.mojo`    | Declarative root + mix of declarative and builder subcommands; `subcommands()` hook, `from_parse_result()` dispatch                                                                                                                                                                                                               |
 
 Build both example binaries:

--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -688,7 +688,7 @@ These features use capabilities already available in Mojo 0.26.2 and can be expe
 
 - **Layered on builder** — `parser.mojo` is a consumer of `Command` + `Argument`; no new parsing engine.
 - **Swift-inspired** — Parametric wrapper types (`Option[T, ...]`, `Flag[...]`, `Positional[T, ...]`, `Count[...]`) mirror Swift's property wrappers (`@Option`, `@Flag`, `@Argument`). `Parsable` trait mirrors `ParsableCommand`.
-- **Two innovations beyond Swift**: (1) `to_command()` exposes the underlying `Command` for builder-level tweaks (groups, implications, coloured help); (2) `parse_split()` returns both typed struct + `ParseResult` for hybrid workflows.
+- **Two innovations beyond Swift**: (1) `to_command()` exposes the underlying `Command` for builder-level tweaks (groups, implications, coloured help); (2) `parse_full()` returns both typed struct + `ParseResult` for hybrid workflows.
 - **Optional** — Users who prefer the builder API are completely unaffected. Zero change to existing code.
 
 **Pre/Post run hooks** — Straightforward callback mechanism (`def(ParseResult) raises`). No special language features needed; just needs API design and a decision on execution order with subcommands.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,8 +3,42 @@
 This document tracks all notable changes to ArgMojo, including new features, API changes, bug fixes, and documentation updates.
 
 <!--
-Comment out unreleased changes here. This file will be edited just before each release to reflect the final changelog for that version.
+Unreleased changes should be commented out from here. This file will be edited just before each release to reflect the final changelog for that version. Otherwise, the users would be confused.
 -->
+
+## 20260404 (v0.5.0)
+
+ArgMojo v0.5.0 introduces the **struct-based declarative API** — define a `Parsable` struct with typed wrapper fields (`Option`, `Flag`, `Positional`, `Count`), call `MyArgs.parse()`, and get typed results. The declarative API coexists with the existing builder API and bridges between them via `to_command()` / `parse_from_command()`. This release also adds asterisk-masked password input and reorganises internal modules.
+
+ArgMojo v0.5.0 targets Mojo v0.26.2.
+
+### ⭐️ New in v0.5.0
+
+1. **Declarative API core** — `Parsable` trait with compile-time reflection over wrapper-typed fields. Conforming structs need only declare fields and provide `description()`; all parsing, Command-building, and write-back methods are provided as trait defaults (PR #34, #35, #37, #40).
+2. **Wrapper types** — `Option[T, ...]`, `Flag[...]`, `Positional[T, ...]`, `Count[...]` parametric structs encode CLI metadata as compile-time parameters. Conform to the internal `ArgumentLike` trait with `add_to_command()` / `read_from_result()` hooks (PR #34).
+3. **Auto-initialisation** — `Parsable.__init__` uses `mark_initialized` + `comptime for` + `UnsafePointer.init_pointee_move` to default-construct all fields via reflection. Users never need to write `__init__` (PR #37).
+4. **Hybrid bridge** — `to_command()` reflects a `Parsable` struct into an owned `Command` for builder-level customisation; `parse_from_command(cmd^)` parses back into a typed struct (PR #35, #40).
+5. **Dual-return parsing** — `parse_full()` returns `Tuple[Self, ParseResult]` for workflows that need both typed struct fields and raw `ParseResult` access (e.g. subcommand dispatch). `parse_full_from_command(cmd^)` does the same from a pre-configured Command (PR #40, #42).
+6. **Subcommand support** — `subcommands()` hook on `Parsable` returns `List[Command]`; called automatically by `to_command()` for recursive tree assembly. `run(self)` method for leaf command execution. `from_parse_result()` for typed write-back from subcommand results (PR #39, #43).
+7. **Asterisk-masked password input** — `.password[True]()` on `Argument` echoes `*` for each keystroke (sudo-rs style), complementing the existing `.password()` which hides input entirely. Uses raw terminal mode with ICANON/ISIG disabled (PR #32).
+
+### 🦋 Changed in v0.5.0
+
+1. Remove `Arg` alias for `Argument` and drop `ArgumentLike` from the public export list. The public API now exports: `Argument`, `Command`, `ParseResult`, `Parsable`, `Option`, `Flag`, `Positional`, `Count` (PR #42).
+2. `subcommands()` hook signature changed from `subcommands(mut cmd: Command) raises` to `subcommands() raises -> List[Command]` — returns a list of Commands instead of mutating one (PR #43).
+3. Reorganise `Argument` and `Command` source files into clearly grouped internal sections for readability (PR #33).
+
+### 📚 Documentation and testing in v0.5.0
+
+- Add `docs/declarative_api_planning.md` — comprehensive design document for the declarative API (PR #33).
+- Add 4 declarative examples: `search.mojo` (pure declarative), `deploy.mojo` (hybrid), `convert.mojo` (full parse + extra builder args), `jomo.mojo` (subcommands with hybrid tree) (PR #41).
+- Add 4 test modules: `test_wrappers.mojo` (wrapper defaults, copy/move, `Flag.__bool__`), `test_declarative.mojo` (to_command, parse_args, from_parse_result), `test_hybrid.mojo` (builder customisation, mutually exclusive, implies, configure pattern), `test_subcommands_declarative.mojo` (flat/nested subcommands, run() dispatch, dual return) (PR #38, #39).
+- Add `test_interactive.mojo` for interactive prompting edge cases (PR #33).
+- Add method matrix table to README, user manual, and planning doc.
+- Update README with declarative API Quick Start, examples table, and project structure.
+- Update user manual with declarative API usage guide, full-parse section, and API summary.
+
+---
 
 ## 20260321 (v0.4.0)
 

--- a/docs/declarative_api_planning.md
+++ b/docs/declarative_api_planning.md
@@ -115,15 +115,15 @@ Direct mapping to argmojo declarative API:
 | `ExpressibleByArgument` protocol | `ExpressibleByArgument` trait                                   |
 | `CommandGroup`                   | `Parsable` at every level + `to_command()` / `add_subcommand()` |
 | `Greet.main()`                   | `Greet.parse()` — trait default method                          |
-| `mutating func validate()`       | `def validate(self) raises` on `Parsable`                       |
+| `mutating func validate()`       | `def validate(self) raises` on `Parsable` (Phase 4)             |
 
 What I think argmojo can add beyond Swift:
 
 1. `to_command()` returns an owned `Command` for builder-level customisation followed by `parse_from_command(cmd^)` — Swift's `ParsableCommand` is a sealed box with no escape hatch to things like mutually exclusive groups, implications, or custom help formatting.
-2. `parse_split()` returns both typed struct + `ParseResult` — Swift requires all fields to live in the struct.
+2. `parse_full()` returns both typed struct + `ParseResult` — Swift requires all fields to live in the struct.
 3. Declarative is optional — Swift has no builder alternative; you *must* use the struct-based approach.
 
-**`validate()`**: I'm also thinking about an optional `def validate(self) raises` method on `Parsable` (mirroring Swift's `validate()`). It would complement `to_command()` for post-parse cross-field validation without requiring the builder API.
+**`validate()`**: I'm also thinking about an optional `def validate(self) raises` method on `Parsable` (mirroring Swift's `validate()`). It would complement `to_command()` for post-parse cross-field validation without requiring the builder API. *(Phase 4)*
 
 **A note on naming** — I had to pick names for several structs and traits. Some were genuinely hard. The final names inevitably reflect my personal taste, but I tried to be consistent and self-explanatory. Here's what I chose and why:
 
@@ -131,54 +131,54 @@ What I think argmojo can add beyond Swift:
 
 2. **`Positional`**: Swift calls it `@Argument`, but I already have an `Argument` struct in the builder layer that covers *all* argument types. Two different `Argument` types with different meanings would be confusing. `Positional` is unambiguous — it tells you exactly what kind of argument it is.
 
-3. **No `Parser[T]` struct** — In an earlier draft I had a `Parser[T]` orchestrator struct. But I realised this extra wrapper serves no purpose: Mojo 0.26.2 supports `Self` reflection inside trait default methods, so the `Parsable` trait itself can host `parse()`, `to_command()`, `parse_split()`, etc. This eliminates one layer of indirection and produces an API that matches Rust's `MyArgs::parse()` and Swift's `Greet.main()` — the user struct is the parser. This is also directly analogous to Rust clap's `#[derive(Parser)]`, which generates `MyArgs::parse()` on the implementing struct — our `Parsable` trait's default methods achieve the same effect without proc macros. I verified this approach in `temp_test_plan_b_full.mojo` — all 7 patterns (parse, to_command, parse_from_command, parse_split, validate, parse_args, configure callback) compile and run correctly.
+3. **No `Parser[T]` struct** — In an earlier draft I had a `Parser[T]` orchestrator struct. But I realised this extra wrapper serves no purpose: Mojo 0.26.2 supports `Self` reflection inside trait default methods, so the `Parsable` trait itself can host `parse()`, `to_command()`, `parse_full()`, etc. This eliminates one layer of indirection and produces an API that matches Rust's `MyArgs::parse()` and Swift's `Greet.main()` — the user struct is the parser. This is also directly analogous to Rust clap's `#[derive(Parser)]`, which generates `MyArgs::parse()` on the implementing struct — our `Parsable` trait's default methods achieve the same effect without proc macros. I verified this approach in `temp_test_plan_b_full.mojo` — all 7 patterns (parse, to_command, parse_from_command, parse_full, validate, parse_args, configure callback) compile and run correctly.
 
 ## 3. Architecture
 
 ```txt
-┌──────────────────────────────────────────────────────────────────────────┐
-│  User Code                                                               │
-│                                                                          │
-│  struct MyArgs(Parsable):                                                │
-│      var name: Positional[String, help="Name", required=True]            │
-│      var verbose: Flag[short="v", help="Verbose"]                        │
-│      var output: Option[String, long="output", short="o"]                │
-│      # No __init__ needed — Parsable auto-initialises all fields         │
-│                                                                          │
-│  # Pure declarative (one line):                                          │
-│  var args = MyArgs.parse()                                               │
-│                                                                          │
-│  # Hybrid (to_command → customise → parse_from_command):                       │
-│  var cmd = MyArgs.to_command()                                           │
-│  cmd.mutually_exclusive([...])                                           │
-│  var args = MyArgs.parse_from_command(cmd^)                                    │
-│                                                                          │
-│  # Dual return:                                                          │
-│  var result = MyArgs.parse_split()                                       │
-│  print(result[0].name.value)   # typed                                   │
-│  print(result[1].get_string("extra"))  # untyped                         │
-│                                                                          │
-├──────────────────────────────────────────────────────────────────────────┤
-│  parsable.mojo  (trait default methods — the core of declarative API)    │
-│                                                                          │
-│  Parsable.to_command()  → Command   (reflect Self → builder calls)       │
-│  Parsable.parse()       → Self      (to_command + parse + write-back)    │
-│  Parsable.parse_from_command() → Self     (parse from pre-configured Command)  │
-│  Parsable.parse_split() → (Self, ParseResult)  (dual return)             │
-│  Parsable.parse_args()  → Self      (parse from explicit arg list)       │
-│  Parsable.validate()    → None      (post-parse cross-field validation)  │
-│  (wrapper types are auto-initialised by Parsable — no manual __init__)   │
-│                                                                          │
-│  argument_wrappers.mojo — wrapper types:                                 │
-│  Positional[T, ...], Option[T, ...], Flag[...], Count[...]               │
-│                                                                          │
-├──────────────────────────────────────────────────────────────────────────┤
-│  argument.mojo + command.mojo + parse_result.mojo  (UNCHANGED)           │
-│                                                                          │
-│  Argument(...).long["x"]().short["y"]().flag()                           │
-│  Command("app").add_argument(...).parse() → ParseResult                  │
-│                                                                          │
-└──────────────────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  User Code                                                                   │
+│                                                                              │
+│  struct MyArgs(Parsable):                                                    │
+│      var name: Positional[String, help="Name", required=True]                │
+│      var verbose: Flag[short="v", help="Verbose"]                            │
+│      var output: Option[String, long="output", short="o"]                    │
+│      # No __init__ needed — Parsable auto-initialises all fields             │
+│                                                                              │
+│  # Pure declarative (one line):                                              │
+│  var args = MyArgs.parse()                                                   │
+│                                                                              │
+│  # Hybrid (to_command → customise → parse_from_command):                     │
+│  var cmd = MyArgs.to_command()                                               │
+│  cmd.mutually_exclusive([...])                                               │
+│  var args = MyArgs.parse_from_command(cmd^)                                  │
+│                                                                              │
+│  # Dual return:                                                              │
+│  var result = MyArgs.parse_full()                                           │
+│  print(result[0].name.value)   # typed                                       │
+│  print(result[1].get_string("extra"))  # untyped                             │
+│                                                                              │
+├──────────────────────────────────────────────────────────────────────────────┤
+│  parsable.mojo  (trait default methods — the core of declarative API)        │
+│                                                                              │
+│  Parsable.to_command()  → Command   (reflect Self → builder calls)           │
+│  Parsable.parse()       → Self      (to_command + parse + write-back)        │
+│  Parsable.parse_from_command() → Self  (parse from pre-configured Command)   │
+│  Parsable.parse_full() → (Self, ParseResult)  (dual return)                 │
+│  Parsable.parse_args()  → Self      (parse from explicit arg list)           │
+│  Parsable.validate()    → None      (post-parse cross-field validation)      │  ← Phase 4, not yet implemented
+│  (wrapper types are auto-initialised by Parsable — no manual __init__)       │
+│                                                                              │
+│  argument_wrappers.mojo — wrapper types:                                     │
+│  Positional[T, ...], Option[T, ...], Flag[...], Count[...]                   │
+│                                                                              │
+├──────────────────────────────────────────────────────────────────────────────┤
+│  argument.mojo + command.mojo + parse_result.mojo  (UNCHANGED)               │
+│                                                                              │
+│  Argument(...).long["x"]().short["y"]().flag()                               │
+│  Command("app").add_argument(...).parse() → ParseResult                      │
+│                                                                              │
+└──────────────────────────────────────────────────────────────────────────────┘
 ```
 
 ### Files Changed
@@ -199,7 +199,7 @@ What I think argmojo can add beyond Swift:
 | Parse         | `command.parse()`           | `MyArgs.parse()` (returns typed struct)                            |
 | Parse result  | `ParseResult`               | Typed struct `MyArgs` with inner `.value` fields                   |
 | Hybrid bridge | —                           | `MyArgs.to_command()` → modify → `MyArgs.parse_from_command(cmd^)` |
-| Dual return   | —                           | `MyArgs.parse_split()` → `Tuple[MyArgs, ParseResult]`              |
+| Dual return   | —                           | `MyArgs.parse_full()` → `Tuple[MyArgs, ParseResult]`               |
 
 ## 4. Detailed API Design
 
@@ -420,7 +420,7 @@ trait Parsable(Defaultable, Movable):
     # ── Dual return ──
 
     @staticmethod
-    def parse_split() raises -> Tuple[Self, ParseResult]:
+    def parse_full() raises -> Tuple[Self, ParseResult]:
         """Parse and return BOTH a typed struct AND the raw ParseResult.
         The struct covers declarative fields; ParseResult covers everything."""
         var cmd = Self.to_command()
@@ -429,7 +429,7 @@ trait Parsable(Defaultable, Movable):
         return Tuple[Self, ParseResult](typed^, result^)
 
     @staticmethod
-    def parse_with_command(owned cmd: Command) raises -> Tuple[Self, ParseResult]:
+    def parse_full_from_command(owned cmd: Command) raises -> Tuple[Self, ParseResult]:
         """Parse from a pre-configured Command and return BOTH typed Self
         AND raw ParseResult. Essential for subcommand dispatch:
         the typed Self gives root-level flags, ParseResult gives
@@ -473,11 +473,12 @@ trait Parsable(Defaultable, Movable):
         Inspired by Swift's ParsableCommand.run()."""
         pass
 
-    # ── Post-parse validation ──
+    # ── Post-parse validation (Phase 4 — not yet implemented) ──
 
     def validate(self) raises:
         """Cross-field validation. Override to add custom checks.
-        Called automatically after parse() if overridden."""
+        Called automatically after parse() if overridden.
+        Not yet implemented — deferred to Phase 4."""
         pass
 ```
 
@@ -492,14 +493,24 @@ struct MyArgs(Parsable):
         return "My awesome tool"
 ```
 
-Everything else (`parse()`, `to_command()`, `parse_from_command()`, `parse_with_command()`, `from_parse_result()`, `parse_split()`, `parse_args()`, `validate()`, `run()`, `subcommands()`, `version()`, `name()`) comes from trait defaults.
+Everything else (`parse()`, `to_command()`, `parse_from_command()`, `parse_full_from_command()`, `from_parse_result()`, `parse_full()`, `parse_args()`, `run()`, `subcommands()`, `version()`, `name()`) comes from trait defaults. `validate()` is planned for Phase 4.
+
+The four parsing methods follow a 2×2 naming convention:
+
+|                 | `sys.argv()`   | from `Command`                  |
+| --------------- | -------------- | ------------------------------- |
+| returns `Self`  | `parse()`      | `parse_from_command(cmd^)`      |
+| returns `Tuple` | `parse_full()` | `parse_full_from_command(cmd^)` |
+
+- **`full`** means dual return — you get both the typed struct and the raw `ParseResult`.
+- **`from_command`** means parsing from a pre-configured `Command` (created via `to_command()` + builder customisation).
 
 ### 4.3 Implementation Notes
 
 All reflection logic lives directly inside the `Parsable` trait's default methods — there are **no standalone helper functions**:
 
 - **`to_command()`** — creates a `Command`, iterates Self's fields via `comptime for` + `struct_field_types[Self]()`, downcasts each `ArgumentLike`-conforming field, and calls `field.add_to_command(name, cmd)`. Registers subcommands via `subcommands()` hook.
-- **`from_parse_result(result)`** — creates `Self()`, iterates fields, downcasts each `ArgumentLike`-conforming field, and calls `field.read_from_result(name, result)`. Called by `parse()`, `parse_args()`, `parse_from_command()`, `parse_split()`, `parse_with_command()`, and directly by users for subcommand dispatch.
+- **`from_parse_result(result)`** — creates `Self()`, iterates fields, downcasts each `ArgumentLike`-conforming field, and calls `field.read_from_result(name, result)`. Called by `parse()`, `parse_args()`, `parse_from_command()`, `parse_full()`, `parse_full_from_command()`, and directly by users for subcommand dispatch.
 
 This design keeps `parsable.mojo` self-contained: the trait IS the entire declarative API.
 
@@ -665,7 +676,7 @@ def main() raises:
     print("replicas:", deploy.replicas.value)
 ```
 
-### 5.3 Split Parse (declarative + extra builder fields)
+### 5.3 Full Parse (declarative + extra builder fields)
 
 [See `examples/declarative/convert.mojo` for the full code](../examples/declarative/convert.mojo).
 
@@ -708,8 +719,8 @@ def main() raises:
     command.header_color["GREEN"]()  # Set the help header color to green
     command.help_on_no_arguments()  # Show help if no arguments are provided
 
-    # parse_with_command() returns BOTH the typed struct AND the raw ParseResult
-    var result = Convert.parse_with_command(command^)
+    # parse_full_from_command() returns BOTH the typed struct AND the raw ParseResult
+    var result = Convert.parse_full_from_command(command^)
     ref args = result[0]  # typed Convert
     ref raw = result[1]  # untyped ParseResult
 
@@ -788,7 +799,7 @@ struct MyGit(Parsable):
 
 def main() raises:
     # One call builds the entire tree (to_command calls subcommands() automatically)
-    var (git_args, result) = MyGit.parse_split()
+    var (git_args, result) = MyGit.parse_full()
 
     if git_args.verbose:
         print("Verbose mode on")
@@ -805,7 +816,7 @@ Compare this to the earlier design that required manual tree assembly in `main()
 
 #### 5.4.1 With Builder Customization
 
-When you need root-level builder config (colors, tips, etc.), use `to_command()` + `parse_with_command()`:
+When you need root-level builder config (colors, tips, etc.), use `to_command()` + `parse_full_from_command()`:
 
 ```mojo
 def main() raises:
@@ -813,7 +824,7 @@ def main() raises:
     cmd.header_color["CYAN"]()
     cmd.add_tip("Run 'mgit help <command>' for details")
 
-    var (git_args, result) = MyGit.parse_with_command(cmd^)
+    var (git_args, result) = MyGit.parse_full_from_command(cmd^)
 
     var sub = result.get_subcommand_result()
     if result.subcommand == "clone":
@@ -884,7 +895,7 @@ struct MyGit(Parsable):
         cmd.add_subcommand(Remote.to_command())  # nested tree assembled recursively
 
 def main() raises:
-    var (git_args, result) = MyGit.parse_split()
+    var (git_args, result) = MyGit.parse_full()
 
     var sub = result.get_subcommand_result()
     if result.subcommand == "clone":
@@ -919,7 +930,7 @@ struct MyGit(Parsable):
     @staticmethod
     def execute() raises:
         """Parse + dispatch in one call. Auto-generated from Subcommands."""
-        var (self_args, result) = Self.parse_split()
+        var (self_args, result) = Self.parse_full()
         @parameter
         for i in range(len(Self.Subcommands)):
             alias T = Self.Subcommands[i]
@@ -963,11 +974,11 @@ Simple tools    →    Medium complexity tools   →    Maximum control
 
 I don't know of any other Mojo CLI library that offers this continuum. You never have to completely rewrite from one style to another when requirements grow.
 
-**Type safety note**: If you use `to_command()` to add **constraints** (groups, implications, colours), full type safety is preserved — `parse_from_command()` still returns `T`. But if you add **new arguments** (`add_argument(...)`), those fields are only available via `ParseResult` from `parse_split()`. This is an intentional trade-off:
+**Type safety note**: If you use `to_command()` to add **constraints** (groups, implications, colours), full type safety is preserved — `parse_from_command()` still returns `T`. But if you add **new arguments** (`add_argument(...)`), those fields are only available via `ParseResult` from `parse_full()`. This is an intentional trade-off:
 
 ```txt
 to_command() + constraints only    →  parse_from_command()  →  T (fully typed ✓)
-to_command() + new arguments       →  parse_split()   →  Tuple[T, ParseResult] (partially typed ⚠️)
+to_command() + new arguments       →  parse_full()   →  Tuple[T, ParseResult] (partially typed ⚠️)
 ```
 
 **`configure()` as a free function pattern**: I've verified in Mojo 0.26.2 that non-capturing callbacks work. Since there's no `Parser[T]` wrapper to chain on, the configure pattern uses a free function or inline modification:
@@ -991,7 +1002,7 @@ var args = Deploy.parse_from_command(cmd^)
 
 `to_command()` + `parse_from_command()` is the primary bridge for multi-step customization.
 
-### 6.2 Innovation #2: `parse_split()` — Dual-Return Parsing
+### 6.2 Innovation #2: `parse_full()` — Dual-Return Parsing
 
 **The problem**: When mixing declarative and builder fields, how do I give you typed access to declarative fields AND untyped access to builder-added fields?
 
@@ -999,11 +1010,11 @@ var args = Deploy.parse_from_command(cmd^)
 
 **Naive approach**: Return only `ParseResult`, losing the typed struct benefit.
 
-**My approach**: `parse_split()` returns a **tuple of both**:
+**My approach**: `parse_full()` returns a **tuple of both**:
 
 ```mojo
 @staticmethod
-def parse_split() raises -> Tuple[Self, ParseResult]:
+def parse_full() raises -> Tuple[Self, ParseResult]:
 ```
 
 - The first element is your struct `T` with all declarative-registered fields populated & typed.
@@ -1012,7 +1023,7 @@ def parse_split() raises -> Tuple[Self, ParseResult]:
 This means:
 
 ```mojo
-var result = MyArgs.parse_split()
+var result = MyArgs.parse_full()
 var args = result[0]       # typed MyArgs
 var raw  = result[1]       # untyped ParseResult
 
@@ -1032,7 +1043,7 @@ As far as I know, this is a **new pattern** not seen in any CLI library in any l
 The dual-return enables a practical workflow:
 
 1. Start with pure declarative
-2. Need one advanced option? Add it via `to_command()` + `parse_with_command(command: Command)`
+2. Need one advanced option? Add it via `to_command()` + `parse_full_from_command(command: Command)`
 3. No need to convert the struct field (or add a new nested type)
 
 ### 6.3 Innovation #3: Compile-Time Schema Validation
@@ -1236,7 +1247,7 @@ def run(self) raises:
 
 # Parse + split for dispatch
 @staticmethod
-def parse_with_command(owned cmd: Command) raises -> Tuple[Self, ParseResult]:
+def parse_full_from_command(owned cmd: Command) raises -> Tuple[Self, ParseResult]:
     """Parse cmd and return both typed Self (root flags)
     and raw ParseResult (for subcommand dispatch)."""
 
@@ -1250,7 +1261,7 @@ def from_parse_result(result: ParseResult) raises -> Self:
 
 ```mojo
 # Simple — tree built automatically via subcommands() hook
-var (git_args, result) = MyGit.parse_split()
+var (git_args, result) = MyGit.parse_full()
 if result.subcommand == "clone":
     var sub = result.get_subcommand_result()
     Clone.from_parse_result(sub).run()
@@ -1258,7 +1269,7 @@ if result.subcommand == "clone":
 # With customization — to_command() already includes subcommands
 var cmd = MyGit.to_command()
 cmd.header_color["CYAN"]()
-var (git_args, result) = MyGit.parse_with_command(cmd^)
+var (git_args, result) = MyGit.parse_full_from_command(cmd^)
 ```
 
 **Comparison with alternatives**:
@@ -1308,7 +1319,7 @@ I think this is the right call — these features describe *relationships betwee
 | Count flag                      | ✗ not built-in                       | ✓ `Count[short="v", max=3]`                      |
 | Builder fallback                | ✗ no builder API                     | ✓ full builder API as alternative                |
 | Declarative ↔ builder bridge    | ✗ no escape hatch                    | ✓ `to_command()` exposes owned `Command`         |
-| Dual-return parse               | ✗ struct-only return                 | ✓ `parse_split()` → (T, ParseResult)             |
+| Dual-return parse               | ✗ struct-only return                 | ✓ `parse_full()` → (T, ParseResult)              |
 | Post-parse validation           | `mutating func validate()`           | `def validate(self) raises` (planned)            |
 | Mutually exclusive groups       | ✗ not in struct schema               | ✓ via `to_command()`                             |
 | Interactive prompt              | ✗ not supported                      | ✓ `prompt=True` in wrapper                       |
@@ -1330,7 +1341,7 @@ I think this is the right call — these features describe *relationships betwee
 - [x] Implement `Positional`, `Option`, `Flag`, `Count` wrapper structs — in `argument_wrappers.mojo`
 - [x] Implement `ArgumentLike` trait with `add_to_command()` and `read_from_result()` methods
 - [x] Implement `Parsable` trait with default methods (`description`, `version`, `name`, `subcommands`, `run`)
-- [x] ~~Implement convenience functions as free functions: `to_command`, `parse`, `parse_args`, `parse_split`, `parse_from_command`, `parse_with_command`, `from_parse_result`~~ — removed; these duplicated the Parsable trait static methods. All public access is now via `T.to_command()`, `T.parse()`, `T.parse_args()`, etc.
+- [x] ~~Implement convenience functions as free functions: `to_command`, `parse`, `parse_args`, `parse_full`, `parse_from_command`, `parse_full_from_command`, `from_parse_result`~~ — removed; these duplicated the Parsable trait static methods. All public access is now via `T.to_command()`, `T.parse()`, `T.parse_args()`, etc.
 - [x] ~~Implement `_reflect_and_register[T]()` and `_from_result[T]()`~~ — merged into trait method `to_command()` and `from_parse_result()`. No standalone helper functions remain.
 - [x] Auto-naming convention (underscore → hyphen)
 - [x] 4 passing tests: `test_to_command`, `test_parse_args`, `test_from_result`, `test_auto_naming`
@@ -1344,13 +1355,13 @@ I think this is the right call — these features describe *relationships betwee
 - [x] Test: extra builder args accessible via ParseResult + `from_parse_result()`
 - [x] ~~Test free functions: `to_command[T]()`, `parse_args[T]()`, `from_parse_result[T]()`~~ — converted to trait static method tests (`T.to_command()`, `T.parse_args()`, `T.from_parse_result()`)
 - [x] Document the `configure()` free function pattern (via test helper + test)
-- Note: `parse_from_command()`, `parse_split()`, `parse_with_command()` call `cmd.parse()` (reads `sys.argv()`), so they cannot be unit-tested with synthetic args. Their logic is identical to `to_command()` + `parse_arguments()` + `from_parse_result()` which **is** tested.
+- Note: `parse_from_command()`, `parse_full()`, `parse_full_from_command()` call `cmd.parse()` (reads `sys.argv()`), so they cannot be unit-tested with synthetic args. Their logic is identical to `to_command()` + `parse_arguments()` + `from_parse_result()` which **is** tested.
 
 ### Phase 3: Subcommands
 
-- [x] Implement `subcommands(mut cmd)` hook on `Parsable` trait + auto-call in `to_command()`
+- [x] Implement `subcommands()` hook on `Parsable` trait (returns `List[Command]`) + auto-call in `to_command()`
 - [x] Implement `run(self)` on `Parsable` trait (default no-op)
-- [x] Implement `parse_with_command()` as trait static method
+- [x] Implement `parse_full_from_command()` as trait static method
 - [x] Implement `from_parse_result()` as trait static method (public write-back)
 - [x] Test: flat subcommands with `subcommands()` hook (6 tests in `test_subcommands_declarative.mojo`)
 - [x] Test: nested subcommands (2+ levels) with mid-level flags and recursive `subcommands()` (6 tests)
@@ -1373,14 +1384,15 @@ I think this is the right call — these features describe *relationships betwee
   - [ ] Ensure choices flow to `generate_completion` output
   - [ ] Explore compile-time completion script generation
 - [ ] Some command-level features can be exposed via declarative parameters (e.g. `help_on_no_arguments=True`), but others (e.g. `confirmation_option()`) require builder-level access. Document best practices for when to use `to_command()` for command-level behavior.
+- [ ] Implement `validate(self) raises` method on `Parsable` (mirroring Swift's `validate()`) — post-parse cross-field validation without requiring the builder API
 - [ ] Add more built-in types for `Option` (e.g. `Float`) and ensure they work end-to-end with both declarative and builder patterns. This requires more methods in `ParseResult` (e.g. `get_float()`) and corresponding write-back logic in `from_parse_result()`.
 
 ### Phase 5: Polish
 
 - [ ] Comprehensive test suite (parallel to existing builder tests)
 - [x] Examples: `jomo.mojo` (Mojo CLI lookalike, hybrid declarative + builder)
-- [ ] Examples: simple pure-declarative, more hybrid patterns
-- [ ] User manual additions
-- [ ] README update with declarative examples
+- [x] Examples: simple pure-declarative (`search.mojo`), hybrid (`deploy.mojo`), full parse (`convert.mojo`)
+- [x] User manual additions
+- [x] README update with declarative examples
 
 [^fieldwise_init]: removed — compiler auto-synthesises move init from `Movable` conformance; the `Parsable` trait now provides a reflection-based default `__init__` via `mark_initialized` + `comptime for`.

--- a/docs/declarative_api_planning.md
+++ b/docs/declarative_api_planning.md
@@ -154,7 +154,7 @@ What I think argmojo can add beyond Swift:
 │  var args = MyArgs.parse_from_command(cmd^)                                  │
 │                                                                              │
 │  # Dual return:                                                              │
-│  var result = MyArgs.parse_full()                                           │
+│  var result = MyArgs.parse_full()                                            │
 │  print(result[0].name.value)   # typed                                       │
 │  print(result[1].get_string("extra"))  # untyped                             │
 │                                                                              │
@@ -164,7 +164,7 @@ What I think argmojo can add beyond Swift:
 │  Parsable.to_command()  → Command   (reflect Self → builder calls)           │
 │  Parsable.parse()       → Self      (to_command + parse + write-back)        │
 │  Parsable.parse_from_command() → Self  (parse from pre-configured Command)   │
-│  Parsable.parse_full() → (Self, ParseResult)  (dual return)                 │
+│  Parsable.parse_full() → (Self, ParseResult)  (dual return)                  │
 │  Parsable.parse_args()  → Self      (parse from explicit arg list)           │
 │  Parsable.validate()    → None      (post-parse cross-field validation)      │  ← Phase 4, not yet implemented
 │  (wrapper types are auto-initialised by Parsable — no manual __init__)       │

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -120,7 +120,7 @@ from argmojo import Argument, Command
   - [The `Parsable` Trait](#the-parsable-trait)
   - [Pure Declarative — One-Line Parse](#pure-declarative--one-line-parse)
   - [Hybrid — Declarative + Builder Customisation](#hybrid--declarative--builder-customisation)
-  - [Split Parse — Declarative + Extra Builder Fields](#split-parse--declarative--extra-builder-fields)
+  - [Full Parse — Declarative + Extra Builder Fields](#full-parse--declarative--extra-builder-fields)
   - [Subcommands](#subcommands-1)
   - [Auto-Naming Convention](#auto-naming-convention)
   - [API Summary](#api-summary)
@@ -3029,7 +3029,7 @@ Server region [us/eu/ap] (us): ap
 #### All arguments provided — no prompting at all
 
 ```console
-$ ./login --user alice --token secret-123 --region eu
+./login --user alice --token secret-123 --region eu
 ```
 
 No prompts appear. The CLI values are used directly.
@@ -3103,8 +3103,8 @@ Enable verbose output [y/n]:        ← flag prompt
 ### Interaction with Other Features
 
 - **`.required()`**: Prompting happens *before* validation. If the user provides a value via the prompt, the required check passes. `.prompt()` does **not** require `.required()` — it works on any argument.
-- **`.default[]()` **: If the user presses Enter (empty input), the default is applied by the normal default-filling phase.
-- **`.choice[]()` **: Choices are displayed in the prompt. If the user enters an invalid choice, a validation error is raised after prompting.
+- **`.default[]()`**: If the user presses Enter (empty input), the default is applied by the normal default-filling phase.
+- **`.choice[]()`**: Choices are displayed in the prompt. If the user enters an invalid choice, a validation error is raised after prompting.
 - **Subcommands**: Each subcommand can have its own prompt-enabled arguments.
 - **Persistent flags**: Persistent arguments with `.prompt()` are prompted at the level where they are missing.
 - **`help_on_no_arguments()`**: Cannot be combined with `.prompt()` on the same command. When no arguments are given, `help_on_no_arguments()` prints help and exits *before* prompting runs, making prompt-enabled arguments unreachable. ArgMojo raises a registration-time error if you attempt this combination.
@@ -3114,7 +3114,7 @@ Enable verbose output [y/n]:        ← flag prompt
 When stdin is not a terminal (piped input, CI environments, `< /dev/null`), the `input()` call raises on EOF. ArgMojo catches this gracefully and stops prompting — any values collected so far are preserved, defaults are then applied normally, and validation proceeds as usual.
 
 ```console
-$ echo "" | ./login --user alice --token secret
+echo "" | ./login --user alice --token secret
 ```
 
 Prompts are still printed to stdout, but `input()` reads from the pipe. Once the pipe is exhausted, `input()` raises and prompting stops. `--region` gets its default `"us"`.
@@ -3122,7 +3122,7 @@ Prompts are still printed to stdout, but `input()` reads from the pipe. Once the
 To avoid prompting entirely, always provide all arguments on the command line:
 
 ```console
-$ ./login --user alice --token secret --region eu
+./login --user alice --token secret --region eu
 ```
 
 ## Argument Parents and Inheritance
@@ -3298,7 +3298,7 @@ When stdin is not a terminal, the echo-control calls return `False` (harmless), 
 To bypass the prompt entirely, provide the value on the command line:
 
 ```console
-$ ./login --username alice --password s3cret
+./login --username alice --password s3cret
 ```
 
 ## Confirmation Option
@@ -3399,7 +3399,7 @@ def main() raises:
     var result = cmd.parse()
 ```
 
-The custom string appears as-is after `Usage: ` in both `--help` output and error messages:
+The custom string appears as-is after `Usage:` in both `--help` output and error messages:
 
 ```sh
 $ ./git --help
@@ -3733,7 +3733,7 @@ def main() raises:
 
 See [`examples/declarative/deploy.mojo`](../examples/declarative/deploy.mojo) for a complete example.
 
-### Split Parse — Declarative + Extra Builder Fields
+### Full Parse — Declarative + Extra Builder Fields
 
 When some arguments are too complex for the struct, add them via builder methods and retrieve both the typed struct and the raw `ParseResult`:
 
@@ -3744,7 +3744,7 @@ def main() raises:
         Argument("format", help="Output format")
         .long["format"]().choice["json"]().choice["yaml"]().default["json"]()
     )
-    var (args, raw) = Convert.parse_with_command(cmd^)
+    var (args, raw) = Convert.parse_full_from_command(cmd^)
     print(args.input.value)              # typed — from struct
     print(raw.get_string("format"))      # untyped — from builder
 ```
@@ -3776,11 +3776,13 @@ struct MyGit(Parsable):
     def description() -> String: return "A mini git tool."
 
     @staticmethod
-    def subcommands(mut cmd: Command) raises:
-        cmd.add_subcommand(Clone.to_command())
+    def subcommands() raises -> List[Command]:
+        var subs = List[Command]()
+        subs.append(Clone.to_command())
+        return subs^
 
 def main() raises:
-    var (git_args, result) = MyGit.parse_split()
+    var (git_args, result) = MyGit.parse_full()
     if git_args.verbose:
         print("Verbose mode on")
     if result.subcommand == "clone":
@@ -3804,15 +3806,25 @@ Fields wrapped in `Positional[...]` don't get auto-generated long names.
 
 ### API Summary
 
-| Method                        | Returns                 | Purpose                                                      |
-| ----------------------------- | ----------------------- | ------------------------------------------------------------ |
-| `T.parse()`                   | `T`                     | Build + parse `sys.argv()` + typed result                    |
-| `T.parse_args(args)`          | `T`                     | Parse explicit arg list (testing)                            |
-| `T.to_command()`              | `Command`               | Reflect struct → owned `Command` for customisation           |
-| `T.parse_from_command(cmd^)`  | `T`                     | Parse a customised `Command` → typed struct                  |
-| `T.parse_split()`             | `Tuple[T, ParseResult]` | Typed struct + raw result from `sys.argv()`                  |
-| `T.parse_with_command(cmd^)`  | `Tuple[T, ParseResult]` | Typed struct + raw result from customised `Command`          |
-| `T.from_parse_result(result)` | `T`                     | Write-back from existing `ParseResult` (subcommand dispatch) |
+| Method                            | Returns                 | Purpose                                                      |
+| --------------------------------- | ----------------------- | ------------------------------------------------------------ |
+| `T.parse()`                       | `T`                     | Build + parse `sys.argv()` + typed result                    |
+| `T.parse_args(args)`              | `T`                     | Parse explicit arg list (testing)                            |
+| `T.to_command()`                  | `Command`               | Reflect struct → owned `Command` for customisation           |
+| `T.parse_from_command(cmd^)`      | `T`                     | Parse a customised `Command` → typed struct                  |
+| `T.parse_full()`                  | `Tuple[T, ParseResult]` | Typed struct + raw result from `sys.argv()`                  |
+| `T.parse_full_from_command(cmd^)` | `Tuple[T, ParseResult]` | Typed struct + raw result from customised `Command`          |
+| `T.from_parse_result(result)`     | `T`                     | Write-back from existing `ParseResult` (subcommand dispatch) |
+
+The four parsing methods follow a 2×2 naming convention:
+
+|                 | `sys.argv()`   | from `Command`                  |
+| --------------- | -------------- | ------------------------------- |
+| returns `Self`  | `parse()`      | `parse_from_command(cmd^)`      |
+| returns `Tuple` | `parse_full()` | `parse_full_from_command(cmd^)` |
+
+- **`full`** means dual return — you get both the typed struct and the raw `ParseResult`.
+- **`from_command`** means parsing from a pre-configured `Command` (created via `to_command()` + builder customisation).
 
 ## Cross-Library Method Name Reference
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -215,7 +215,7 @@ command.add_argument(Argument("pattern", help="Search pattern").positional().req
 command.add_argument(Argument("path",    help="Search path").positional().default["."]())
 ```
 
-```bash
+```shell
 myapp "hello" ./src
 #       ↑        ↑
 #     pattern   path
@@ -243,7 +243,7 @@ Long options start with `--` and can receive a value in two ways:
 command.add_argument(Argument("output", help="Output file").long["output"]())
 ```
 
-```bash
+```shell
 myapp --output result.txt
 myapp --output=result.txt
 ```
@@ -264,7 +264,7 @@ command.add_argument(
 )
 ```
 
-```bash
+```shell
 myapp -o result.txt          # space-separated
 myapp -oresult.txt           # attached value (see §9)
 ```
@@ -288,7 +288,7 @@ command.add_argument(
 )
 ```
 
-```bash
+```shell
 myapp --verbose    # verbose = True
 myapp -v           # verbose = True
 myapp              # verbose = False (default)
@@ -314,7 +314,7 @@ command.add_argument(
 )
 ```
 
-```bash
+```shell
 myapp "hello"                # format = "table", path = "."
 myapp "hello" --format csv   # format = "csv",   path = "."
 myapp "hello" ./src          # format = "table", path = "./src"
@@ -332,7 +332,7 @@ command.add_argument(
 )
 ```
 
-```bash
+```shell
 myapp "hello"   # OK
 myapp           # Error: Required argument 'pattern' was not provided
 ```
@@ -353,7 +353,7 @@ command.add_argument(
 )
 ```
 
-```bash
+```shell
 myapp --colour red     # OK — colour = "red"
 myapp --color  red     # OK — resolved via alias, colour = "red"
 ```
@@ -528,7 +528,7 @@ command.add_argument(Argument("brief",     help="Brief mode").long["brief"]().sh
 command.add_argument(Argument("colorize",  help="Colorize").long["colorize"]().short["c"]().flag())
 ```
 
-```bash
+```shell
 myapp -abc
 # Expands to: -a -b -c
 # all = True, brief = True, colorize = True
@@ -540,7 +540,7 @@ myapp -abc
 command.add_argument(Argument("output", help="Output file").long["output"]().short["o"]())
 ```
 
-```bash
+```shell
 myapp -abofile.txt
 # Expands to: -a -b -o file.txt
 # all = True, brief = True, output = "file.txt"
@@ -554,7 +554,7 @@ A short option that takes a value can have its value **attached directly** — n
 command.add_argument(Argument("output", help="Output file").long["output"]().short["o"]())
 ```
 
-```bash
+```shell
 myapp -ofile.txt          # output = "file.txt"
 myapp -o file.txt         # output = "file.txt"  (same result)
 ```
@@ -574,7 +574,7 @@ command.add_argument(
 )
 ```
 
-```bash
+```shell
 myapp -v             # verbose = 1
 myapp -vv            # verbose = 2
 myapp -vvv           # verbose = 3
@@ -606,7 +606,7 @@ command.add_argument(
 )
 ```
 
-```bash
+```shell
 myapp -vvv           # verbose = 3
 myapp -vvvvv         # verbose = 3  (capped, warning printed)
 myapp -vvvvvvvvvv    # verbose = 3  (capped, warning printed)
@@ -615,7 +615,7 @@ myapp -vv            # verbose = 2  (below ceiling, not affected)
 
 The warning looks like:
 
-```bash
+```console
 warning: '--verbose' count 5 exceeds maximum 3, capped to 3
 ```
 
@@ -640,7 +640,7 @@ command.add_argument(
 
 ---
 
-```bash
+```shell
 myapp --color       # color = True,  has("color") = True
 myapp --no-color    # color = False, has("color") = True
 myapp               # color = False, has("color") = False  (default)
@@ -714,7 +714,7 @@ command.add_argument(
 
 ---
 
-```bash
+```shell
 myapp --tag alpha --tag beta --tag gamma
 # tags = ["alpha", "beta", "gamma"]
 
@@ -780,7 +780,7 @@ command.add_argument(
 )
 ```
 
-```bash
+```shell
 myapp --env dev --env prod       # OK
 myapp --env dev --env local      # Error: Invalid value 'local' for argument 'env'
 ```
@@ -806,7 +806,7 @@ Calling `.delimiter[","]()` automatically implies `.append()` — you do not nee
 
 ---
 
-```bash
+```shell
 myapp --env dev,staging,prod
 # envs = ["dev", "staging", "prod"]
 
@@ -851,7 +851,7 @@ command.add_argument(
 )
 ```
 
-```bash
+```shell
 myapp --env dev,prod       # OK
 myapp --env dev,local      # Error: Invalid value 'local' for argument 'env'
 ```
@@ -869,7 +869,7 @@ command.add_argument(
 )
 ```
 
-```bash
+```shell
 myapp --path "/usr/lib;/opt/lib;/home/lib"
 # paths = ["/usr/lib", "/opt/lib", "/home/lib"]
 ```
@@ -886,7 +886,7 @@ command.add_argument(
 )
 ```
 
-```bash
+```shell
 myapp --tag a,b --tag c -t d,e
 # tags = ["a", "b", "c", "d", "e"]
 ```
@@ -915,7 +915,7 @@ retrieved with `get_list()`.
 
 ---
 
-```bash
+```shell
 myapp --point 10 20
 # point = ["10", "20"]
 
@@ -929,7 +929,7 @@ myapp --rgb 255 128 0
 
 Each occurrence consumes N more values, all accumulating in the same list:
 
-```bash
+```shell
 myapp --point 1 2 --point 3 4
 # point = ["1", "2", "3", "4"]
 ```
@@ -940,7 +940,7 @@ myapp --point 1 2 --point 3 4
 
 nargs works with short options too:
 
-```bash
+```shell
 myapp -c 255 128 0
 # rgb = ["255", "128", "0"]
 ```
@@ -968,7 +968,7 @@ command.add_argument(
 )
 ```
 
-```bash
+```shell
 myapp --route north east    # ✓ both valid
 myapp --route north up      # ✗ 'up' is not a valid choice
 ```
@@ -1012,7 +1012,7 @@ command.add_argument(
 )
 ```
 
-```bash
+```shell
 myapp --define CC=gcc -D CXX=g++
 # result.get_map("define") → {"CC": "gcc", "CXX": "g++"}
 ```
@@ -1029,7 +1029,7 @@ next `=` to produce key `CC` and value `gcc`.
 **Value with embedded `=`** — everything after the first `=` in the
 raw value is the value part:
 
-```bash
+```shell
 myapp --define PATH=/usr/bin:/bin
 # key = "PATH", value = "/usr/bin:/bin"
 ```
@@ -1048,7 +1048,7 @@ command.add_argument(
 )
 ```
 
-```bash
+```shell
 myapp --define CC=gcc,CXX=g++
 # result.get_map("define") → {"CC": "gcc", "CXX": "g++"}
 ```
@@ -1089,7 +1089,7 @@ command.add_argument(
 )
 ```
 
-```bash
+```shell
 myapp --log-level debug    # OK
 myapp --log-level trace    # Error: Invalid value 'trace' for argument 'log-level'
                            #        (choose from 'debug', 'info', 'warn', 'error')
@@ -1097,13 +1097,13 @@ myapp --log-level trace    # Error: Invalid value 'trace' for argument 'log-leve
 
 **In help text**, choices are shown automatically:
 
-```bash
+```console
   --log-level {debug,info,warn,error}  Log level
 ```
 
 **Combining with short options and attached values:**
 
-```bash
+```shell
 myapp -ldebug              # (if short name is "l") OK
 myapp -l trace             # Error, same as above
 ```
@@ -1119,7 +1119,7 @@ command.add_argument(Argument("pattern", help="Search pattern").positional().req
 # Only 1 positional arg is defined.
 ```
 
-```bash
+```shell
 myapp "hello"                  # OK
 myapp "hello" extra1 extra2    # Error: Too many positional arguments: expected 1, got 3
 ```
@@ -1131,7 +1131,7 @@ command.add_argument(Argument("pattern", help="Search pattern").positional().req
 command.add_argument(Argument("path",    help="Search path").positional().default["."]())
 ```
 
-```bash
+```shell
 myapp "hello" ./src            # OK — pattern = "hello", path = "./src"
 myapp "hello" ./src /tmp       # Error: Too many positional arguments: expected 2, got 3
 ```
@@ -1151,7 +1151,7 @@ command.add_argument(
 )
 ```
 
-```bash
+```shell
 myapp --port 8080    # OK
 myapp --port 0       # Error: Value 0 for '--port' is out of range [1, 65535]
 myapp --port 70000   # Error: Value 70000 for '--port' is out of range [1, 65535]
@@ -1161,7 +1161,7 @@ myapp --port 70000   # Error: Value 70000 for '--port' is out of range [1, 65535
 
 **Boundary values** — both min and max are inclusive:
 
-```bash
+```shell
 myapp --port 1       # OK
 myapp --port 65535   # OK
 ```
@@ -1177,7 +1177,7 @@ command.add_argument(
 )
 ```
 
-```bash
+```shell
 myapp --port 50 --port 101
 # Error: Value 101 for '--port' is out of range [1, 100]
 ```
@@ -1195,7 +1195,7 @@ command.add_argument(
 )
 ```
 
-```bash
+```shell
 myapp --level 5      # OK — level = 5
 myapp --level 20     # Warning, level = 9  (clamped to max)
 myapp --level -3     # Warning, level = 0  (clamped to min)
@@ -1203,7 +1203,7 @@ myapp --level -3     # Warning, level = 0  (clamped to min)
 
 The warning looks like:
 
-```bash
+```console
 warning: '--level' value 20 is out of range [0, 9], clamped to 9
 ```
 
@@ -1217,7 +1217,7 @@ command.add_argument(
 )
 ```
 
-```bash
+```shell
 myapp --port 50 --port 200 --port 0
 # warning: '--port' value 200 is out of range [1, 100], clamped to 100
 # warning: '--port' value 0 is out of range [1, 100], clamped to 1
@@ -1228,7 +1228,7 @@ myapp --port 50 --port 200 --port 0
 
 **Without `.clamp()`** — the existing behaviour is unchanged; an out-of-range value raises an error:
 
-```bash
+```shell
 myapp --port 200
 # Error: Value 200 for '--port' is out of range [1, 100]
 ```
@@ -1256,7 +1256,7 @@ command.mutually_exclusive(group^)
 
 ---
 
-```bash
+```shell
 myapp --json           # OK — only one from the group
 myapp --yaml           # OK
 myapp                  # OK — none from the group is also fine
@@ -1278,7 +1278,7 @@ var io_group: List[String] = ["input", "stdin"]
 command.mutually_exclusive(io_group^)
 ```
 
-```bash
+```shell
 myapp --input data.csv         # OK
 myapp --stdin                  # OK
 myapp --input data.csv --stdin # Error: mutually exclusive
@@ -1330,7 +1330,7 @@ command.one_required(format_group^)
 
 ---
 
-```bash
+```shell
 myapp --json               # OK (one provided)
 myapp --yaml               # OK (one provided)
 myapp                      # Error: At least one of the following arguments is required: '--json', '--yaml'
@@ -1353,7 +1353,7 @@ command.mutually_exclusive(excl^)
 command.one_required(req^)
 ```
 
-```bash
+```shell
 myapp --json               # OK
 myapp --yaml               # OK
 myapp                      # Error: At least one of the following arguments is required: '--json', '--yaml'
@@ -1370,7 +1370,7 @@ command.add_argument(Argument("stdin", help="Read from stdin").long["stdin"]().f
 command.one_required(["input", "stdin"])
 ```
 
-```bash
+```shell
 myapp --input data.txt     # OK
 myapp --stdin              # OK
 myapp                      # Error: At least one of the following arguments is required: '--input', '--stdin'
@@ -1387,7 +1387,7 @@ command.one_required(["json", "yaml"])
 command.one_required(["input", "stdin"])
 ```
 
-```bash
+```shell
 myapp --json --input f.txt   # OK (both groups satisfied)
 myapp --json                 # Error (source group unsatisfied)
 ```
@@ -1421,7 +1421,7 @@ command.required_together(group^)
 
 ---
 
-```bash
+```shell
 myapp --username admin --password secret   # OK — both provided
 myapp                                      # OK — neither provided
 myapp --username admin                     # Error: Arguments required together:
@@ -1445,7 +1445,7 @@ var net_group: List[String] = ["host", "port", "proto"]
 command.required_together(net_group^)
 ```
 
-```bash
+```shell
 myapp --host localhost --port 8080 --proto https   # OK
 myapp --host localhost                             # Error: '--port', '--proto' required when '--host' is provided
 ```
@@ -1491,7 +1491,7 @@ command.required_if("output", "save")
 
 This means: **if `--save` is provided, then `--output` must also be provided.**
 
-```bash
+```shell
 myapp --save --output out.txt   # OK — both present
 myapp --save                    # Error: '--output' is required when '--save' is provided
 myapp --output file.txt         # OK — condition not triggered
@@ -1517,7 +1517,7 @@ Each rule is checked independently after parsing.
 
 Error messages use `--long` display names when available:
 
-```bash
+```console
 Error: Argument '--output' is required when '--save' is provided
 ```
 
@@ -1548,7 +1548,7 @@ command.implies("debug", "verbose")
 
 This means: **if `--debug` is provided, `--verbose` is automatically set too.**
 
-```bash
+```shell
 myapp --debug          # OK — --verbose is auto-set
 myapp --debug -v       # OK — --verbose already set, no conflict
 myapp --verbose        # OK — --debug is NOT set (one-directional)
@@ -1661,7 +1661,7 @@ app.add_subcommand(init^)
 var result = app.parse()
 ```
 
-```bash
+```shell
 app search "fn main" --max-depth 3
 app init my-project
 ```
@@ -1670,7 +1670,7 @@ app init my-project
 
 **Root-level flags before the subcommand token** are parsed as part of the root command:
 
-```bash
+```shell
 app --verbose search "fn main"
 # verbose = True (root flag), subcommand = "search"
 ```
@@ -1698,7 +1698,7 @@ Commands:
 
 **Child help** shows the full command path in the usage line:
 
-```bash
+```shell
 app search --help
 ```
 
@@ -1720,7 +1720,7 @@ Options:
 
 **The `--` stop marker** prevents subcommand dispatch. After `--`, all tokens become positional arguments for the root command:
 
-```bash
+```shell
 app -- search
 # "search" is a root positional, NOT a subcommand dispatch
 ```
@@ -1787,7 +1787,7 @@ app.add_subcommand(search^)
 
 **Both positions work**
 
-```bash
+```shell
 app --verbose search "fn main"     # flag BEFORE subcommand
 app search --verbose "fn main"     # flag AFTER subcommand  (same result)
 app -v search -o json "fn main"    # short forms work too
@@ -1863,7 +1863,7 @@ app.add_argument(
 
 When you call `add_subcommand()` for the first time, ArgMojo automatically registers a `help` subcommand. This mirrors the behaviour of `git help`, `cargo help`, and `kubectl help`.
 
-```bash
+```shell
 app help search    # equivalent to: app search --help
 app help init      # equivalent to: app init --help
 app help           # shows root help (same as: app --help)
@@ -1894,7 +1894,7 @@ clone.command_aliases(aliases^)
 app.add_subcommand(clone^)
 ```
 
-```bash
+```shell
 app cl https://example.com/repo.git   # dispatches to "clone"
 app clone https://example.com/repo.git # still works
 ```
@@ -1918,7 +1918,7 @@ Aliases are also included in shell-completion scripts and typo suggestions.
 
 When the root command has subcommands registered **and `allow_positional_with_subcommands()` has not been called**, an unrecognised token triggers an error listing available commands:
 
-```bash
+```shell
 app foobar
 # error: app: Unknown command 'foobar'. Available commands: search, init
 ```
@@ -2001,7 +2001,7 @@ Please seriously **think twice** before doing this — it's usually better to de
 
 **Error path prefix** — errors inside child parsing include the full command path for clarity:
 
-```bash
+```shell
 app search --unknown-flag
 # error: app search: Unknown option '--unknown-flag'
 ```
@@ -2031,14 +2031,14 @@ command.add_argument(
 
 **Help output (before):**
 
-```bash
+```console
   -o, --output <output>       Output file path
   -d, --max-depth <max-depth> Maximum directory depth
 ```
 
 **Help output (after `.value_name()` — wrapped by default):**
 
-```bash
+```console
   -o, --output <FILE>         Output file path
   -d, --max-depth <N>         Maximum directory depth
 ```
@@ -2052,7 +2052,7 @@ command.add_argument(
 )
 ```
 
-```bash
+```console
       --point COORD COORD COORD    A 3D coordinate
 ```
 
@@ -2069,7 +2069,7 @@ command.add_argument(
 )
 ```
 
-```bash
+```shell
 myapp --debug-index    # Works — flag is set to True
 myapp --help           # --debug-index does NOT appear in the help text
 ```
@@ -2094,7 +2094,7 @@ command.add_argument(
 )
 ```
 
-```bash
+```shell
 myapp --format-old csv
 # stderr: Warning: '--format-old' is deprecated: Use --format instead
 # parsing continues: format_old = "csv"
@@ -2112,7 +2112,7 @@ command.add_argument(
 )
 ```
 
-```bash
+```shell
 myapp -C
 # stderr: Warning: '-C' is deprecated: Will be removed in 2.0
 ```
@@ -2122,7 +2122,7 @@ myapp -C
 **Help display** — deprecated arguments show the deprecation
 message in the help text:
 
-```bash
+```console
 Options:
   --format-old <format_old>    Legacy output format [deprecated: Use --format instead]
 ```
@@ -2168,14 +2168,14 @@ command.add_argument(
 
 **Help display** — the optional value is shown in brackets:
 
-```bash
+```console
 Options:
       --compress[=<compress>]    Compression algorithm
 ```
 
 With `.value_name["ALGO"]()`:
 
-```bash
+```console
 Options:
       --compress[=ALGO]          Compression algorithm
 ```
@@ -2204,7 +2204,7 @@ command.add_argument(
 
 **Help display** — the `=` is shown in the help:
 
-```bash
+```console
 Options:
   -o, --output=<output>    Output file
 ```
@@ -2236,7 +2236,7 @@ command.add_argument(
 
 **Help output:**
 
-```bash
+```console
 Options:
   -v, --verbose              Increase verbosity
   -h, --help                 Show this help message
@@ -2262,7 +2262,7 @@ Output:
 
 Every command automatically supports `--help` (or `-h` or `-?`). The help text is generated from the registered argument definitions.
 
-```bash
+```shell
 myapp --help
 myapp -h
 myapp '-?'     # quote needed: ? is a shell glob wildcard
@@ -2270,7 +2270,7 @@ myapp '-?'     # quote needed: ? is a shell glob wildcard
 
 **Example output:**
 
-```bash
+```console
 A CJK-aware text search tool
 
 Usage: myapp <pattern> [path] [OPTIONS]
@@ -2367,7 +2367,7 @@ ArgMojo respects the [`NO_COLOR`](https://no-color.org/) convention. When the `N
 - Warning messages (`_warn()`)
 - Error messages (`_error()` and `_error_with_usage()`)
 
-```bash
+```console
 NO_COLOR=1 myapp --help    # plain-text help, no colours
 NO_COLOR= myapp --help     # also suppressed (empty string counts as "set")
 myapp --help               # coloured output (NO_COLOR is unset)
@@ -2388,7 +2388,7 @@ command.help_on_no_arguments()
 var result = command.parse()
 ```
 
-```bash
+```shell
 myapp          # prints help and exits
 myapp --file x # normal parsing
 ```
@@ -2437,14 +2437,14 @@ Multiple tips can be added; each is displayed on its own line prefixed with `Tip
 
 Every command automatically supports `--version` (or `-V`).
 
-```bash
+```shell
 myapp --version
 myapp -V
 ```
 
 **Output:**
 
-```bash
+```console
 myapp 1.0.0
 ```
 
@@ -2510,7 +2510,7 @@ CJK users frequently forget to switch input methods, accidentally typing **fullw
 
 ArgMojo automatically detects and corrects these characters **before parsing**, printing a coloured warning to stderr:
 
-```bash
+```console
 warning: detected full-width characters in '－－ｖｅｒｂｏｓｅ', auto-corrected to '--verbose'
 ```
 
@@ -2574,7 +2574,7 @@ var command = Command("calc", "Calculator")
 command.add_argument(Argument("operand", help="A number").positional().required())
 ```
 
-```bash
+```shell
 calc -9876543        # operand = "-9876543" (auto-detected as a number)
 calc -3.14           # operand = "-3.14"
 calc -.5             # operand = "-.5"
@@ -2592,7 +2592,7 @@ Recognised patterns: `-N`, `-N.N`, `-.N`, `-NeX`, `-N.NeX`, `-Ne+X`, `-Ne-X` (wh
 
 The `--` stop marker forces everything after it to be treated as positional. This is the most universal approach and works regardless of any configuration.
 
-```bash
+```shell
 calc -- -10.18         # operand = "-10.18"
 calc -- -3e4         # operand = "-3e4"
 ```
@@ -2618,7 +2618,7 @@ command.add_argument(
 command.add_argument(Argument("operand", help="A number").positional().required())
 ```
 
-```bash
+```shell
 calc --triple -3.14   # triple = True, operand = "-3.14"
 calc -3               # operand = "-3" (NOT the -3 flag!)
 ```
@@ -2655,7 +2655,7 @@ command.add_argument(Argument("verbose", help="Verbose output").long["verbose"](
 command.add_argument(Argument("output",  help="Output file").long["output"]().short["o"]())
 ```
 
-```bash
+```shell
 myapp --verb               # resolves to --verbose
 myapp --out file.txt       # resolves to --output file.txt
 myapp --out=file.txt       # resolves to --output=file.txt
@@ -2672,7 +2672,7 @@ command.add_argument(Argument("verbose",      help="Verbose").long["verbose"]().
 command.add_argument(Argument("version-info", help="Version info").long["version-info"]().flag())
 ```
 
-```bash
+```shell
 myapp --ver
 # Error: Ambiguous option '--ver' could match: '--verbose', '--version-info'
 ```
@@ -2688,7 +2688,7 @@ command.add_argument(Argument("color",    help="Color mode").long["color"]().fla
 command.add_argument(Argument("colorize", help="Colorize output").long["colorize"]().flag())
 ```
 
-```bash
+```shell
 myapp --color       # exact match → color (not ambiguous with colorize)
 myapp --col         # ambiguous → error
 ```
@@ -2699,7 +2699,7 @@ myapp --col         # ambiguous → error
 
 Prefix matching also applies to `--no-X` negation:
 
-```bash
+```shell
 myapp --no-col      # resolves to --no-color (if color is the only negatable match)
 ```
 
@@ -2707,7 +2707,7 @@ myapp --no-col      # resolves to --no-color (if color is the only negatable mat
 
 This feature is always enabled — no configuration needed. It is most useful for long option names where typing the full name is cumbersome:
 
-```bash
+```shell
 myapp --max 5       # instead of --max-depth 5
 myapp --ig          # instead of --ignore-case
 ```
@@ -2723,7 +2723,7 @@ command.add_argument(Argument("ling", help="Use Lingming encoding").long["ling"]
 command.add_argument(Argument("pattern", help="Search pattern").positional().required())
 ```
 
-```bash
+```shell
 myapp -- --ling
 # ling = False  (the -- stopped option parsing)
 # pattern = "--ling"  (treated as a positional value)
@@ -2731,7 +2731,7 @@ myapp -- --ling
 
 This is especially useful for patterns or file paths that look like options:
 
-```bash
+```shell
 myapp --ling -- "-v is not a flag here" ./src
 # ling = True  (parsed before --)
 # pattern = "-v is not a flag here"
@@ -2740,7 +2740,7 @@ myapp --ling -- "-v is not a flag here" ./src
 
 A common use-case is passing **negative numbers** as positional arguments:
 
-```bash
+```shell
 myapp -- -10.18
 # pattern = "-10.18"
 ```
@@ -2763,7 +2763,7 @@ command.add_argument(
 )
 ```
 
-```bash
+```shell
 runner myapp --verbose -x --output=foo.txt
 # program = "myapp"
 # args    = ["--verbose", "-x", "--output=foo.txt"]
@@ -2794,7 +2794,7 @@ command.add_argument(
 )
 ```
 
-```bash
+```shell
 cat -        # file = "-"  (stdin convention)
 cat input.txt  # file = "input.txt"
 ```
@@ -2828,7 +2828,7 @@ var unknown = result.get_unknown_args()
 # e.g., ["--color", "-x", "--threads=4"]
 ```
 
-```bash
+```shell
 wrapper input.txt --verbose --color -x --threads=4
 # verbose = True
 # file    = "input.txt"
@@ -2875,14 +2875,14 @@ src/main.mojo
 src/utils.mojo
 ```
 
-```bash
+```shell
 mytool @args.txt
 # equivalent to: mytool --verbose --output=build/release --jobs=4 src/main.mojo src/utils.mojo
 ```
 
 Response file arguments can be mixed freely with direct CLI arguments:
 
-```bash
+```shell
 mytool --debug @args.txt --extra-flag
 ```
 
@@ -2890,7 +2890,7 @@ mytool --debug @args.txt --extra-flag
 
 To pass a literal token that starts with `@` (e.g., an email address), double the prefix:
 
-```bash
+```shell
 mytool @@user@example.com
 # parsed as: @user@example.com
 ```
@@ -2916,7 +2916,7 @@ Response files may reference other response files:
 --output=build/release
 ```
 
-```bash
+```shell
 mytool @build-args.txt
 # expands to: mytool --verbose --output=build/release
 ```
@@ -3028,7 +3028,7 @@ Server region [us/eu/ap] (us): ap
 
 #### All arguments provided — no prompting at all
 
-```console
+```shell
 ./login --user alice --token secret-123 --region eu
 ```
 
@@ -3113,7 +3113,7 @@ Enable verbose output [y/n]:        ← flag prompt
 
 When stdin is not a terminal (piped input, CI environments, `< /dev/null`), the `input()` call raises on EOF. ArgMojo catches this gracefully and stops prompting — any values collected so far are preserved, defaults are then applied normally, and validation proceeds as usual.
 
-```console
+```shell
 echo "" | ./login --user alice --token secret
 ```
 
@@ -3121,7 +3121,7 @@ Prompts are still printed to stdout, but `input()` reads from the pipe. Once the
 
 To avoid prompting entirely, always provide all arguments on the command line:
 
-```console
+```shell
 ./login --user alice --token secret --region eu
 ```
 
@@ -3297,7 +3297,7 @@ When stdin is not a terminal, the echo-control calls return `False` (harmless), 
 
 To bypass the prompt entirely, provide the value on the command line:
 
-```console
+```shell
 ./login --username alice --password s3cret
 ```
 
@@ -3442,7 +3442,7 @@ var result = app.parse()
 
 Users run:
 
-```bash
+```shell
 myapp --completions bash   # prints Bash completion script and exits
 myapp --completions zsh    # prints Zsh completion script and exits
 myapp --completions fish   # prints Fish completion script and exits
@@ -3450,7 +3450,7 @@ myapp --completions fish   # prints Fish completion script and exits
 
 The `--completions` option is shown in the help output alongside `--help` and `--version`:
 
-```bash
+```console
 Options:
   --help                  Show this help message and exit
   --version               Show the version and exit
@@ -3536,7 +3536,7 @@ myapp --completions bash > ~/.bash_completion.d/myapp
 
 **Zsh:**
 
-```bash
+```zsh
 # Place in your fpath (file must be named _myapp)
 myapp --completions zsh > ~/.zsh/completions/_myapp
 
@@ -3549,7 +3549,7 @@ myapp --completions zsh > ~/.zsh/completions/_myapp
 
 **Fish:**
 
-```bash
+```shell
 # Fish auto-loads from this directory
 myapp --completions fish > ~/.config/fish/completions/myapp.fish
 ```

--- a/examples/declarative/convert.mojo
+++ b/examples/declarative/convert.mojo
@@ -1,4 +1,4 @@
-"""Example: Split Parse (declarative + extra builder fields)
+"""Example: Full Parse (declarative + extra builder fields)
 
 Try it out with:
 

--- a/examples/declarative/convert.mojo
+++ b/examples/declarative/convert.mojo
@@ -47,8 +47,8 @@ def main() raises:
     command.header_color["GREEN"]()  # Set the help header color to green
     command.help_on_no_arguments()  # Show help if no arguments are provided
 
-    # parse_with_command() returns BOTH the typed struct AND the raw ParseResult
-    var result = Convert.parse_with_command(command^)
+    # parse_full_from_command() returns BOTH the typed struct AND the raw ParseResult
+    var result = Convert.parse_full_from_command(command^)
     ref args = result[0]  # typed Convert
     ref raw = result[1]  # untyped ParseResult
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 name = "argmojo"
 platforms = ["osx-arm64", "linux-64"]
 readme = "README.md"
-version = "0.4.0"
+version = "0.5.0"
 
 [dependencies]
 mojo = "==0.26.2.0"
@@ -39,7 +39,8 @@ test = """\
     && mojo run -I src -D ASSERT=all tests/test_interactive.mojo < /dev/null \
     && mojo run -I src -D ASSERT=all tests/test_declarative.mojo \
     && mojo run -I src -D ASSERT=all tests/test_hybrid.mojo \
-    && mojo run -I src -D ASSERT=all tests/test_subcommands_declarative.mojo"""
+    && mojo run -I src -D ASSERT=all tests/test_subcommands_declarative.mojo \
+    && mojo run -I src -D ASSERT=all tests/test_wrappers.mojo"""
 # NOTE: test_response_file.mojo is excluded — response file expansion
 # is temporarily disabled to work around a Mojo compiler deadlock
 # with -D ASSERT=all.  Re-enable when the compiler bug is fixed.
@@ -60,6 +61,7 @@ t = """\
   mojo run -I src -D ASSERT=all tests/test_declarative.mojo &             pids+=($!); \
   mojo run -I src -D ASSERT=all tests/test_hybrid.mojo &                  pids+=($!); \
   mojo run -I src -D ASSERT=all tests/test_subcommands_declarative.mojo & pids+=($!); \
+  mojo run -I src -D ASSERT=all tests/test_wrappers.mojo &                pids+=($!);
   rc=0; for p in "${pids[@]}"; do wait "$p" || rc=1; done; exit $rc'
 """
 
@@ -70,7 +72,10 @@ build = """pixi run package && bash -c '\
   mojo build -I src examples/mgit.mojo  -o mgit  & pids+=($!); \
   mojo build -I src examples/demo.mojo  -o demo  & pids+=($!); \
   mojo build -I src examples/yu.mojo    -o yu    & pids+=($!); \
-  mojo build -I src examples/jomo.mojo  -o jomo  & pids+=($!); \
+  mojo build -I src examples/declarative/search.mojo  -o search  & pids+=($!); \
+  mojo build -I src examples/declarative/deploy.mojo   -o deploy  & pids+=($!); \
+  mojo build -I src examples/declarative/convert.mojo  -o convert & pids+=($!); \
+  mojo build -I src examples/declarative/jomo.mojo     -o jomo    & pids+=($!); \
   rc=0; for p in "${pids[@]}"; do wait "$p" || rc=1; done; exit $rc'
 """
 
@@ -107,7 +112,7 @@ d = """pixi run package && bash -c '\
 """
 
 # clean build artifacts
-clean = "rm -f argmojo.mojopkg mgrep mgit demo yu search deploy convert jomo"
+clean = "rm -f argmojo.mojopkg mgrep mgit demo yu jomo search deploy convert"
 
 # Run all
 all = """

--- a/src/argmojo/__init__.mojo
+++ b/src/argmojo/__init__.mojo
@@ -1,10 +1,10 @@
 """ArgMojo: A command-line argument parser library for Mojo."""
 
 # Builder API
-from .argument import Argument, Arg
+from .argument import Argument
 from .command import Command
 from .parse_result import ParseResult
 
 # Declarative API
 from .parsable import Parsable
-from .argument_wrappers import Option, Flag, Positional, Count, ArgumentLike
+from .argument_wrappers import Option, Flag, Positional, Count

--- a/src/argmojo/argument.mojo
+++ b/src/argmojo/argument.mojo
@@ -3,10 +3,6 @@
 from std.sys import exit, stderr
 
 
-comptime Arg = Argument
-"""Shorthand alias for ``Argument``."""
-
-
 struct Argument(Copyable, Movable, Writable):
     """A command-line argument with its metadata and constraints.
 

--- a/src/argmojo/argument_wrappers.mojo
+++ b/src/argmojo/argument_wrappers.mojo
@@ -1,6 +1,6 @@
-"""Declarative wrapper types for CLI arguments.
+"""Declares wrapper types for CLI arguments.
 
-Four wrapper structs that encode argument metadata as compile-time
+Four wrapper structs encode argument metadata as compile-time
 parameters.  Each wraps a runtime ``value`` field and carries all
 configuration (long name, short name, help text, choices, ...) in its
 type signature so that reflection-based ``to_command`` can
@@ -31,14 +31,14 @@ from .parse_result import ParseResult
 
 
 trait ArgumentLike:
-    """Trait for wrapper types that can register themselves on a Command
-    and write back parsed values from a ParseResult.
+    """Provides hooks for registering an argument on a Command
+    and writing back parsed values from a ParseResult.
 
     Implemented by Option, Flag, Positional, and Count.
     """
 
     def add_to_command(self, field_name: String, mut cmd: Command) raises:
-        """Translate compile-time parameters into an Argument and add to cmd.
+        """Translates compile-time parameters into an Argument and adds it to cmd.
 
         Args:
             field_name: The struct field name (used as default long name).
@@ -49,7 +49,7 @@ trait ArgumentLike:
     def read_from_result(
         mut self, field_name: String, result: ParseResult
     ) raises:
-        """Populate self.value from a ParseResult.
+        """Populates self.value from a ParseResult.
 
         Args:
             field_name: The struct field name (used as lookup key).
@@ -163,11 +163,11 @@ struct Option[
     """The runtime value populated by parsing."""
 
     def __init__(out self):
-        """Default-initialise with ``T()``."""
+        """Default-initialises with ``T()``."""
         self.value = Self.T()
 
     def __init__(out self, *, copy: Self):
-        """Copy from an existing instance.
+        """Copies from an existing instance.
 
         Args:
             copy: The Option to copy from.
@@ -175,7 +175,7 @@ struct Option[
         self.value = copy.value.copy()
 
     def __init__(out self, *, deinit take: Self):
-        """Move from an existing instance.
+        """Moves from an existing instance.
 
         Args:
             take: The Option to move from.
@@ -183,6 +183,12 @@ struct Option[
         self.value = take.value^
 
     def add_to_command(self, field_name: String, mut cmd: Command) raises:
+        """Translates compile-time parameters into an Argument and adds it to the Command.
+
+        Args:
+            field_name: The struct field name (used as default long name).
+            cmd: The Command to register the argument on.
+        """
         var long_name = String(Self.long) if Self.long else field_name.replace(
             "_", "-"
         )
@@ -243,6 +249,12 @@ struct Option[
     def read_from_result(
         mut self, field_name: String, result: ParseResult
     ) raises:
+        """Populates self.value from the ParseResult.
+
+        Args:
+            field_name: The struct field name (used as lookup key).
+            result: The ParseResult containing parsed values.
+        """
         if not result.has(field_name):
             return
         comptime type_name = get_type_name[Self.T]()
@@ -315,11 +327,11 @@ struct Flag[
     """The runtime value populated by parsing."""
 
     def __init__(out self):
-        """Default-initialise to ``False``."""
+        """Default-initialises to ``False``."""
         self.value = False
 
     def __init__(out self, val: Bool):
-        """Initialise with an explicit value.
+        """Initialises with an explicit value.
 
         Args:
             val: The initial boolean value.
@@ -327,7 +339,7 @@ struct Flag[
         self.value = val
 
     def __init__(out self, *, copy: Self):
-        """Copy from an existing instance.
+        """Copies from an existing instance.
 
         Args:
             copy: The Flag to copy from.
@@ -335,7 +347,7 @@ struct Flag[
         self.value = copy.value
 
     def __init__(out self, *, deinit take: Self):
-        """Move from an existing instance.
+        """Moves from an existing instance.
 
         Args:
             take: The Flag to move from.
@@ -343,7 +355,7 @@ struct Flag[
         self.value = take.value
 
     def __bool__(self) -> Bool:
-        """Implicit conversion to ``Bool`` for convenience.
+        """Converts to ``Bool`` implicitly for convenience.
 
         Allows ``if args.verbose:`` rather than ``if args.verbose.value:``.
 
@@ -353,6 +365,12 @@ struct Flag[
         return self.value
 
     def add_to_command(self, field_name: String, mut cmd: Command) raises:
+        """Translates compile-time parameters into a flag Argument and adds it to the Command.
+
+        Args:
+            field_name: The struct field name (used as default long name).
+            cmd: The Command to register the flag on.
+        """
         var long_name = String(Self.long) if Self.long else field_name.replace(
             "_", "-"
         )
@@ -375,6 +393,12 @@ struct Flag[
     def read_from_result(
         mut self, field_name: String, result: ParseResult
     ) raises:
+        """Populates self.value from the ParseResult.
+
+        Args:
+            field_name: The struct field name (used as lookup key).
+            result: The ParseResult containing parsed values.
+        """
         self.value = result.get_flag(field_name)
 
 
@@ -433,11 +457,11 @@ struct Positional[
     """The runtime value populated by parsing."""
 
     def __init__(out self):
-        """Default-initialise with ``T()``."""
+        """Default-initialises with ``T()``."""
         self.value = Self.T()
 
     def __init__(out self, *, copy: Self):
-        """Copy from an existing instance.
+        """Copies from an existing instance.
 
         Args:
             copy: The Positional to copy from.
@@ -445,7 +469,7 @@ struct Positional[
         self.value = copy.value.copy()
 
     def __init__(out self, *, deinit take: Self):
-        """Move from an existing instance.
+        """Moves from an existing instance.
 
         Args:
             take: The Positional to move from.
@@ -453,6 +477,12 @@ struct Positional[
         self.value = take.value^
 
     def add_to_command(self, field_name: String, mut cmd: Command) raises:
+        """Translates compile-time parameters into a positional Argument and adds it to the Command.
+
+        Args:
+            field_name: The struct field name (used as the argument name).
+            cmd: The Command to register the positional on.
+        """
         var arg = Argument(field_name, help=String(Self.help)).positional()
         comptime if Self.remainder:
             arg._is_remainder = True
@@ -474,6 +504,12 @@ struct Positional[
     def read_from_result(
         mut self, field_name: String, result: ParseResult
     ) raises:
+        """Populates self.value from the ParseResult.
+
+        Args:
+            field_name: The struct field name (used as lookup key).
+            result: The ParseResult containing parsed values.
+        """
         if not result.has(field_name):
             return
         comptime type_name = get_type_name[Self.T]()
@@ -540,11 +576,11 @@ struct Count[
     """The runtime value populated by parsing."""
 
     def __init__(out self):
-        """Default-initialise to ``0``."""
+        """Default-initialises to ``0``."""
         self.value = 0
 
     def __init__(out self, val: Int):
-        """Initialise with an explicit value.
+        """Initialises with an explicit value.
 
         Args:
             val: The initial count value.
@@ -552,7 +588,7 @@ struct Count[
         self.value = val
 
     def __init__(out self, *, copy: Self):
-        """Copy from an existing instance.
+        """Copies from an existing instance.
 
         Args:
             copy: The Count to copy from.
@@ -560,7 +596,7 @@ struct Count[
         self.value = copy.value
 
     def __init__(out self, *, deinit take: Self):
-        """Move from an existing instance.
+        """Moves from an existing instance.
 
         Args:
             take: The Count to move from.
@@ -568,6 +604,12 @@ struct Count[
         self.value = take.value
 
     def add_to_command(self, field_name: String, mut cmd: Command) raises:
+        """Translates compile-time parameters into a count Argument and adds it to the Command.
+
+        Args:
+            field_name: The struct field name (used as default long name).
+            cmd: The Command to register the count on.
+        """
         var long_name = String(Self.long) if Self.long else field_name.replace(
             "_", "-"
         )
@@ -589,4 +631,10 @@ struct Count[
     def read_from_result(
         mut self, field_name: String, result: ParseResult
     ) raises:
+        """Populates self.value from the ParseResult.
+
+        Args:
+            field_name: The struct field name (used as lookup key).
+            result: The ParseResult containing parsed values.
+        """
         self.value = result.get_count(field_name)

--- a/src/argmojo/parsable.mojo
+++ b/src/argmojo/parsable.mojo
@@ -44,7 +44,7 @@ trait Parsable(Defaultable, Movable):
     """
 
     def __init__(out self):
-        """Default-initialise all fields via reflection.
+        """Default-initialises all fields via reflection.
 
         Uses ``__mlir_op.lit.ownership.mark_initialized`` to bypass the
         compiler's definite-assignment check, then placement-news each
@@ -80,7 +80,7 @@ trait Parsable(Defaultable, Movable):
 
     @staticmethod
     def description() -> String:
-        """Return the command description for --help.
+        """Returns the command description for --help.
 
         Returns:
             The description string.
@@ -89,7 +89,7 @@ trait Parsable(Defaultable, Movable):
 
     @staticmethod
     def version() -> String:
-        """Return the version string for --version.
+        """Returns the version string for --version.
 
         Override to change from the default ``"0.1.0"``.
 
@@ -100,7 +100,7 @@ trait Parsable(Defaultable, Movable):
 
     @staticmethod
     def name() -> String:
-        """Return the command name.
+        """Returns the command name.
 
         Override to provide a custom command name.
         An empty string (the default) means ``"command"`` is used.
@@ -112,7 +112,7 @@ trait Parsable(Defaultable, Movable):
 
     @staticmethod
     def subcommands() raises -> List[Command]:
-        """Return a list of child subcommands.
+        """Returns a list of child subcommands.
 
         Called automatically by ``to_command()`` to register children.
         Override to declare declarative subcommands:
@@ -136,7 +136,7 @@ trait Parsable(Defaultable, Movable):
         return List[Command]()
 
     def run(self) raises:
-        """Execute this command's logic after parsing.
+        """Executes this command's logic after parsing.
 
         Override in leaf commands. The default does nothing.
         """
@@ -146,7 +146,7 @@ trait Parsable(Defaultable, Movable):
 
     @staticmethod
     def parse() raises -> Self:
-        """Build, parse sys.argv(), and return a populated Self.
+        """Builds, parses sys.argv(), and returns a populated Self.
 
         This is the primary entry point for pure-declarative usage.
 
@@ -159,7 +159,7 @@ trait Parsable(Defaultable, Movable):
 
     @staticmethod
     def parse_args(args: List[String]) raises -> Self:
-        """Build, parse the given argument list, and return a populated Self.
+        """Builds, parses the given argument list, and returns a populated Self.
 
         Useful for testing without touching sys.argv().
 
@@ -177,13 +177,13 @@ trait Parsable(Defaultable, Movable):
 
     @staticmethod
     def to_command() raises -> Command:
-        """Reflect over Self's fields, register them, and return a configured Command.
+        """Reflects over Self's fields, registers them, and returns a configured Command.
 
         Iterates Self's fields via reflection and registers
         ArgumentLike-conforming ones as Arguments on the Command.
         Automatically calls ``subcommands()`` to register child commands.
         Users can modify the returned Command with builder methods
-        before calling ``parse_from_command()`` or ``parse_with_command()``.
+        before calling ``parse_from_command()`` or ``parse_full_from_command()``.
 
         Returns:
             A fully configured Command.
@@ -219,7 +219,7 @@ trait Parsable(Defaultable, Movable):
 
     @staticmethod
     def parse_from_command(var cmd: Command) raises -> Self:
-        """Parse using a pre-configured Command and return a populated Self.
+        """Parses using a pre-configured Command and returns a populated Self.
 
         Use after ``to_command()`` + builder customisations.
 
@@ -235,8 +235,8 @@ trait Parsable(Defaultable, Movable):
     # ── Dual return ──
 
     @staticmethod
-    def parse_split() raises -> Tuple[Self, ParseResult]:
-        """Build, parse argv, and return both Self and raw ParseResult.
+    def parse_full() raises -> Tuple[Self, ParseResult]:
+        """Builds, parses argv, and returns both Self and raw ParseResult.
 
         Use when you need both typed fields and subcommand dispatch.
 
@@ -249,8 +249,10 @@ trait Parsable(Defaultable, Movable):
         return Tuple[Self, ParseResult](args^, result^)
 
     @staticmethod
-    def parse_with_command(var cmd: Command) raises -> Tuple[Self, ParseResult]:
-        """Parse using a pre-configured Command and return both Self and ParseResult.
+    def parse_full_from_command(
+        var cmd: Command,
+    ) raises -> Tuple[Self, ParseResult]:
+        """Parses using a pre-configured Command and returns both Self and ParseResult.
 
         Essential for subcommand dispatch: the typed Self gives
         root-level flags, ParseResult gives subcommand name + fields.
@@ -269,7 +271,7 @@ trait Parsable(Defaultable, Movable):
 
     @staticmethod
     def from_parse_result(result: ParseResult) raises -> Self:
-        """Populate Self from an existing ParseResult (no parsing).
+        """Populates Self from an existing ParseResult (no parsing).
 
         Useful for subcommand dispatch — after the parent parses,
         extract child fields from the subcommand result.

--- a/tests/test_declarative.mojo
+++ b/tests/test_declarative.mojo
@@ -169,7 +169,7 @@ def test_split_return() raises:
     # Parse into a raw ParseResult.
     var result = cmd.parse_arguments(args)
 
-    # Typed write-back (same as what parse_split returns as element 0).
+    # Typed write-back (same as what parse_full returns as element 0).
     var grep = Grep.from_parse_result(result)
 
     # Verify typed access.
@@ -178,7 +178,7 @@ def test_split_return() raises:
     assert_true(grep.pattern.value == "split_pattern", "split typed pattern")
     assert_true(grep.debug_level.value == 2, "split typed debug_level")
 
-    # Verify raw ParseResult access (same as what parse_split returns as element 1).
+    # Verify raw ParseResult access (same as what parse_full returns as element 1).
     assert_true(result.get_string("output") == "split.txt", "split raw output")
     assert_true(result.get_flag("verbose"), "split raw verbose")
     assert_true(

--- a/tests/test_hybrid.mojo
+++ b/tests/test_hybrid.mojo
@@ -13,7 +13,7 @@ Covers:
   - Extra builder args accessible via ParseResult
   - configure() free function pattern
 
-Note: parse_from_command(), parse_split(), and parse_with_command() call
+Note: parse_from_command(), parse_full(), and parse_full_from_command() call
 cmd.parse() which reads sys.argv(), so they cannot be exercised in
 unit tests with synthetic argument lists.  Their logic is identical
 to to_command() + parse_arguments() + from_parse_result() which IS tested.
@@ -283,7 +283,7 @@ def test_implies_chain() raises:
 
 
 # =======================================================================
-# 5. Extra builder args + parse_split / dual return
+# 5. Extra builder args + parse_full / dual return
 # =======================================================================
 
 
@@ -341,12 +341,13 @@ def test_extra_builder_args_defaults() raises:
 
 
 # =======================================================================
-# 6. parse_with_command trait static method pattern
+# 6. parse_full_from_command trait static method pattern
 # =======================================================================
 
 
-def test_parse_with_command_manual() raises:
-    """Simulate parse_with_command: to_command → customise → parse → both."""
+def test_parse_full_from_command_manual() raises:
+    """Simulate parse_full_from_command: to_command → customise → parse → both.
+    """
     var cmd = Deploy.to_command()
     cmd.add_tip("Verify before deploying")
 

--- a/tests/test_subcommands_declarative.mojo
+++ b/tests/test_subcommands_declarative.mojo
@@ -7,7 +7,7 @@ Tests Parsable structs as subcommand participants:
   - run() dispatch pattern for leaf command execution
   - Child.from_parse_result() write-back from subcommand ParseResult
 
-Note: parse_from_command(), parse_split(), and parse_with_command() call
+Note: parse_from_command(), parse_full(), and parse_full_from_command() call
 cmd.parse() which reads sys.argv(), so they cannot be exercised in
 unit tests with synthetic argument lists.  The testable equivalents
 (to_command + parse_arguments + from_parse_result) exercise identical logic.
@@ -472,7 +472,7 @@ def test_root_customization_builder_child() raises:
 
 
 def test_dual_return_root_and_subcommand() raises:
-    """Simulate parse_split: get typed root + raw result for dispatch."""
+    """Simulate parse_full: get typed root + raw result for dispatch."""
     var cmd = AppRoot.to_command()
     var args: List[String] = ["app", "--verbose", "search", "hello"]
     var result = cmd.parse_arguments(args)


### PR DESCRIPTION
This PR standardizes the declarative `Parsable` parsing method names (including the dual-return APIs), updates public exports accordingly, and refreshes docs/examples/tasks for the v0.5.0 release.

**Changes:**
- Rename `Parsable` dual-return methods for consistency (`parse_split` → `parse_full`, `parse_with_command` → `parse_full_from_command`) and update references.
- Remove the `Arg` alias export (and stop exporting `ArgumentLike`) to simplify the public surface.
- Update README/user manual/planning docs/changelog and build/test tasks (including running the new `test_wrappers.mojo`).