### PR TITLE
[test][github] Split the current Github tests into 5 jobs

### DIFF
--- a/.github/actions/setup-mojo/action.yml
+++ b/.github/actions/setup-mojo/action.yml
@@ -1,0 +1,18 @@
+name: Setup Mojo with Pixi
+description: Install pixi, activate the Mojo environment, and build the argmojo package
+
+runs:
+  using: composite
+  steps:
+    - uses: prefix-dev/setup-pixi@v0.9.5
+      with:
+        cache: true
+        activate-environment: true
+    - name: Build package (with retry)
+      shell: bash
+      run: |
+        for attempt in 1 2 3; do
+          if pixi run package; then break; fi
+          if [ "$attempt" -eq 3 ]; then exit 1; fi
+          sleep 5
+        done

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -10,44 +10,37 @@ permissions:
   contents: read
   pull-requests: read
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
-  testing-argmojo:
-    name: Test with ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ["macos-latest"]
-
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
-
-    defaults:
-      run:
-        shell: bash
-    env:
-      DEBIAN_FRONTEND: noninteractive
-
+  # ── Job 1: Format + Package ────────────────────────────────────────────
+  build:
+    name: Build & Format
+    runs-on: macos-latest
+    timeout-minutes: 10
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
+      - uses: actions/checkout@v4
       - name: Install pixi
-        run: |
-          curl -fsSL https://pixi.sh/install.sh | sh
-
+        run: curl -fsSL https://pixi.sh/install.sh | sh
       - name: Add pixi to PATH
         run: |
           echo "PIXI_HOME=$HOME/.pixi" >> $GITHUB_ENV
-          echo "$HOME/.pixi/bin"  >> $GITHUB_PATH
-
-      - name: Pixi install
+          echo "$HOME/.pixi/bin" >> $GITHUB_PATH
+      - name: pixi install
+        run: pixi install
+      - name: Format check
         run: |
-          pixi install
-
-      - name: Build package (with retry for Mojo compiler intermittent crashes)
+          pixi run format
+          if ! git diff --exit-code; then
+            echo "::error::Code is not formatted. Run 'pixi run format' locally."
+            exit 1
+          fi
+      - name: Build package (with retry)
         run: |
           for attempt in 1 2 3; do
-            echo "=== mojo package attempt $attempt ==="
+            echo "=== package attempt $attempt ==="
             if pixi run package; then
               echo "=== package succeeded on attempt $attempt ==="
               break
@@ -60,11 +53,35 @@ jobs:
             sleep 5
           done
 
-      - name: Run tests (with retry for Mojo compiler intermittent crashes)
+  # ── Job 2: Core parsing tests ──────────────────────────────────────────
+  test-core:
+    name: "Test: Core Parsing"
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pixi
+        run: curl -fsSL https://pixi.sh/install.sh | sh
+      - name: Add pixi to PATH
+        run: |
+          echo "PIXI_HOME=$HOME/.pixi" >> $GITHUB_ENV
+          echo "$HOME/.pixi/bin" >> $GITHUB_PATH
+      - name: pixi install
+        run: pixi install
+      - name: Build package (with retry)
+        run: |
+          for attempt in 1 2 3; do
+            if pixi run package; then break; fi
+            if [ "$attempt" -eq 3 ]; then exit 1; fi
+            sleep 5
+          done
+      - name: Run core tests (with retry)
         run: |
           for attempt in 1 2 3; do
             echo "=== test attempt $attempt ==="
-            if pixi run test; then
+            if mojo run -I src -D ASSERT=all tests/test_parse.mojo \
+            && mojo run -I src -D ASSERT=all tests/test_options.mojo \
+            && mojo run -I src -D ASSERT=all tests/test_groups.mojo; then
               echo "=== tests passed on attempt $attempt ==="
               break
             fi
@@ -76,7 +93,113 @@ jobs:
             sleep 5
           done
 
