### PR TITLE
[core] Add `prelude` module for convenient import

### DIFF
--- a/src/argmojo/prelude.mojo
+++ b/src/argmojo/prelude.mojo
@@ -1,0 +1,19 @@
+"""Prelude module for ArgMojo.
+
+Usage:
+
+```mojo
+from argmojo.prelude import *
+```
+
+This imports all public types and traits from ArgMojo for convenience.
+"""
+
+# Builder API
+from .argument import Argument
+from .command import Command
+from .parse_result import ParseResult
+
+# Declarative API
+from .parsable import Parsable
+from .argument_wrappers import ArgumentLike, Option, Flag, Positional, Count

--- a/src/argmojo/prelude.mojo
+++ b/src/argmojo/prelude.mojo
@@ -16,4 +16,4 @@ from .parse_result import ParseResult
 
 # Declarative API
 from .parsable import Parsable
-from .argument_wrappers import ArgumentLike, Option, Flag, Positional, Count
+from .argument_wrappers import Option, Flag, Positional, Count


### PR DESCRIPTION
This PR adds a dedicated `argmojo.prelude` module intended to provide a single convenient import point for ArgMojo’s primary public types/traits. It introduces `src/argmojo/prelude.mojo` with re-exports for the builder API (`Argument`, `Command`, `ParseResult`) and declarative API (`Parsable`, `Option`, `Flag`, `Positional`, `Count`).