### PR TITLE
[core][declarative] Add compile time validation on flag length, choices, and range

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A feature-rich command-line argument parser library for Mojo, with both builder and struct-based declarative APIs. Inspired by Python's `argparse`, Rust's `clap`, Go's `cobra`, and Swift's `swift-argument-parser`.
 
+ArgMojo has been successfully deployed in production in [Decimo](https://github.com/forfudan/decimo), an arbitrary-precision integer and decimal library for Mojo. You can see the [code of Decimo CLI calculator](https://github.com/forfudan/decimo/blob/main/src/cli/main.mojo) as a real-world example of ArgMojo usage.
+
 <!-- 
 > **A**rguments **R**esolved and **G**rouped into **M**eaningful **O**ptions and **J**oined **O**bjects
  -->
@@ -210,10 +212,10 @@ var deploy = Deploy.parse_from_command(cmd^)     # Command → typed struct
 
 The `Parsable` trait provides four parsing methods:
 
-|                  | `sys.argv()`     | from `Command`                  |
-| ---------------- | ---------------- | ------------------------------- |
-| returns `Self`   | `parse()`        | `parse_from_command(cmd^)`      |
-| returns `Tuple`  | `parse_full()`   | `parse_full_from_command(cmd^)` |
+|                 | `sys.argv()`   | from `Command`                  |
+| --------------- | -------------- | ------------------------------- |
+| returns `Self`  | `parse()`      | `parse_from_command(cmd^)`      |
+| returns `Tuple` | `parse_full()` | `parse_full_from_command(cmd^)` |
 
 Plus: `parse_args(args)` for testing, `to_command()` to reflect a struct into a `Command`, and `from_parse_result(result)` for subcommand write-back.
 

--- a/docs/declarative_api_planning.md
+++ b/docs/declarative_api_planning.md
@@ -1372,11 +1372,14 @@ I think this is the right call — these features describe *relationships betwee
 ### Phase 4: Further enhancements
 
 - [ ] Implement `_validate_schema[T]()` compile-time checks (§6.3)
-  - [ ] Duplicate short flag detection
-  - [ ] Invalid short flag length
+  - [ ] Duplicate short flag detection (blocked: Mojo's parametric `StringLiteral` prevents accessing wrapper type parameters through trait-erased types; runtime detection already works via the builder layer)
+  - [x] Invalid short flag length (`comptime assert len(short) == 1` in `Option`, `Flag`, `Count`)
   - [ ] Positional ordering enforcement
   - [ ] Type-metadata mismatch detection
-  - [ ] Choices vs default consistency
+  - [x] Choices vs default consistency (`comptime assert` in `Option` and `Positional`)
+  - [x] Range min ≤ max (`comptime assert range_min <= range_max` in `Option`)
+  - [x] Test: positive schema validation (test_schema_validation.mojo, 5 tests)
+  - [x] Test: negative schema validation (check_schema_errors.sh, 6 compile-error tests)
 - [ ] Add `depends_on`/`conflicts_with` parameters to `Option` and `Flag` (§6.4)
   - [ ] Compile-time validation of referenced field names
   - [ ] Translation to builder `required_together()`/`mutually_exclusive()` in `to_command()`

--- a/examples/mgit.mojo
+++ b/examples/mgit.mojo
@@ -394,15 +394,10 @@ def main() raises:
     diff.command_aliases(diff_aliases^)
     diff.add_argument(Argument("path", help="Path to diff").positional())
     diff.add_argument(
-        Argument("staged", help="Show staged changes").long["staged"]().flag()
-    )
-    # Alias for --staged
-    diff.add_argument(
-        Argument("cached", help="Synonym for --staged")
-        .long["cached"]()
-        .alias_name["staged"]()
+        Argument("staged", help="Show staged changes")
+        .long["staged"]()
+        .alias_name["cached"]()
         .flag()
-        .hidden()
     )
     diff.add_argument(
         Argument("stat", help="Show diffstat instead of patch")

--- a/pixi.toml
+++ b/pixi.toml
@@ -40,7 +40,9 @@ test = """\
     && mojo run -I src -D ASSERT=all tests/test_declarative.mojo \
     && mojo run -I src -D ASSERT=all tests/test_hybrid.mojo \
     && mojo run -I src -D ASSERT=all tests/test_subcommands_declarative.mojo \
-    && mojo run -I src -D ASSERT=all tests/test_wrappers.mojo"""
+    && mojo run -I src -D ASSERT=all tests/test_wrappers.mojo \
+    && mojo run -I src -D ASSERT=all tests/test_schema_validation.mojo \
+    && bash tests/check_schema_errors.sh"""
 # NOTE: test_response_file.mojo is excluded — response file expansion
 # is temporarily disabled to work around a Mojo compiler deadlock
 # with -D ASSERT=all.  Re-enable when the compiler bug is fixed.
@@ -61,8 +63,10 @@ t = """\
   mojo run -I src -D ASSERT=all tests/test_declarative.mojo &             pids+=($!); \
   mojo run -I src -D ASSERT=all tests/test_hybrid.mojo &                  pids+=($!); \
   mojo run -I src -D ASSERT=all tests/test_subcommands_declarative.mojo & pids+=($!); \
-  mojo run -I src -D ASSERT=all tests/test_wrappers.mojo &                pids+=($!);
-  rc=0; for p in "${pids[@]}"; do wait "$p" || rc=1; done; exit $rc'
+  mojo run -I src -D ASSERT=all tests/test_wrappers.mojo &                pids+=($!); \
+  mojo run -I src -D ASSERT=all tests/test_schema_validation.mojo &       pids+=($!);
+  rc=0; for p in "${pids[@]}"; do wait "$p" || rc=1; done; \
+  bash tests/check_schema_errors.sh || rc=1; exit $rc'
 """
 
 # build example binaries (parallel, fail if any build fails)

--- a/src/argmojo/argument_wrappers.mojo
+++ b/src/argmojo/argument_wrappers.mojo
@@ -191,14 +191,19 @@ struct Option[
         """
 
         # == Compile-time schema validation ==
-        # 1. The short name must be exactly 1 character if provided.
-        # 2. If a range is specified, min must be <= max.
-        # 3. If choices and default are both specified, default must be one of the choices.
+        # - The short name must be exactly 1 character if provided.
+        # - The short name must not be '-' (conflicts with '--' end-of-options marker).
+        # - If a range is specified, min must be <= max.
+        # - If choices and default are both specified, default must be one of the choices.
         comptime if Self.short != "":
             comptime assert len(Self.short) == 1, (
                 "Option short flag must be exactly 1 character, got '"
                 + Self.short
                 + "'"
+            )
+            comptime assert Self.short != "-", (
+                "Option short flag must not be '-' — it conflicts with"
+                " the '--' end-of-options marker"
             )
         comptime if Self.has_range:
             comptime assert (
@@ -400,12 +405,17 @@ struct Flag[
         """
 
         # == Compile-time schema validation ==
-        # 1. The short name must be exactly 1 character if provided.
+        # - The short name must be exactly 1 character if provided.
+        # - The short name must not be '-' (conflicts with '--' end-of-options marker).
         comptime if Self.short != "":
             comptime assert len(Self.short) == 1, (
                 "Flag short flag must be exactly 1 character, got '"
                 + Self.short
                 + "'"
+            )
+            comptime assert Self.short != "-", (
+                "Flag short flag must not be '-' — it conflicts with"
+                " the '--' end-of-options marker"
             )
 
         # == Translate fields of the wrapper struct into Argument properties ==
@@ -665,12 +675,17 @@ struct Count[
         """
 
         # == Compile-time schema validation ==
-        # 1. The short name must be exactly 1 character if provided.
+        # - The short name must be exactly 1 character if provided.
+        # - The short name must not be '-' (conflicts with '--' end-of-options marker).
         comptime if Self.short != "":
             comptime assert len(Self.short) == 1, (
                 "Count short flag must be exactly 1 character, got '"
                 + Self.short
                 + "'"
+            )
+            comptime assert Self.short != "-", (
+                "Count short flag must not be '-' — it conflicts with"
+                " the '--' end-of-options marker"
             )
 
         # == Translate fields of the wrapper struct into Argument properties ==

--- a/src/argmojo/argument_wrappers.mojo
+++ b/src/argmojo/argument_wrappers.mojo
@@ -189,6 +189,33 @@ struct Option[
             field_name: The struct field name (used as default long name).
             cmd: The Command to register the argument on.
         """
+
+        # == Compile-time schema validation ==
+        # 1. The short name must be exactly 1 character if provided.
+        # 2. If a range is specified, min must be <= max.
+        # 3. If choices and default are both specified, default must be one of the choices.
+        comptime if Self.short != "":
+            comptime assert len(Self.short) == 1, (
+                "Option short flag must be exactly 1 character, got '"
+                + Self.short
+                + "'"
+            )
+        comptime if Self.has_range:
+            comptime assert (
+                Self.range_min <= Self.range_max
+            ), "Option range_min must be <= range_max"
+        comptime if Self.choices != "" and Self.default != "":
+            comptime assert ("," + Self.choices + ",").find(
+                "," + Self.default + ","
+            ) >= 0, (
+                "Option default '"
+                + Self.default
+                + "' is not in choices '"
+                + Self.choices
+                + "'"
+            )
+
+        # == Translate fields of the wrapper struct into Argument properties ==
         var long_name = String(Self.long) if Self.long else field_name.replace(
             "_", "-"
         )
@@ -371,6 +398,17 @@ struct Flag[
             field_name: The struct field name (used as default long name).
             cmd: The Command to register the flag on.
         """
+
+        # == Compile-time schema validation ==
+        # 1. The short name must be exactly 1 character if provided.
+        comptime if Self.short != "":
+            comptime assert len(Self.short) == 1, (
+                "Flag short flag must be exactly 1 character, got '"
+                + Self.short
+                + "'"
+            )
+
+        # == Translate fields of the wrapper struct into Argument properties ==
         var long_name = String(Self.long) if Self.long else field_name.replace(
             "_", "-"
         )
@@ -483,6 +521,21 @@ struct Positional[
             field_name: The struct field name (used as the argument name).
             cmd: The Command to register the positional on.
         """
+
+        # == Compile-time schema validation ==
+        # 1. If choices and default are both specified, default must be one of the choices.
+        comptime if Self.choices != "" and Self.default != "":
+            comptime assert ("," + Self.choices + ",").find(
+                "," + Self.default + ","
+            ) >= 0, (
+                "Positional default '"
+                + Self.default
+                + "' is not in choices '"
+                + Self.choices
+                + "'"
+            )
+
+        # == Translate fields of the wrapper struct into Argument properties ==
         var arg = Argument(field_name, help=String(Self.help)).positional()
         comptime if Self.remainder:
             arg._is_remainder = True
@@ -610,6 +663,17 @@ struct Count[
             field_name: The struct field name (used as default long name).
             cmd: The Command to register the count on.
         """
+
+        # == Compile-time schema validation ==
+        # 1. The short name must be exactly 1 character if provided.
+        comptime if Self.short != "":
+            comptime assert len(Self.short) == 1, (
+                "Count short flag must be exactly 1 character, got '"
+                + Self.short
+                + "'"
+            )
+
+        # == Translate fields of the wrapper struct into Argument properties ==
         var long_name = String(Self.long) if Self.long else field_name.replace(
             "_", "-"
         )

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -470,7 +470,7 @@ struct Command(Copyable, Movable, Writable):
             and len(self.subcommands) > 0
             and not self._allow_positional_with_subcommands
         ):
-            self._error(
+            raise Error(
                 "Cannot add positional argument '"
                 + argument.name
                 + "' to '"
@@ -482,7 +482,7 @@ struct Command(Copyable, Movable, Writable):
         if (
             argument._require_equals or argument._has_default_if_no_value
         ) and argument._number_of_values > 0:
-            self._error(
+            raise Error(
                 "Argument '"
                 + argument.name
                 + "': .require_equals() / .default_if_no_value() cannot be"
@@ -492,7 +492,7 @@ struct Command(Copyable, Movable, Writable):
         if argument._is_remainder and (
             argument._long_name or argument._short_name
         ):
-            self._error(
+            raise Error(
                 "Argument '"
                 + argument.name
                 + "': .remainder() is for positional arguments only; remove"
@@ -502,7 +502,7 @@ struct Command(Copyable, Movable, Writable):
         if argument._is_remainder:
             for _ri in range(len(self.args)):
                 if self.args[_ri]._is_remainder:
-                    self._error(
+                    raise Error(
                         "Argument '"
                         + argument.name
                         + "': only one .remainder() positional is allowed"
@@ -514,7 +514,7 @@ struct Command(Copyable, Movable, Writable):
         if argument._is_positional and not argument._is_remainder:
             for _ri in range(len(self.args)):
                 if self.args[_ri]._is_remainder:
-                    self._error(
+                    raise Error(
                         "Argument '"
                         + argument.name
                         + "': cannot add a positional argument after"
@@ -524,7 +524,7 @@ struct Command(Copyable, Movable, Writable):
                     )
         # Guard: .prompt() conflicts with help_on_no_arguments().
         if argument._prompt and self._help_on_no_arguments:
-            self._error(
+            raise Error(
                 "Argument '"
                 + argument.name
                 + "': .prompt() cannot be used on a command with"
@@ -534,7 +534,7 @@ struct Command(Copyable, Movable, Writable):
             )
         # Guard: .password() only makes sense on value-taking arguments.
         if argument._hide_input and (argument._is_flag or argument._is_count):
-            self._error(
+            raise Error(
                 "Argument '"
                 + argument.name
                 + "': .password() cannot be used on a flag or count"
@@ -543,7 +543,7 @@ struct Command(Copyable, Movable, Writable):
         # Guard: duplicate internal name.
         for _di in range(len(self.args)):
             if self.args[_di].name == argument.name:
-                self._error(
+                raise Error(
                     "Argument '"
                     + argument.name
                     + "': duplicate name — an argument with the same"
@@ -558,7 +558,7 @@ struct Command(Copyable, Movable, Writable):
                     self.args[_di]._long_name
                     and self.args[_di]._long_name == argument._long_name
                 ):
-                    self._error(
+                    raise Error(
                         "Argument '"
                         + argument.name
                         + "': duplicate long flag '--"
@@ -576,7 +576,7 @@ struct Command(Copyable, Movable, Writable):
                     self.args[_di]._short_name
                     and self.args[_di]._short_name == argument._short_name
                 ):
-                    self._error(
+                    raise Error(
                         "Argument '"
                         + argument.name
                         + "': duplicate short flag '-"
@@ -625,7 +625,7 @@ struct Command(Copyable, Movable, Writable):
         if not self._allow_positional_with_subcommands:
             for _pi in range(len(self.args)):
                 if self.args[_pi]._is_positional:
-                    self._error(
+                    raise Error(
                         "Cannot add subcommand '"
                         + sub.name
                         + "' to '"
@@ -649,7 +649,7 @@ struct Command(Copyable, Movable, Writable):
                     and ca._long_name
                     and pa._long_name == ca._long_name
                 ):
-                    self._error(
+                    raise Error(
                         "Persistent flag '--"
                         + pa._long_name
                         + "' on '"
@@ -665,7 +665,7 @@ struct Command(Copyable, Movable, Writable):
                     and ca._short_name
                     and pa._short_name == ca._short_name
                 ):
-                    self._error(
+                    raise Error(
                         "Persistent flag '-"
                         + pa._short_name
                         + "' on '"
@@ -1190,7 +1190,7 @@ struct Command(Copyable, Movable, Writable):
         # Guard: conflict with .prompt() arguments.
         for _pi in range(len(self.args)):
             if self.args[_pi]._prompt:
-                self._error(
+                raise Error(
                     "help_on_no_arguments() cannot be used on a command"
                     " that has .prompt() arguments (argument '"
                     + self.args[_pi].name
@@ -1354,12 +1354,12 @@ struct Command(Copyable, Movable, Writable):
         # Guard: reject if --yes or -y is already registered.
         for i in range(len(self.args)):
             if self.args[i]._long_name == "yes":
-                self._error(
+                raise Error(
                     "confirmation_option: a '--yes' argument is already"
                     " registered"
                 )
             if self.args[i]._short_name == "y":
-                self._error(
+                raise Error(
                     "confirmation_option: a '-y' argument is already registered"
                 )
         self._confirmation_enabled = True

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -449,8 +449,10 @@ struct Command(Copyable, Movable, Writable):
 
         Raises:
             Error if adding a positional argument to a Command that already
-            has subcommands registered, unless
-            ``allow_positional_with_subcommands()`` has been called.
+            has subcommands registered (unless
+            ``allow_positional_with_subcommands()`` has been called), or if
+            the argument's name, long flag, short flag, or any alias
+            collides with an already-registered argument.
 
         Args:
             argument: The Argument to register.

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -540,6 +540,53 @@ struct Command(Copyable, Movable, Writable):
                 + "': .password() cannot be used on a flag or count"
                 " argument — it only applies to value-taking arguments"
             )
+        # Guard: duplicate internal name.
+        for _di in range(len(self.args)):
+            if self.args[_di].name == argument.name:
+                self._error(
+                    "Argument '"
+                    + argument.name
+                    + "': duplicate name — an argument with the same"
+                    " name is already registered on '"
+                    + self.name
+                    + "'"
+                )
+        # Guard: duplicate long name.
+        if argument._long_name:
+            for _di in range(len(self.args)):
+                if (
+                    self.args[_di]._long_name
+                    and self.args[_di]._long_name == argument._long_name
+                ):
+                    self._error(
+                        "Argument '"
+                        + argument.name
+                        + "': duplicate long flag '--"
+                        + argument._long_name
+                        + "' — already used by argument '"
+                        + self.args[_di].name
+                        + "' on '"
+                        + self.name
+                        + "'"
+                    )
+        # Guard: duplicate short name.
+        if argument._short_name:
+            for _di in range(len(self.args)):
+                if (
+                    self.args[_di]._short_name
+                    and self.args[_di]._short_name == argument._short_name
+                ):
+                    self._error(
+                        "Argument '"
+                        + argument.name
+                        + "': duplicate short flag '-"
+                        + argument._short_name
+                        + "' — already used by argument '"
+                        + self.args[_di].name
+                        + "' on '"
+                        + self.name
+                        + "'"
+                    )
         self.args.append(argument^)
 
     def add_subcommand(mut self, var sub: Command) raises:

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -551,7 +551,7 @@ struct Command(Copyable, Movable, Writable):
                     + self.name
                     + "'"
                 )
-        # Guard: duplicate long name.
+        # Guard: duplicate long name (including alias collisions).
         if argument._long_name:
             for _di in range(len(self.args)):
                 if (
@@ -569,6 +569,54 @@ struct Command(Copyable, Movable, Writable):
                         + self.name
                         + "'"
                     )
+                # Check new argument's long name against existing aliases.
+                for _ai in range(len(self.args[_di]._alias_names)):
+                    if self.args[_di]._alias_names[_ai] == argument._long_name:
+                        raise Error(
+                            "Argument '"
+                            + argument.name
+                            + "': long flag '--"
+                            + argument._long_name
+                            + "' collides with alias of argument '"
+                            + self.args[_di].name
+                            + "' on '"
+                            + self.name
+                            + "'"
+                        )
+        # Guard: new argument's aliases against existing long names and aliases.
+        for _ni in range(len(argument._alias_names)):
+            for _di in range(len(self.args)):
+                if (
+                    self.args[_di]._long_name
+                    and self.args[_di]._long_name == argument._alias_names[_ni]
+                ):
+                    raise Error(
+                        "Argument '"
+                        + argument.name
+                        + "': alias '--"
+                        + argument._alias_names[_ni]
+                        + "' collides with long flag of argument '"
+                        + self.args[_di].name
+                        + "' on '"
+                        + self.name
+                        + "'"
+                    )
+                for _ai in range(len(self.args[_di]._alias_names)):
+                    if (
+                        self.args[_di]._alias_names[_ai]
+                        == argument._alias_names[_ni]
+                    ):
+                        raise Error(
+                            "Argument '"
+                            + argument.name
+                            + "': alias '--"
+                            + argument._alias_names[_ni]
+                            + "' collides with alias of argument '"
+                            + self.args[_di].name
+                            + "' on '"
+                            + self.name
+                            + "'"
+                        )
         # Guard: duplicate short name.
         if argument._short_name:
             for _di in range(len(self.args)):

--- a/src/argmojo/parsable.mojo
+++ b/src/argmojo/parsable.mojo
@@ -208,30 +208,30 @@ trait Parsable(Defaultable, Movable):
         comptime field_types = struct_field_types[Self]()
         comptime field_names = struct_field_names[Self]()
 
-        # Compile-time schema validation: duplicate short flags
+        # Runtime duplicate detection
         # [Mojo Miji]
         # Cross-field duplicate detection (same name, long flag, or
         # short flag) cannot be checked at compile time because Mojo's
         # parametric StringLiteral[value] type prevents trait-level access
-        # to wrapper parameters through erased types. However, this is
-        # caught at runtime: Command.add_argument() raises on duplicate
-        # name, --long, or -short flags, so duplicates are surfaced the
-        # moment to_command() is called.
-        # TODO: Consider adding compile-time duplicate detection when
-        # Mojo supports it.
+        # to wrapper parameters through erased types. Instead, this is
+        # enforced at runtime: Command.add_argument() raises on duplicate
+        # name, --long, alias, or -short flags, so duplicates are
+        # surfaced the moment to_command() is called.
+        # TODO: Revisit when Mojo supports accessing parametric values
+        # through trait-erased types.
 
         # Per-field validations (short flag length, default-in-choices,
         # range consistency) are checked inside each wrapper's
         # add_to_command() method.
 
         # Register fields
-        comptime for idx in range(field_count):
-            comptime ftype = field_types[idx]
-            comptime if conforms_to(ftype, ArgumentLike):
-                ref field = __struct_field_ref(idx, instance)
-                comptime fname = field_names[idx]
+        comptime for field_index in range(field_count):
+            comptime field_type = field_types[field_index]
+            comptime if conforms_to(field_type, ArgumentLike):
+                ref field = __struct_field_ref(field_index, instance)
+                comptime field_name = field_names[field_index]
                 trait_downcast[ArgumentLike](field).add_to_command(
-                    String(fname), cmd
+                    String(field_name), cmd
                 )
 
         var subs = Self.subcommands()
@@ -309,13 +309,13 @@ trait Parsable(Defaultable, Movable):
         comptime field_types = struct_field_types[Self]()
         comptime field_names = struct_field_names[Self]()
 
-        comptime for idx in range(field_count):
-            comptime ftype = field_types[idx]
-            comptime if conforms_to(ftype, ArgumentLike):
-                ref field = __struct_field_ref(idx, out)
-                comptime fname = field_names[idx]
+        comptime for field_index in range(field_count):
+            comptime field_type = field_types[field_index]
+            comptime if conforms_to(field_type, ArgumentLike):
+                ref field = __struct_field_ref(field_index, out)
+                comptime field_name = field_names[field_index]
                 trait_downcast[ArgumentLike](field).read_from_result(
-                    String(fname), result
+                    String(field_name), result
                 )
 
         return out^

--- a/src/argmojo/parsable.mojo
+++ b/src/argmojo/parsable.mojo
@@ -142,7 +142,7 @@ trait Parsable(Defaultable, Movable):
         """
         pass
 
-    # ── Core: one-line parse ──
+    # == Core: one-line parse ==
 
     @staticmethod
     def parse() raises -> Self:
@@ -173,7 +173,7 @@ trait Parsable(Defaultable, Movable):
         var result = cmd.parse_arguments(args)
         return Self.from_parse_result(result)
 
-    # ── Hybrid: to_command → customise → parse_from_command ──
+    # == Hybrid: to_command → customise → parse_from_command ==
 
     @staticmethod
     def to_command() raises -> Command:
@@ -197,12 +197,34 @@ trait Parsable(Defaultable, Movable):
             version=String(Self.version()),
         )
 
-        # Register fields into Command via reflection.
+        # Register fields into Command via reflection
+        # Each field is expected to be an argument wrapper type
+        # (e.g. Option, Flag, Positional, Count) that conforms to ArgumentLike.
+        # They will be converted into Argument type and added to the Command.
+
+        # Comptime calculation of field count, types, and names
         var instance = Self()
         comptime field_count = struct_field_count[Self]()
         comptime field_types = struct_field_types[Self]()
         comptime field_names = struct_field_names[Self]()
 
+        # Compile-time schema validation: duplicate short flags
+        # [Mojo Miji]
+        # Cross-field duplicate detection (same name, long flag, or
+        # short flag) cannot be checked at compile time because Mojo's
+        # parametric StringLiteral[value] type prevents trait-level access
+        # to wrapper parameters through erased types. However, this is
+        # caught at runtime: Command.add_argument() raises on duplicate
+        # name, --long, or -short flags, so duplicates are surfaced the
+        # moment to_command() is called.
+        # TODO: Consider adding compile-time duplicate detection when
+        # Mojo supports it.
+
+        # Per-field validations (short flag length, default-in-choices,
+        # range consistency) are checked inside each wrapper's
+        # add_to_command() method.
+
+        # Register fields
         comptime for idx in range(field_count):
             comptime ftype = field_types[idx]
             comptime if conforms_to(ftype, ArgumentLike):
@@ -232,7 +254,7 @@ trait Parsable(Defaultable, Movable):
         var result = cmd.parse()
         return Self.from_parse_result(result)
 
-    # ── Dual return ──
+    # == Dual return ==
 
     @staticmethod
     def parse_full() raises -> Tuple[Self, ParseResult]:
@@ -267,7 +289,7 @@ trait Parsable(Defaultable, Movable):
         var args = Self.from_parse_result(result)
         return Tuple[Self, ParseResult](args^, result^)
 
-    # ── Subcommand write-back ──
+    # == Subcommand write-back ==
 
     @staticmethod
     def from_parse_result(result: ParseResult) raises -> Self:

--- a/tests/check_schema_errors.sh
+++ b/tests/check_schema_errors.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# check_schema_errors.sh — verify that invalid schemas produce compile errors.
+#
+# Each test writes a small .mojo file that should FAIL to compile.
+# If it compiles, the test fails (the schema check is missing).
+#
+# Usage:  bash tests/check_schema_errors.sh
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+PASS=0
+FAIL=0
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+check_compile_error() {
+    local name="$1"
+    local code="$2"
+    local expect_msg="$3"
+
+    local file="$TMPDIR/${name}.mojo"
+    echo "$code" > "$file"
+
+    if pixi run mojo run -I src "$file" 2>"$TMPDIR/${name}.err"; then
+        echo "FAIL  $name — expected compile error but compilation succeeded"
+        FAIL=$((FAIL + 1))
+    else
+        if grep -q "$expect_msg" "$TMPDIR/${name}.err"; then
+            echo "PASS  $name"
+            PASS=$((PASS + 1))
+        else
+            echo "FAIL  $name — compiled failed but error message not found:"
+            echo "      expected: $expect_msg"
+            echo "      got:      $(head -5 "$TMPDIR/${name}.err")"
+            FAIL=$((FAIL + 1))
+        fi
+    fi
+}
+
+echo "=== Compile-time schema validation negative tests ==="
+echo
+
+# 1. Short flag too long (Option)
+check_compile_error "option_short_too_long" '
+from argmojo import Parsable, Option
+struct Bad(Parsable):
+    var x: Option[String, short="abc"]
+    @staticmethod
+    def description() -> String:
+        return String("bad")
+def main() raises:
+    _ = Bad.to_command()
+' "short flag must be exactly 1 character"
+
+# 2. Short flag too long (Flag)
+check_compile_error "flag_short_too_long" '
+from argmojo import Parsable, Flag
+struct Bad(Parsable):
+    var x: Flag[short="vv"]
+    @staticmethod
+    def description() -> String:
+        return String("bad")
+def main() raises:
+    _ = Bad.to_command()
+' "short flag must be exactly 1 character"
+
+# 3. Short flag too long (Count)
+check_compile_error "count_short_too_long" '
+from argmojo import Parsable, Count
+struct Bad(Parsable):
+    var x: Count[short="dd"]
+    @staticmethod
+    def description() -> String:
+        return String("bad")
+def main() raises:
+    _ = Bad.to_command()
+' "short flag must be exactly 1 character"
+
+# 4. Default not in choices (Option)
+check_compile_error "option_default_not_in_choices" '
+from argmojo import Parsable, Option
+struct Bad(Parsable):
+    var fmt: Option[String, choices="json,yaml,csv", default="xml"]
+    @staticmethod
+    def description() -> String:
+        return String("bad")
+def main() raises:
+    _ = Bad.to_command()
+' "not in choices"
+
+# 5. Default not in choices (Positional)
+check_compile_error "positional_default_not_in_choices" '
+from argmojo import Parsable, Positional
+struct Bad(Parsable):
+    var action: Positional[String, choices="start,stop", default="restart"]
+    @staticmethod
+    def description() -> String:
+        return String("bad")
+def main() raises:
+    _ = Bad.to_command()
+' "not in choices"
+
+# 6. Range min > max (Option)
+check_compile_error "option_range_inverted" '
+from argmojo import Parsable, Option
+struct Bad(Parsable):
+    var port: Option[Int, has_range=True, range_min=100, range_max=10]
+    @staticmethod
+    def description() -> String:
+        return String("bad")
+def main() raises:
+    _ = Bad.to_command()
+' "range_min must be <= range_max"
+
+echo
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/tests/check_schema_errors.sh
+++ b/tests/check_schema_errors.sh
@@ -30,7 +30,7 @@ check_compile_error() {
             echo "PASS  $name"
             PASS=$((PASS + 1))
         else
-            echo "FAIL  $name — compiled failed but error message not found:"
+            echo "FAIL  $name — compilation failed but error message not found:"
             echo "      expected: $expect_msg"
             echo "      got:      $(head -5 "$TMPDIR/${name}.err")"
             FAIL=$((FAIL + 1))

--- a/tests/check_schema_errors.sh
+++ b/tests/check_schema_errors.sh
@@ -20,7 +20,7 @@ check_compile_error() {
     local expect_msg="$3"
 
     local file="$TMPDIR/${name}.mojo"
-    echo "$code" > "$file"
+    printf '%s\n' "$code" > "$file"
 
     if pixi run mojo run -I src "$file" 2>"$TMPDIR/${name}.err"; then
         echo "FAIL  $name — expected compile error but compilation succeeded"

--- a/tests/test_declarative.mojo
+++ b/tests/test_declarative.mojo
@@ -187,6 +187,90 @@ def test_split_return() raises:
     assert_true(result.get_count("debug_level") == 2, "split raw debug_level")
 
 
+# ==============================================================================
+# Schema validation: valid schemas compile and work correctly.
+#
+# Compile-time schema validation is enforced via ``comptime assert`` in each
+# wrapper's ``add_to_command()``.  The checks below exercise code paths that
+# touch every validated property — if any ``comptime assert`` fires erroneously
+# on a valid schema, these tests will fail to compile.
+#
+# Invalid schemas (e.g. short="abc", default not in choices) cannot be tested
+# at runtime because they prevent compilation.  Verify manually:
+#
+#   var bad: Option[String, short="abc"]                         → compile error
+#   var bad: Option[String, choices="a,b", default="c"]          → compile error
+#   var bad: Option[Int, has_range=True, range_min=10, range_max=5]
+#                                                                → compile error
+# ==============================================================================
+
+
+struct ValidChoicesDefault(Parsable):
+    """Schema where default is one of the choices — should compile fine."""
+
+    var fmt: Option[
+        String,
+        long="format",
+        short="f",
+        choices="json,yaml,csv",
+        default="json",
+    ]
+
+    @staticmethod
+    def description() -> String:
+        return String("Valid choices+default test.")
+
+
+def test_valid_choices_default() raises:
+    """Test that a valid choices+default schema compiles and parses."""
+    var cmd = ValidChoicesDefault.to_command()
+    assert_true(len(cmd.args) == 1, "expected 1 arg")
+    assert_true(cmd.args[0]._long_name == "format", "long name")
+    assert_true(len(cmd.args[0]._choice_values) == 3, "3 choices")
+
+
+struct ValidRange(Parsable):
+    """Schema with valid range (min <= max) — should compile fine."""
+
+    var port: Option[
+        Int,
+        long="port",
+        short="p",
+        has_range=True,
+        range_min=1,
+        range_max=65535,
+    ]
+
+    @staticmethod
+    def description() -> String:
+        return String("Valid range test.")
+
+
+def test_valid_range() raises:
+    """Test that a valid range schema compiles and parses."""
+    var cmd = ValidRange.to_command()
+    assert_true(len(cmd.args) == 1, "expected 1 arg")
+    assert_true(cmd.args[0]._has_range, "has_range set")
+    assert_true(cmd.args[0]._range_min == 1, "range_min")
+    assert_true(cmd.args[0]._range_max == 65535, "range_max")
+
+
+struct ChoicesNoDefault(Parsable):
+    """Schema with choices but no default — should compile fine."""
+
+    var level: Option[String, long="level", choices="debug,info,warn,error"]
+
+    @staticmethod
+    def description() -> String:
+        return String("Choices without default test.")
+
+
+def test_choices_without_default() raises:
+    """Test that choices without default compiles correctly."""
+    var cmd = ChoicesNoDefault.to_command()
+    assert_true(len(cmd.args[0]._choice_values) == 4, "4 choices")
+
+
 # =======================================================================
 # Main
 # =======================================================================

--- a/tests/test_declarative.mojo
+++ b/tests/test_declarative.mojo
@@ -196,12 +196,8 @@ def test_split_return() raises:
 # on a valid schema, these tests will fail to compile.
 #
 # Invalid schemas (e.g. short="abc", default not in choices) cannot be tested
-# at runtime because they prevent compilation.  Verify manually:
-#
-#   var bad: Option[String, short="abc"]                         → compile error
-#   var bad: Option[String, choices="a,b", default="c"]          → compile error
-#   var bad: Option[Int, has_range=True, range_min=10, range_max=5]
-#                                                                → compile error
+# at runtime because they prevent compilation.  These negative cases are
+# verified by tests/check_schema_errors.sh (run automatically via `pixi run test`).
 # ==============================================================================
 
 

--- a/tests/test_schema_validation.mojo
+++ b/tests/test_schema_validation.mojo
@@ -1,0 +1,150 @@
+"""Tests for compile-time schema validation.
+
+Positive tests: valid schemas that should compile and work.
+Negative tests cannot live here (they prevent compilation);
+see the shell script tests/check_schema_errors.sh instead.
+"""
+
+from std.testing import assert_true, assert_false, assert_equal, TestSuite
+
+from argmojo import (
+    Command,
+    Parsable,
+    Option,
+    Flag,
+    Positional,
+    Count,
+)
+
+
+# =======================================================================
+# Positive: valid single-char short flags on all wrapper types
+# =======================================================================
+
+
+struct AllShortFlags(Parsable):
+    var output: Option[String, long="output", short="o", help="Output"]
+    var verbose: Flag[short="v", help="Verbose"]
+    var debug: Count[short="d", help="Debug"]
+    var pattern: Positional[String, help="Pattern"]
+
+    @staticmethod
+    def description() -> String:
+        return String("All short flag types.")
+
+
+def test_valid_short_flags() raises:
+    """All single-char short flags compile fine."""
+    var cmd = AllShortFlags.to_command()
+    assert_true(len(cmd.args) == 4, "4 args")
+    assert_true(cmd.args[0]._short_name == "o", "Option short")
+    assert_true(cmd.args[1]._short_name == "v", "Flag short")
+    assert_true(cmd.args[2]._short_name == "d", "Count short")
+
+
+# =======================================================================
+# Positive: choices + default consistency
+# =======================================================================
+
+
+struct ChoicesDefaultMatch(Parsable):
+    var fmt: Option[
+        String,
+        long="format",
+        short="f",
+        choices="json,yaml,csv",
+        default="yaml",
+    ]
+
+    @staticmethod
+    def description() -> String:
+        return String("Choices with matching default.")
+
+
+def test_choices_default_match() raises:
+    """Default value matches one of the choices — compiles fine."""
+    var args = List[String]()
+    args.append(String("cmd"))
+    var result = ChoicesDefaultMatch.parse_args(args)
+    assert_true(result.fmt.value == "yaml", "default yaml applied")
+
+
+# =======================================================================
+# Positive: range with min == max (edge case)
+# =======================================================================
+
+
+struct RangeEqualMinMax(Parsable):
+    var count: Option[
+        Int,
+        long="count",
+        has_range=True,
+        range_min=5,
+        range_max=5,
+    ]
+
+    @staticmethod
+    def description() -> String:
+        return String("Range min==max edge case.")
+
+
+def test_range_equal_bounds() raises:
+    """Range where range_min == range_max is valid (exactly one allowed value).
+    """
+    var cmd = RangeEqualMinMax.to_command()
+    assert_true(cmd.args[0]._range_min == 5, "min 5")
+    assert_true(cmd.args[0]._range_max == 5, "max 5")
+
+
+# =======================================================================
+# Positive: Positional choices + default
+# =======================================================================
+
+
+struct PositionalChoices(Parsable):
+    var action: Positional[
+        String, help="Action", choices="start,stop,restart", default="start"
+    ]
+
+    @staticmethod
+    def description() -> String:
+        return String("Positional with choices and default.")
+
+
+def test_positional_choices_default() raises:
+    """Positional with valid choices+default compiles fine."""
+    var cmd = PositionalChoices.to_command()
+    assert_true(cmd.args[0]._is_positional, "is positional")
+    assert_true(len(cmd.args[0]._choice_values) == 3, "3 choices")
+    assert_true(cmd.args[0]._default_value == "start", "default start")
+
+
+# =======================================================================
+# Positive: no short flags at all (no validation triggered)
+# =======================================================================
+
+
+struct NoShortFlags(Parsable):
+    var output: Option[String, long="output", help="Output"]
+    var verbose: Flag[long="verbose", help="Verbose"]
+
+    @staticmethod
+    def description() -> String:
+        return String("No short flags.")
+
+
+def test_no_short_flags() raises:
+    """Schema with no short flags compiles without issues."""
+    var cmd = NoShortFlags.to_command()
+    assert_true(len(cmd.args) == 2, "2 args")
+    assert_true(cmd.args[0]._short_name == "", "no short on output")
+    assert_true(cmd.args[1]._short_name == "", "no short on verbose")
+
+
+# =======================================================================
+# Main
+# =======================================================================
+
+
+def main() raises:
+    TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_schema_validation.mojo
+++ b/tests/test_schema_validation.mojo
@@ -5,10 +5,9 @@ Negative tests cannot live here (they prevent compilation);
 see the shell script tests/check_schema_errors.sh instead.
 """
 
-from std.testing import assert_true, assert_false, assert_equal, TestSuite
+from std.testing import assert_true, TestSuite
 
 from argmojo import (
-    Command,
     Parsable,
     Option,
     Flag,


### PR DESCRIPTION
This PR adds compile-time schema validation for declarative argument wrappers (short flag length, choices/default consistency, and numeric range ordering) and introduces test coverage for both valid and intentionally-invalid schemas.

**Changes:**
- Added `comptime assert` validations inside `Option`/`Flag`/`Count`/`Positional` wrapper `add_to_command()` implementations.
- Strengthened runtime registration-time validation in `Command.add_argument()` (duplicate name/long/short checks) and updated documentation/comments.
- Added positive compile/run tests and negative “must fail to compile” tests, wired into `pixi` test tasks.