-      - name: Run example binaries in debug mode (catches developer-facing validation errors)
+  # ── Job 3: Feature tests ───────────────────────────────────────────────
+  test-features:
+    name: "Test: Features"
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pixi
+        run: curl -fsSL https://pixi.sh/install.sh | sh
+      - name: Add pixi to PATH
+        run: |
+          echo "PIXI_HOME=$HOME/.pixi" >> $GITHUB_ENV
+          echo "$HOME/.pixi/bin" >> $GITHUB_PATH
+      - name: pixi install
+        run: pixi install
+      - name: Build package (with retry)
+        run: |
+          for attempt in 1 2 3; do
+            if pixi run package; then break; fi
+            if [ "$attempt" -eq 3 ]; then exit 1; fi
+            sleep 5
+          done
+      - name: Run feature tests (with retry)
+        run: |
+          for attempt in 1 2 3; do
+            echo "=== test attempt $attempt ==="
+            if mojo run -I src -D ASSERT=all tests/test_help.mojo \
+            && mojo run -I src -D ASSERT=all tests/test_completion.mojo \
+            && mojo run -I src -D ASSERT=all tests/test_interactive.mojo < /dev/null \
+            && mojo run -I src -D ASSERT=all tests/test_wrappers.mojo; then
+              echo "=== tests passed on attempt $attempt ==="
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "=== tests failed after 3 attempts ==="
+              exit 1
+            fi
+            echo "=== test run crashed, retrying in 5s... ==="
+            sleep 5
+          done
+
+  # ── Job 4: Declarative API tests ───────────────────────────────────────
+  test-declarative:
+    name: "Test: Declarative API"
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pixi
+        run: curl -fsSL https://pixi.sh/install.sh | sh
+      - name: Add pixi to PATH
+        run: |
+          echo "PIXI_HOME=$HOME/.pixi" >> $GITHUB_ENV
+          echo "$HOME/.pixi/bin" >> $GITHUB_PATH
+      - name: pixi install
+        run: pixi install
+      - name: Build package (with retry)
+        run: |
+          for attempt in 1 2 3; do
+            if pixi run package; then break; fi
+            if [ "$attempt" -eq 3 ]; then exit 1; fi
+            sleep 5
+          done
+      - name: Run declarative tests (with retry)
+        run: |
+          for attempt in 1 2 3; do
+            echo "=== test attempt $attempt ==="
+            if mojo run -I src -D ASSERT=all tests/test_declarative.mojo \
+            && mojo run -I src -D ASSERT=all tests/test_hybrid.mojo \
+            && mojo run -I src -D ASSERT=all tests/test_subcommands.mojo \
+            && mojo run -I src -D ASSERT=all tests/test_subcommands_declarative.mojo \
+            && mojo run -I src -D ASSERT=all tests/test_schema_validation.mojo \
+            && bash tests/check_schema_errors.sh; then
+              echo "=== tests passed on attempt $attempt ==="
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "=== tests failed after 3 attempts ==="
+              exit 1
+            fi
+            echo "=== test run crashed, retrying in 5s... ==="
+            sleep 5
+          done
+
+  # ── Job 5: Example binaries ────────────────────────────────────────────
+  test-examples:
+    name: "Test: Examples"
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pixi
+        run: curl -fsSL https://pixi.sh/install.sh | sh
+      - name: Add pixi to PATH
+        run: |
+          echo "PIXI_HOME=$HOME/.pixi" >> $GITHUB_ENV
+          echo "$HOME/.pixi/bin" >> $GITHUB_PATH
+      - name: pixi install
+        run: pixi install
+      - name: Build package (with retry)
+        run: |
+          for attempt in 1 2 3; do
+            if pixi run package; then break; fi
+            if [ "$attempt" -eq 3 ]; then exit 1; fi
+            sleep 5
+          done
+      - name: Run example binaries (with retry)
         run: |
           for attempt in 1 2 3; do
             echo "=== debug attempt $attempt ==="

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -15,9 +15,9 @@ defaults:
     shell: bash
 
 jobs:
-  # ── Job 1: Format + Package ────────────────────────────────────────────
+  # ── Job 1: Format gate ──────────────────────────────────────────────────
   build:
-    name: Build & Format
+    name: Format Check
     runs-on: macos-latest
     timeout-minutes: 10
     steps:
@@ -32,21 +32,6 @@ jobs:
             echo "::error::Code is not formatted. Run 'pixi run format' locally."
             exit 1
           fi
-      - name: Build package (with retry)
-        run: |
-          for attempt in 1 2 3; do
-            echo "=== package attempt $attempt ==="
-            if pixi run package; then
-              echo "=== package succeeded on attempt $attempt ==="
-              break
-            fi
-            if [ "$attempt" -eq 3 ]; then
-              echo "=== package failed after 3 attempts ==="
-              exit 1
-            fi
-            echo "=== package crashed, retrying in 5s... ==="
-            sleep 5
-          done
 
   # ── Job 2: Core parsing tests ──────────────────────────────────────────
   test-core:

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -22,14 +22,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - name: Install pixi
-        run: curl -fsSL https://pixi.sh/install.sh | sh
-      - name: Add pixi to PATH
-        run: |
-          echo "PIXI_HOME=$HOME/.pixi" >> $GITHUB_ENV
-          echo "$HOME/.pixi/bin" >> $GITHUB_PATH
-      - name: pixi install
-        run: pixi install
+      - uses: prefix-dev/setup-pixi@v0.9.5
+        with:
+          cache: true
       - name: Format check
         run: |
           pixi run format
@@ -56,32 +51,19 @@ jobs:
   # ── Job 2: Core parsing tests ──────────────────────────────────────────
   test-core:
     name: "Test: Core Parsing"
+    needs: build
     runs-on: macos-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
-      - name: Install pixi
-        run: curl -fsSL https://pixi.sh/install.sh | sh
-      - name: Add pixi to PATH
-        run: |
-          echo "PIXI_HOME=$HOME/.pixi" >> $GITHUB_ENV
-          echo "$HOME/.pixi/bin" >> $GITHUB_PATH
-      - name: pixi install
-        run: pixi install
-      - name: Build package (with retry)
-        run: |
-          for attempt in 1 2 3; do
-            if pixi run package; then break; fi
-            if [ "$attempt" -eq 3 ]; then exit 1; fi
-            sleep 5
-          done
+      - uses: ./.github/actions/setup-mojo
       - name: Run core tests (with retry)
         run: |
           for attempt in 1 2 3; do
             echo "=== test attempt $attempt ==="
-            if pixi run mojo run -I src -D ASSERT=all tests/test_parse.mojo \
-            && pixi run mojo run -I src -D ASSERT=all tests/test_options.mojo \
-            && pixi run mojo run -I src -D ASSERT=all tests/test_groups.mojo; then
+            if mojo run -I src -D ASSERT=all tests/test_parse.mojo \
+            && mojo run -I src -D ASSERT=all tests/test_options.mojo \
+            && mojo run -I src -D ASSERT=all tests/test_groups.mojo; then
               echo "=== tests passed on attempt $attempt ==="
               break
             fi
@@ -96,33 +78,20 @@ jobs:
   # ── Job 3: Feature tests ───────────────────────────────────────────────
   test-features:
     name: "Test: Features"
+    needs: build
     runs-on: macos-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
-      - name: Install pixi
-        run: curl -fsSL https://pixi.sh/install.sh | sh
-      - name: Add pixi to PATH
-        run: |
-          echo "PIXI_HOME=$HOME/.pixi" >> $GITHUB_ENV
-          echo "$HOME/.pixi/bin" >> $GITHUB_PATH
-      - name: pixi install
-        run: pixi install
-      - name: Build package (with retry)
-        run: |
-          for attempt in 1 2 3; do
-            if pixi run package; then break; fi
-            if [ "$attempt" -eq 3 ]; then exit 1; fi
-            sleep 5
-          done
+      - uses: ./.github/actions/setup-mojo
       - name: Run feature tests (with retry)
         run: |
           for attempt in 1 2 3; do
             echo "=== test attempt $attempt ==="
-            if pixi run mojo run -I src -D ASSERT=all tests/test_help.mojo \
-            && pixi run mojo run -I src -D ASSERT=all tests/test_completion.mojo \
-            && pixi run mojo run -I src -D ASSERT=all tests/test_interactive.mojo < /dev/null \
-            && pixi run mojo run -I src -D ASSERT=all tests/test_wrappers.mojo; then
+            if mojo run -I src -D ASSERT=all tests/test_help.mojo \
+            && mojo run -I src -D ASSERT=all tests/test_completion.mojo \
+            && mojo run -I src -D ASSERT=all tests/test_interactive.mojo < /dev/null \
+            && mojo run -I src -D ASSERT=all tests/test_wrappers.mojo; then
               echo "=== tests passed on attempt $attempt ==="
               break
             fi
@@ -137,34 +106,21 @@ jobs:
   # ── Job 4: Declarative API tests ───────────────────────────────────────
   test-declarative:
     name: "Test: Declarative API"
+    needs: build
     runs-on: macos-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
-      - name: Install pixi
-        run: curl -fsSL https://pixi.sh/install.sh | sh
-      - name: Add pixi to PATH
-        run: |
-          echo "PIXI_HOME=$HOME/.pixi" >> $GITHUB_ENV
-          echo "$HOME/.pixi/bin" >> $GITHUB_PATH
-      - name: pixi install
-        run: pixi install
-      - name: Build package (with retry)
-        run: |
-          for attempt in 1 2 3; do
-            if pixi run package; then break; fi
-            if [ "$attempt" -eq 3 ]; then exit 1; fi
-            sleep 5
-          done
+      - uses: ./.github/actions/setup-mojo
       - name: Run declarative tests (with retry)
         run: |
           for attempt in 1 2 3; do
             echo "=== test attempt $attempt ==="
-            if pixi run mojo run -I src -D ASSERT=all tests/test_declarative.mojo \
-            && pixi run mojo run -I src -D ASSERT=all tests/test_hybrid.mojo \
-            && pixi run mojo run -I src -D ASSERT=all tests/test_subcommands.mojo \
-            && pixi run mojo run -I src -D ASSERT=all tests/test_subcommands_declarative.mojo \
-            && pixi run mojo run -I src -D ASSERT=all tests/test_schema_validation.mojo \
+            if mojo run -I src -D ASSERT=all tests/test_declarative.mojo \
+            && mojo run -I src -D ASSERT=all tests/test_hybrid.mojo \
+            && mojo run -I src -D ASSERT=all tests/test_subcommands.mojo \
+            && mojo run -I src -D ASSERT=all tests/test_subcommands_declarative.mojo \
+            && mojo run -I src -D ASSERT=all tests/test_schema_validation.mojo \
             && bash tests/check_schema_errors.sh; then
               echo "=== tests passed on attempt $attempt ==="
               break
@@ -180,25 +136,12 @@ jobs:
   # ── Job 5: Example binaries ────────────────────────────────────────────
   test-examples:
     name: "Test: Examples"
+    needs: build
     runs-on: macos-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
-      - name: Install pixi
-        run: curl -fsSL https://pixi.sh/install.sh | sh
-      - name: Add pixi to PATH
-        run: |
-          echo "PIXI_HOME=$HOME/.pixi" >> $GITHUB_ENV
-          echo "$HOME/.pixi/bin" >> $GITHUB_PATH
-      - name: pixi install
-        run: pixi install
-      - name: Build package (with retry)
-        run: |
-          for attempt in 1 2 3; do
-            if pixi run package; then break; fi
-            if [ "$attempt" -eq 3 ]; then exit 1; fi
-            sleep 5
-          done
+      - uses: ./.github/actions/setup-mojo
       - name: Run example binaries (with retry)
         run: |
           for attempt in 1 2 3; do

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -15,9 +15,11 @@ defaults:
     shell: bash
 
 jobs:
-  # ── Job 1: Format gate ──────────────────────────────────────────────────
+  # ── Job 1: Format + Package ────────────────────────────────────────────
+  # If this job fails, the later test jobs will be skipped,
+  # so we can save time by checking formatting and packaging first.
   build:
-    name: Format Check
+    name: Build & Format
     runs-on: macos-latest
     timeout-minutes: 10
     steps:
@@ -32,6 +34,21 @@ jobs:
             echo "::error::Code is not formatted. Run 'pixi run format' locally."
             exit 1
           fi
+      - name: Build package (with retry)
+        run: |
+          for attempt in 1 2 3; do
+            echo "=== package attempt $attempt ==="
+            if pixi run package; then
+              echo "=== package succeeded on attempt $attempt ==="
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "=== package failed after 3 attempts ==="
+              exit 1
+            fi
+            echo "=== package crashed, retrying in 5s... ==="
+            sleep 5
+          done
 
   # ── Job 2: Core parsing tests ──────────────────────────────────────────
   test-core:

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -79,9 +79,9 @@ jobs:
         run: |
           for attempt in 1 2 3; do
             echo "=== test attempt $attempt ==="
-            if mojo run -I src -D ASSERT=all tests/test_parse.mojo \
-            && mojo run -I src -D ASSERT=all tests/test_options.mojo \
-            && mojo run -I src -D ASSERT=all tests/test_groups.mojo; then
+            if pixi run mojo run -I src -D ASSERT=all tests/test_parse.mojo \
+            && pixi run mojo run -I src -D ASSERT=all tests/test_options.mojo \
+            && pixi run mojo run -I src -D ASSERT=all tests/test_groups.mojo; then
               echo "=== tests passed on attempt $attempt ==="
               break
             fi
@@ -119,10 +119,10 @@ jobs:
         run: |
           for attempt in 1 2 3; do
             echo "=== test attempt $attempt ==="
-            if mojo run -I src -D ASSERT=all tests/test_help.mojo \
-            && mojo run -I src -D ASSERT=all tests/test_completion.mojo \
-            && mojo run -I src -D ASSERT=all tests/test_interactive.mojo < /dev/null \
-            && mojo run -I src -D ASSERT=all tests/test_wrappers.mojo; then
+            if pixi run mojo run -I src -D ASSERT=all tests/test_help.mojo \
+            && pixi run mojo run -I src -D ASSERT=all tests/test_completion.mojo \
+            && pixi run mojo run -I src -D ASSERT=all tests/test_interactive.mojo < /dev/null \
+            && pixi run mojo run -I src -D ASSERT=all tests/test_wrappers.mojo; then
               echo "=== tests passed on attempt $attempt ==="
               break
             fi
@@ -160,11 +160,11 @@ jobs:
         run: |
           for attempt in 1 2 3; do
             echo "=== test attempt $attempt ==="
-            if mojo run -I src -D ASSERT=all tests/test_declarative.mojo \
-            && mojo run -I src -D ASSERT=all tests/test_hybrid.mojo \
-            && mojo run -I src -D ASSERT=all tests/test_subcommands.mojo \
-            && mojo run -I src -D ASSERT=all tests/test_subcommands_declarative.mojo \
-            && mojo run -I src -D ASSERT=all tests/test_schema_validation.mojo \
+            if pixi run mojo run -I src -D ASSERT=all tests/test_declarative.mojo \
+            && pixi run mojo run -I src -D ASSERT=all tests/test_hybrid.mojo \
+            && pixi run mojo run -I src -D ASSERT=all tests/test_subcommands.mojo \
+            && pixi run mojo run -I src -D ASSERT=all tests/test_subcommands_declarative.mojo \
+            && pixi run mojo run -I src -D ASSERT=all tests/test_schema_validation.mojo \
             && bash tests/check_schema_errors.sh; then
               echo "=== tests passed on attempt $attempt ==="
               break


### PR DESCRIPTION
This PR updates the GitHub Actions CI workflow to split the existing monolithic test run into multiple jobs, aiming to improve CI parallelism and isolate failures.

**Changes:**
- Introduces a dedicated `build` job that runs formatting checks and packages the project.
- Splits the test suite into four separate jobs (`test-core`, `test-features`, `test-declarative`, `test-examples`).
- Replaces the single `pixi run test` invocation with explicit per-test `mojo run …` commands in the split jobs.