### PR TITLE
[core] Enhance help and error messages with improved formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,18 +36,18 @@ ArgMojo currently supports:
 - **Boolean flags**: options that take no value
 - **Positional arguments**: matched by position
 - **Default values**: fallback when an argument is not provided
-- **Required arguments**: validation that mandatory args are present
-- **Auto-generated help**: `--help` / `-h` / `-?` with dynamic column alignment, pixi-style ANSI colours, and customisable header/arg colours
-- **Help on no args**: optionally show help when invoked with no arguments
+- **Required arguments**: validation that mandatory arguments are present
+- **Auto-generated help**: `--help` / `-h` / `-?` with dynamic column alignment, pixi-style ANSI colours, and customisable header/argument colours
+- **Help on no arguments**: optionally show help when invoked with no arguments
 - **Version display**: `--version` / `-V` (also auto-generated)
 - **`--` stop marker**: everything after `--` is treated as positional
 - **Short flag merging**: `-abc` expands to `-a -b -c`
 - **Attached short values**: `-ofile.txt` means `-o file.txt`
 - **Choices validation**: restrict values to a set (e.g., `json`, `csv`, `table`)
 - **Value name**: custom display name for values in help text
-- **Hidden arguments**: exclude internal args from `--help` output
+- **Hidden arguments**: exclude internal arguments from `--help` output
 - **Count flags**: `-vvv` → `get_count("verbose") == 3`
-- **Positional arg count validation**: reject extra positional args
+- **Positional argument count validation**: reject extra positional arguments
 - **Negatable flags**: `--color` / `--no-color` paired flags with `.negatable()`
 - **Mutually exclusive groups**: prevent conflicting flags (e.g., `--json` vs `--yaml`)
 - **Required-together groups**: enforce that related flags are provided together (e.g., `--username` + `--password`)
@@ -195,11 +195,11 @@ struct Search(Parsable):
 
 
 def main() raises:
-    var args = Search.parse()    # one line — typed results
+    var arguments = Search.parse()    # one line — typed results
     
-    print("pattern:", args.pattern.value)
-    print("format: ", args.format.value)
-    print("verbose:", args.verbose.value)
+    print("pattern:", arguments.pattern.value)
+    print("format: ", arguments.format.value)
+    print("verbose:", arguments.verbose.value)
 ```
 
 Need builder-level features (mutually exclusive groups, implications, custom help colours) on top of a declarative struct? Use the hybrid bridge:
@@ -218,7 +218,7 @@ The `Parsable` trait provides four parsing methods:
 | returns `Self`  | `parse()`      | `parse_from_command(cmd^)`      |
 | returns `Tuple` | `parse_full()` | `parse_full_from_command(cmd^)` |
 
-Plus: `parse_args(args)` for testing, `to_command()` to reflect a struct into a `Command`, and `from_parse_result(result)` for subcommand write-back.
+Plus: `parse_args(arguments)` for testing, `to_command()` to reflect a struct into a `Command`, and `from_parse_result(result)` for subcommand write-back.
 
 See `examples/declarative/` for more patterns: pure declarative, hybrid, full parse, and subcommands.
 
@@ -228,17 +228,17 @@ For detailed explanations and more examples of every feature, see the **[User Ma
 
 ArgMojo ships with two complete example CLIs:
 
-| Example                     | File                                | Features                                                                                                                                                                                                                                                                                                                          |
-| --------------------------- | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `mgrep` — simulated grep    | `examples/mgrep.mojo`               | Positional args, flags, count flags, negatable flags, choices, value_name, append/collect, value delimiter, nargs, mutually exclusive groups, required-together groups, conditional requirements, numeric range, key-value map, aliases, deprecated args, hidden args, negative-number passthrough, `--` stop marker, custom tips |
-| `mgit` — simulated git      | `examples/mgit.mojo`                | Subcommands (clone/init/add/commit/push/pull/log/remote/branch/diff/tag/stash), nested subcommands (remote add/remove/rename/show), persistent (global) flags, per-command args, mutually exclusive groups, choices, aliases, deprecated args, custom tips, shell completion script generation                                    |
-| `demo` — feature showcase   | `examples/demo.mojo`                | Comprehensive showcase of all ArgMojo features in a single CLI                                                                                                                                                                                                                                                                    |
-| `yu` — Chinese CLI          | `examples/yu.mojo`                  | CJK-aware help formatting, full-width auto-correction, CJK punctuation detection                                                                                                                                                                                                                                                  |
-| **Declarative examples**    |                                     |                                                                                                                                                                                                                                                                                                                                   |
-| `search` — pure declarative | `examples/declarative/search.mojo`  | Positional args, flags, count flags, choices, range clamping, append/collect — all via `Parsable` struct                                                                                                                                                                                                                          |
-| `deploy` — hybrid           | `examples/declarative/deploy.mojo`  | Declarative struct + builder customisation (`mutually_exclusive`, `implies`, tips, colours)                                                                                                                                                                                                                                       |
-| `convert` — full parse      | `examples/declarative/convert.mojo` | Declarative fields + extra builder args; `parse_full_from_command()` dual return                                                                                                                                                                                                                                                  |
-| `jomo` — subcommands        | `examples/declarative/jomo.mojo`    | Declarative root + mix of declarative and builder subcommands; `subcommands()` hook, `from_parse_result()` dispatch                                                                                                                                                                                                               |
+| Example                     | File                                | Features                                                                                                                                                                                                                                                                                                                                         |
+| --------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `mgrep` — simulated grep    | `examples/mgrep.mojo`               | Positional arguments, flags, count flags, negatable flags, choices, value_name, append/collect, value delimiter, nargs, mutually exclusive groups, required-together groups, conditional requirements, numeric range, key-value map, aliases, deprecated arguments, hidden arguments, negative-number passthrough, `--` stop marker, custom tips |
+| `mgit` — simulated git      | `examples/mgit.mojo`                | Subcommands (clone/init/add/commit/push/pull/log/remote/branch/diff/tag/stash), nested subcommands (remote add/remove/rename/show), persistent (global) flags, per-command arguments, mutually exclusive groups, choices, aliases, deprecated arguments, custom tips, shell completion script generation                                         |
+| `demo` — feature showcase   | `examples/demo.mojo`                | Comprehensive showcase of all ArgMojo features in a single CLI                                                                                                                                                                                                                                                                                   |
+| `yu` — Chinese CLI          | `examples/yu.mojo`                  | CJK-aware help formatting, full-width auto-correction, CJK punctuation detection                                                                                                                                                                                                                                                                 |
+| **Declarative examples**    |                                     |                                                                                                                                                                                                                                                                                                                                                  |
+| `search` — pure declarative | `examples/declarative/search.mojo`  | Positional arguments, flags, count flags, choices, range clamping, append/collect — all via `Parsable` struct                                                                                                                                                                                                                                    |
+| `deploy` — hybrid           | `examples/declarative/deploy.mojo`  | Declarative struct + builder customisation (`mutually_exclusive`, `implies`, tips, colours)                                                                                                                                                                                                                                                      |
+| `convert` — full parse      | `examples/declarative/convert.mojo` | Declarative fields + extra builder arguments; `parse_full_from_command()` dual return                                                                                                                                                                                                                                                            |
+| `jomo` — subcommands        | `examples/declarative/jomo.mojo`    | Declarative root + mix of declarative and builder subcommands; `subcommands()` hook, `from_parse_result()` dispatch                                                                                                                                                                                                                              |
 
 Build both example binaries:
 

--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -359,7 +359,7 @@ The practical view — both dimensions checked together at parse time:
    ```bash
    error: <command>: <what's wrong>
 
-   Usage: <command> <required> [optional] [OPTIONS]
+   usage: <command> <required> [optional] [OPTIONS]
    For more information, try '<command> --help'.
    ```
 
@@ -397,7 +397,7 @@ The practical view — both dimensions checked together at parse time:
 - [x] **`-?` help alias** — `-?` accepted as an alias for `-h` / `--help` (common in Windows CLI tools, Java, MySQL, curl)
 - [x] **Help on no args** — `command.help_on_no_arguments()` shows help when invoked with no arguments (like git/docker/cargo)
 - [x] **Dynamic help padding** — help column alignment is computed from the longest option line instead of a fixed width
-- [x] **colored help output** — ANSI colors (bold+underline headers, colored arg names), with `color=False` opt-out and customisable colors via `header_color["NAME"]()` / `arg_color["NAME"]()` (compile-time validated)
+- [x] **colored help output** — ANSI colors (bold+underline headers, fine-grained colour roles for program/short-option/long-option/value/positional/command names), with `color=False` opt-out and customisable colors via `header_color["NAME"]()` / `argument_color["NAME"]()` / individual setters like `program_color`, `short_option_color`, etc. (compile-time validated)
 - [x] **number of values (multi-value)** — `--point 1 2 3` consumes N values for one option (argparse `nargs`, clap `num_args`)
 - [x] **Conditional requirement** — `--output` required only when `--save` is present (cobra `MarkFlagRequiredWith`, clap `required_if_eq`)
 - [x] **Numeric range validation** — `.range[1, 65535]()` validates `--port` value is within range (no major library has this built-in)
@@ -587,7 +587,7 @@ Before adding Phase 5 features, further decompose `parse_arguments()` for readab
 - [ ] **Extend `implies()`** - support value-taking options with a default value, e.g., `cmd.implies("debug", "output", "debug.log")` — when `--debug` is set, auto-set `--output` to `"debug.log"`. Currently `implies()` only supports flag/count targets (same as cobra in Go). Revisit when there is a concrete use case.
 - [x] **80-character help formatting** — wrap help descriptions at 80 columns with proper indentation (no major library does this by default; users typically pipe through `less` or rely on terminal wrapping)
 - [ ] **Comptime string concatenation** — 將 String 的拼接 comptime 化，避免在運行時進行多次拼接（例如錯誤消息、幫助文本等），提升性能。
-- [ ] **Even more beautiful and colourful help output** — add more colour options (e.g., `argparse` provides different colours for option short, long, and value names). Maybe also make the formatting of the help text to be closer to that of `argparse` so Python users feel more at home. Nevertheless, the main theme colours should be purple~pink and yellow~orange. 讓幫助信息不僅實用，還賞心悦目！
+- [x] **Even more beautiful and colourful help output** — six fine-grained colour roles (`program_color`, `short_option_color`, `long_option_color`, `value_color`, `positional_color`, `command_color`) matching `argparse`'s differentiation; lowercase section headings (`usage:`, `options:`, `commands:`); dynamic terminal-width detection via `ioctl(TIOCGWINSZ)`; pixi-style multi-line error diagnostics with coloured `error:` / `tip:` labels and coloured usage line. `argument_color` remains as a convenience setter for all six roles at once.
 
 #### Explicitly Out of Scope in This Phase
 

--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -587,6 +587,7 @@ Before adding Phase 5 features, further decompose `parse_arguments()` for readab
 - [ ] **Extend `implies()`** - support value-taking options with a default value, e.g., `cmd.implies("debug", "output", "debug.log")` — when `--debug` is set, auto-set `--output` to `"debug.log"`. Currently `implies()` only supports flag/count targets (same as cobra in Go). Revisit when there is a concrete use case.
 - [x] **80-character help formatting** — wrap help descriptions at 80 columns with proper indentation (no major library does this by default; users typically pipe through `less` or rely on terminal wrapping)
 - [ ] **Comptime string concatenation** — 將 String 的拼接 comptime 化，避免在運行時進行多次拼接（例如錯誤消息、幫助文本等），提升性能。
+- [ ] **Even more beautiful and colourful help output** — add more colour options (e.g., `argparse` provides different colours for option short, long, and value names). Maybe also make the formatting of the help text to be closer to that of `argparse` so Python users feel more at home. Nevertheless, the main theme colours should be purple~pink and yellow~orange. 讓幫助信息不僅實用，還賞心悦目！
 
 #### Explicitly Out of Scope in This Phase
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -85,7 +85,7 @@ ArgMojo v0.4.0 targets Mojo v0.26.2.
 
 1. Rename `.metavar()` to `.value_name()` across the entire API (PR #13).
 2. Parameterise `.long[]()` and `.short[]()` as compile-time `StringLiteral` parameters (PR #20).
-3. Parameterise `.alias_name[]()`, `.delimiter[]()`, `.default[]()`, `.deprecated[]()`, `.default_if_no_value[]()`, `.group[]()`, `.prompt[]()`, and colour setters (`header_color[]`, `arg_color[]`, `warn_color[]`, `error_color[]`) as compile-time parameters (PR #18, #21).
+3. Parameterise `.alias_name[]()`, `.delimiter[]()`, `.default[]()`, `.deprecated[]()`, `.default_if_no_value[]()`, `.group[]()`, `.prompt[]()`, and colour setters (`header_color[]`, `argument_color[]`, `warn_color[]`, `error_color[]`) as compile-time parameters (PR #18, #21).
 4. Replace `.choices(list)` with chained `.choice["a"]().choice["b"]()` compile-time parameters (PR #18).
 5. Value-name display uses angle brackets by default; `.value_name["FOO", False]()` for bare display (PR #17).
 6. Move `print_summary()` from `Command` to `ParseResult` (PR #24).

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -56,6 +56,10 @@ from argmojo import Argument, Command
   - [Hidden Subcommands](#hidden-subcommands)
   - [Mixing Positional Args with Subcommands](#mixing-positional-args-with-subcommands)
   - [Compile-Time Best Practice: Split Large Command Trees](#compile-time-best-practice-split-large-command-trees)
+    - [Why monolithic functions compile slowly](#why-monolithic-functions-compile-slowly)
+    - [The pattern](#the-pattern)
+    - [Real-world measurement](#real-world-measurement)
+    - [Rule of thumb](#rule-of-thumb)
 - [Help \& Display](#help--display)
   - [Value Name](#value-name)
   - [Hidden Arguments](#hidden-arguments)
@@ -435,7 +439,13 @@ Argument("name", help="...")
 ║   command.disable_help_subcommand()             opt out of auto-added help subcommand
 ║   ├── Colour customisation
 ║   │   command.header_color["CYAN"]()            section header colour
-║   │   command.arg_color["GREEN"]()              argument name colour
+║   │   command.argument_color["GREEN"]()              all argument name colours at once
+║   │   command.program_color["MAGENTA"]()        program name in usage line
+║   │   command.short_option_color["GREEN"]()     short option names (-h, -p)
+║   │   command.long_option_color["CYAN"]()       long option names (--help)
+║   │   command.value_color["YELLOW"]()           value names / metavar
+║   │   command.positional_color["GREEN"]()       positional argument names
+║   │   command.command_color["CYAN"]()           subcommand names
 ║   │   command.warn_color["YELLOW"]()            deprecation warning colour
 ║   │   command.error_color["RED"]()              error message colour
 ║   ├── Shell completion
@@ -971,7 +981,7 @@ myapp --route north up      # ✗ 'up' is not a valid choice
 nargs options show the placeholder repeated N times:
 
 ```txt
-Options:
+options:
   --point <point> <point>    X Y coordinates
   --rgb N N N                RGB colour        (with .value_name["N"]())
 ```
@@ -1063,7 +1073,7 @@ dictionary just like `get_list()` returns an empty list.
 `<key=value>` instead of the default `<name>` placeholder:
 
 ```console
-Options:
+options:
   -D, --define <key=value>...    Define a variable
 ```
 
@@ -1673,14 +1683,14 @@ app --verbose search "fn main"
 ```text
 My CLI tool
 
-Usage: app <COMMAND> [OPTIONS]
+usage: app <COMMAND> [OPTIONS]
 
-Options:
+options:
   -v, --verbose    Verbose output
   -h, --help       Show this help message
   -V, --version    Show version
 
-Commands:
+commands:
   search    Search for patterns
   init      Initialise a new project
 ```
@@ -1696,12 +1706,12 @@ app search --help
 ```text
 Search for patterns
 
-Usage: app search <pattern> [OPTIONS]
+usage: app search <pattern> [OPTIONS]
 
-Arguments:
+arguments:
   pattern    Search pattern
 
-Options:
+options:
   -d, --max-depth N    Max depth
   -h, --help           Show this help message
   -V, --version        Show version
@@ -1973,20 +1983,20 @@ print(sub.get_flag("verbose"))      # True
 
 ```text
 # Root help (app --help)
-Options:
+options:
   -h, --help       Show this help message
   -V, --version    Show version
 
-Global Options:
+global options:
   -v, --verbose               Verbose output
   -o, --output {json,text,yaml}    Output format
 
 # Child help (app search --help)
-Options:
+options:
   -h, --help    Show this help message
   -V, --version Show version
 
-Global Options:
+global options:
   -v, --verbose               Verbose output
   -o, --output {json,text,yaml}    Output format
 ```
@@ -2068,7 +2078,7 @@ print(result.subcommand)  # always "clone", even if user typed "cl"
 Aliases appear in help output alongside the primary name:
 
 ```console
-Commands:
+commands:
   clone, cl    Clone a repository
   commit, ci   Record changes to the repository
 ```
@@ -2369,7 +2379,7 @@ myapp -C
 message in the help text:
 
 ```console
-Options:
+options:
   --format-old <format_old>    Legacy output format [deprecated: Use --format instead]
 ```
 
@@ -2415,14 +2425,14 @@ command.add_argument(
 **Help display** — the optional value is shown in brackets:
 
 ```console
-Options:
+options:
       --compress[=<compress>]    Compression algorithm
 ```
 
 With `.value_name["ALGO"]()`:
 
 ```console
-Options:
+options:
       --compress[=ALGO]          Compression algorithm
 ```
 
@@ -2451,7 +2461,7 @@ command.add_argument(
 **Help display** — the `=` is shown in the help:
 
 ```console
-Options:
+options:
   -o, --output=<output>    Output file
 ```
 
@@ -2483,7 +2493,7 @@ command.add_argument(
 #### Help output: <!-- omit from toc -->
 
 ```console
-Options:
+options:
   -v, --verbose              Increase verbosity
   -h, --help                 Show this help message
 
@@ -2519,13 +2529,13 @@ myapp '-?'     # quote needed: ? is a shell glob wildcard
 ```console
 A CJK-aware text search tool
 
-Usage: myapp <pattern> [path] [OPTIONS]
+usage: myapp <pattern> [path] [OPTIONS]
 
-Arguments:
+arguments:
   pattern    Search pattern
   path       Search path
 
-Options:
+options:
   -l, --ling                        Use Lingming IME for encoding
   -i, --ignore-case                 Case-insensitive search
   -v, --verbose                     Increase verbosity (-v, -vv, -vvv)
@@ -2544,13 +2554,18 @@ Help text columns are **dynamically aligned**: the padding between the option na
 
 Help output uses **ANSI colour codes** by default to enhance readability.
 
-| Element                 | Default style                        | ANSI code      |
-| ----------------------- | ------------------------------------ | -------------- |
-| Section headers         | **bold + underline + bright yellow** | `\x1b[1;4;93m` |
-| Option / argument names | bright magenta                       | `\x1b[95m`     |
-| Deprecation warnings    | **orange** (dark yellow)             | `\x1b[33m`     |
-| Parse errors            | **bright red**                       | `\x1b[91m`     |
-| Description text        | default terminal colour              | —              |
+| Element               | Default style                        | ANSI code      |
+| --------------------- | ------------------------------------ | -------------- |
+| Section headers       | **bold + underline + bright yellow** | `\x1b[1;4;93m` |
+| Program name          | **bold magenta**                     | `\x1b[1;35m`   |
+| Short option names    | **bold green**                       | `\x1b[1;32m`   |
+| Long option names     | **bold cyan**                        | `\x1b[1;36m`   |
+| Value names / metavar | **bold yellow**                      | `\x1b[1;33m`   |
+| Positional arg names  | **bold green**                       | `\x1b[1;32m`   |
+| Subcommand names      | **bold cyan**                        | `\x1b[1;36m`   |
+| Deprecation warnings  | **orange** (dark yellow)             | `\x1b[33m`     |
+| Parse errors          | **bright red**                       | `\x1b[91m`     |
+| Description text      | default terminal colour              | —              |
 
 The `_generate_help()` method accepts an optional `color` parameter:
 
@@ -2568,9 +2583,20 @@ The **header colour**, **argument-name colour**, **deprecation warning colour**,
 ```mojo
 var command = Command("myapp", "My app")
 command.header_color["BLUE"]()     # section headers in bright blue
-command.arg_color["GREEN"]()       # option/argument names in bright green
+command.argument_color["GREEN"]()       # ALL option/argument names in bright green
 command.warn_color["YELLOW"]()     # deprecation warnings (default: orange)
 command.error_color["MAGENTA"]()   # parse errors (default: red)
+```
+
+`argument_color` is a convenience that sets all six name-colour roles at once. For fine-grained control:
+
+```mojo
+command.program_color["MAGENTA"]()       # program name in usage line
+command.short_option_color["GREEN"]()    # short options (-h, -p)
+command.long_option_color["CYAN"]()      # long options (--help, --port)
+command.value_color["YELLOW"]()          # value names / metavar (PORT, <HOST>)
+command.positional_color["GREEN"]()      # positional argument names
+command.command_color["CYAN"]()          # subcommand names in commands section
 ```
 
 Available colour names (uppercase only):
@@ -2655,18 +2681,18 @@ command.add_tip("Use quotes if you use spaces in expressions.")
 ```text
 A calculator
 
-Usage: calc <expr> [OPTIONS]
+usage: calc <expr> [OPTIONS]
 
-Arguments:
+arguments:
   expr    Expression
 
-Options:
+options:
   -h, --help       Show this help message
   -V, --version    Show version
 
-Tip: Use '--' to pass values starting with '-' as positionals:  calc -- -10.18
-Tip: Expressions starting with `-` are accepted.
-Tip: Use quotes if you use spaces in expressions.
+tip: Use '--' to pass values starting with '-' as positionals:  calc -- -10.18
+tip: Expressions starting with `-` are accepted.
+tip: Use quotes if you use spaces in expressions.
 ```
 
 ---
@@ -2723,7 +2749,7 @@ command.add_argument(
 ```
 
 ```txt
-Options:
+options:
   -o, --output <output>    Output path
       --編碼 <編碼>        設定編碼
 ```
@@ -2739,7 +2765,7 @@ app.add_subcommand(build_cmd^)
 ```
 
 ```txt
-Commands:
+commands:
   初始化    建立新項目
   構建      編譯項目
 ```
@@ -2846,7 +2872,7 @@ calc -- -3e4         # operand = "-3e4"
 See [The `--` Stop Marker](#the----stop-marker) for details. When positional arguments are registered, ArgMojo's help output includes a **Tip** line reminding users about this:
 
 ```text
-Tip: Use '--' to pass values that start with '-' (e.g., negative numbers):  calc -- -10.18
+tip: Use '--' to pass values that start with '-' (e.g., negative numbers):  calc -- -10.18
 ```
 
 ---
@@ -3686,7 +3712,7 @@ Dropping database: mydb
 
 ## Usage Line Customisation
 
-By default, ArgMojo generates usage lines like `Usage: myapp <PATTERN> [OPTIONS]` — showing `[OPTIONS]` for named arguments and listing each positional. This convention (shared by clap, cobra, and Click) works well for most CLIs.
+By default, ArgMojo generates usage lines like `usage: myapp <PATTERN> [OPTIONS]` — showing `[OPTIONS]` for named arguments and listing each positional. This convention (shared by clap, cobra, and Click) works well for most CLIs.
 
 For some programs you may want a hand-written usage string — for example, git's usage line enumerates a few key flags inline rather than collapsing them into `[OPTIONS]`. The `usage()` method on `Command` lets you replace the auto-generated usage line with your own text:
 
@@ -3703,15 +3729,15 @@ def main() raises:
     var result = cmd.parse()
 ```
 
-The custom string appears as-is after `Usage:` in both `--help` output and error messages:
+The custom string appears as-is after `usage:` in both `--help` output and error messages:
 
 ```sh
 $ ./git --help
 The stupid content tracker
 
-Usage: git [-v | --version] [-h | --help] [-C <path>] <command> [<args>]
+usage: git [-v | --version] [-h | --help] [-C <path>] <command> [<args>]
 
-Options:
+options:
   -v, --verbose   Verbose output
   -C <path>       Run as if started in <path>
   -h, --help      Print help
@@ -3755,7 +3781,7 @@ myapp --completions fish   # prints Fish completion script and exits
 The `--completions` option is shown in the help output alongside `--help` and `--version`:
 
 ```console
-Options:
+options:
   --help                  Show this help message and exit
   --version               Show the version and exit
   --completions {bash,zsh,fish}
@@ -3907,7 +3933,7 @@ Methods validated at compile time include:
 | `.number_of_values[N]()`       | Value count is a positive `Int`             |
 | `.range[min, max]()`           | Range bounds are valid `Int` values         |
 | `header_color[name]()`         | Colour name is one of the accepted names    |
-| `arg_color[name]()`            | Same as above                               |
+| `argument_color[name]()`       | Same as above                               |
 | `warn_color[name]()`           | Same as above                               |
 | `error_color[name]()`          | Same as above                               |
 | `response_file_max_depth[N]()` | Depth is a positive `Int`                   |
@@ -4212,14 +4238,14 @@ The table below maps every ArgMojo builder method / command-level method to its 
 
 #### Help & Display <!-- omit from toc -->
 
-| ArgMojo method         | argparse     | click        | clap (Rust)            | cobra / pflag (Go) |
-| ---------------------- | ------------ | ------------ | ---------------------- | ------------------ |
-| `usage(text)`          | `usage="…"`  | —            | `.override_usage("…")` | `Use: "…"`         |
-| `add_tip(tip)`         | `epilog="…"` | `epilog="…"` | `.after_help("…")`     | `Example: "…"`     |
-| `header_color[name]()` | —            | `style()` ¹³ | `Styles::styled()` ¹⁴  | —                  |
-| `arg_color[name]()`    | —            | `style()` ¹³ | `Styles::styled()` ¹⁴  | —                  |
-| `warn_color[name]()`   | —            | `style()` ¹³ | `Styles::styled()` ¹⁴  | —                  |
-| `error_color[name]()`  | —            | `style()` ¹³ | `Styles::styled()` ¹⁴  | —                  |
+| ArgMojo method           | argparse     | click        | clap (Rust)            | cobra / pflag (Go) |
+| ------------------------ | ------------ | ------------ | ---------------------- | ------------------ |
+| `usage(text)`            | `usage="…"`  | —            | `.override_usage("…")` | `Use: "…"`         |
+| `add_tip(tip)`           | `epilog="…"` | `epilog="…"` | `.after_help("…")`     | `Example: "…"`     |
+| `header_color[name]()`   | —            | `style()` ¹³ | `Styles::styled()` ¹⁴  | —                  |
+| `argument_color[name]()` | —            | `style()` ¹³ | `Styles::styled()` ¹⁴  | —                  |
+| `warn_color[name]()`     | —            | `style()` ¹³ | `Styles::styled()` ¹⁴  | —                  |
+| `error_color[name]()`    | —            | `style()` ¹³ | `Styles::styled()` ¹⁴  | —                  |
 
 #### Shell Completions <!-- omit from toc -->
 

--- a/examples/demo.mojo
+++ b/examples/demo.mojo
@@ -7,7 +7,7 @@ them interactively from the command line.
 Showcases: count ceiling (.count().max(N)), range clamping (.range().clamp()),
 one-required groups, mutually exclusive groups, required-together groups,
 conditional requirements, negatable flags, color customisation
-(header_color, arg_color), numeric range validation, append with range
+(header_color, argument_color), numeric range validation, append with range
 clamping, value delimiter, nargs, key-value map, aliases, deprecated args,
 negative number passthrough, allow_positional_with_subcommands, custom tips,
 help_on_no_arguments, default_if_no_value, require_equals, response files,
@@ -121,7 +121,7 @@ def main() raises:
 
     # ── Color customisation ──────────────────────────────────────────────
     app.header_color["CYAN"]()
-    app.arg_color["GREEN"]()
+    app.argument_color["GREEN"]()
 
     # ── Response file support ────────────────────────────────────────────
     app.response_file_prefix()  # enables @args.txt expansion

--- a/pixi.toml
+++ b/pixi.toml
@@ -23,8 +23,7 @@ format = "mojo format ./src ./tests ./examples"
 package = "mojo package src/argmojo -o argmojo.mojopkg"
 
 # doc
-doc = """mojo doc \
---diagnose-missing-doc-strings --Werror src/argmojo"""
+doc = """pixi run mojo doc --diagnose-missing-doc-strings src/argmojo > /dev/null"""
 
 # run tests
 test = """\

--- a/pixi.toml
+++ b/pixi.toml
@@ -23,7 +23,7 @@ format = "mojo format ./src ./tests ./examples"
 package = "mojo package src/argmojo -o argmojo.mojopkg"
 
 # doc
-doc = """pixi run mojo doc --diagnose-missing-doc-strings src/argmojo > /dev/null"""
+doc = """mojo doc --diagnose-missing-doc-strings src/argmojo > /dev/null"""
 
 # run tests
 test = """\

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -9,6 +9,8 @@ from .parse_result import ParseResult
 from .utils import (
     _RESET,
     _BOLD_UL,
+    _BOLD_YELLOW,
+    _BOLD_CYAN,
     _DEFAULT_HEADER_COLOR,
     _DEFAULT_ARGUMENT_COLOR,
     _DEFAULT_WARN_COLOR,
@@ -3173,25 +3175,6 @@ struct Command(Copyable, Movable, Writable):
             # When allow_positional_with_subcommands is set, fall
             # through to positional handling below.
             if not self._allow_positional_with_subcommands:
-                var avail = String("")
-                var first = True
-                for _si in range(len(self.subcommands)):
-                    if (
-                        not self.subcommands[_si]._is_help_subcommand
-                        and not self.subcommands[_si]._is_hidden
-                    ):
-                        if not first:
-                            avail += ", "
-                        avail += self.subcommands[_si].name
-                        # Append aliases to available list.
-                        for _ai in range(
-                            len(self.subcommands[_si]._command_aliases)
-                        ):
-                            avail += (
-                                ", "
-                                + self.subcommands[_si]._command_aliases[_ai]
-                            )
-                        first = False
                 # Try typo suggestion for subcommand names.
                 var sub_names = List[String]()
                 for _si2 in range(len(self.subcommands)):
@@ -3207,16 +3190,56 @@ struct Command(Copyable, Movable, Writable):
                                 self.subcommands[_si2]._command_aliases[_ai2]
                             )
                 var suggestion = _suggest_similar(arg, sub_names)
-                var hint = String("")
-                if suggestion != "":
-                    hint = ". Did you mean '" + suggestion + "'?"
-                self._error(
-                    "Unknown command '"
-                    + arg
-                    + "'. Available commands: "
-                    + avail
-                    + hint
-                )
+
+                # Multi-line error (pixi / argparse style):
+                #   error: prog: unrecognized command 'foo'
+                #
+                #     tip: a similar command exists: 'bar'
+                #
+                #   Usage: prog <COMMAND> [OPTIONS]
+                var err_msg = "unrecognized command '" + arg + "'"
+                if suggestion:
+                    err_msg += ". Did you mean '" + suggestion + "'?"
+                if Self._no_color_env():
+                    print(
+                        "error: " + self.name + ": " + err_msg,
+                        file=stderr,
+                    )
+                    if suggestion:
+                        print(file=stderr)
+                        print(
+                            "  tip: a similar command exists: '"
+                            + suggestion
+                            + "'",
+                            file=stderr,
+                        )
+                else:
+                    print(
+                        self._error_color
+                        + "error: "
+                        + self.name
+                        + ": "
+                        + err_msg
+                        + _RESET,
+                        file=stderr,
+                    )
+                    if suggestion:
+                        print(file=stderr)
+                        print(
+                            "  "
+                            + _BOLD_YELLOW
+                            + "tip: "
+                            + _RESET
+                            + "a similar command exists: '"
+                            + _BOLD_CYAN
+                            + suggestion
+                            + _RESET
+                            + "'",
+                            file=stderr,
+                        )
+                print(file=stderr)
+                print(self._plain_usage(), file=stderr)
+                raise Error(err_msg)
             return -1
 
     # ===------------------------------------------------------------------=== #

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -10,7 +10,6 @@ from .utils import (
     _RESET,
     _BOLD_UL,
     _BOLD_YELLOW,
-    _BOLD_CYAN,
     _UNDERLINE,
     _DEFAULT_HEADER_COLOR,
     _DEFAULT_ARGUMENT_COLOR,
@@ -289,7 +288,7 @@ struct Command(Copyable, Movable, Writable):
     var _tips: List[String]
     """User-defined tips shown at the bottom of the help message.
     Add entries via ``add_tip()``.  Each tip is printed on its own line
-    prefixed with the same bold ``Tip:`` label as the built-in hint."""
+    prefixed with the same bold ``tip:`` label as the built-in hint."""
 
     # === Private fields — Shell completions ===
     var _completions_enabled: Bool
@@ -1570,10 +1569,10 @@ struct Command(Copyable, Movable, Writable):
 
         By default, ArgMojo generates a usage line like::
 
-            Usage: myapp <file> [OPTIONS]
+            usage: myapp <file> [OPTIONS]
 
         Call this method to override it with a completely custom string.
-        The string should **not** include the ``Usage:`` prefix — it will
+        The string should **not** include the ``usage:`` prefix — it will
         be added automatically.
 
         Args:
@@ -1587,7 +1586,7 @@ struct Command(Copyable, Movable, Writable):
         var cmd = Command("git", "The stupid content tracker")
         cmd.usage("git [-v | --version] [-C <path>] <command> [<args>]")
         # --help will show:
-        #   Usage: git [-v | --version] [-C <path>] <command> [<args>]
+        #   usage: git [-v | --version] [-C <path>] <command> [<args>]
         ```
         """
         self._custom_usage = text
@@ -1596,7 +1595,7 @@ struct Command(Copyable, Movable, Writable):
         """Adds a custom tip line to the bottom of the help message.
 
         Each tip is printed on its own line below the built-in ``--``
-        separator hint, prefixed with a bold ``Tip:`` label.  Useful for
+        separator hint, prefixed with a bold ``tip:`` label.  Useful for
         documenting shell idioms, environment variables, or any other
         usage notes that don't fit in argument help strings.
 
@@ -1637,7 +1636,7 @@ struct Command(Copyable, Movable, Writable):
         """
         self._header_color = _resolve_color[name]()
 
-    def arg_color[name: StringLiteral](mut self):
+    def argument_color[name: StringLiteral](mut self):
         """Sets a single colour for ALL option and argument names in help.
 
         This is a convenience method that sets ``program_color``,
@@ -1657,7 +1656,7 @@ struct Command(Copyable, Movable, Writable):
         ```mojo
         from argmojo import Command
         var command = Command("myapp", "A sample application")
-        command.arg_color["GREEN"]()
+        command.argument_color["GREEN"]()
         ```
         """
         var c = _resolve_color[name]()
@@ -2021,8 +2020,10 @@ struct Command(Copyable, Movable, Writable):
     def _colored_usage(self) -> String:
         """Returns a coloured usage line for error output.
 
-        Uses the same colour scheme as help output.  Falls back to
-        plain usage when ``NO_COLOR`` is set.
+        Uses the command's colour settings but with a lighter style than
+        help output — the ``usage:`` label uses ``_header_color`` without
+        bold/underline, matching the subdued diagnostic style of pixi/cargo.
+        Falls back to plain usage when ``NO_COLOR`` is set.
 
         Example output: ``usage: prog <COMMAND> [OPTIONS]`` with colours.
         """
@@ -2031,7 +2032,7 @@ struct Command(Copyable, Movable, Writable):
 
         var hc = self._header_color
         var pc = self._prog_color
-        var vc = self._value_color
+        var posc = self._pos_color
         var lc = self._long_opt_color
         var rc = _RESET
 
@@ -2045,9 +2046,9 @@ struct Command(Copyable, Movable, Writable):
                 if self.args[i]._is_remainder:
                     display += "..."
                 if self.args[i]._is_required:
-                    s += " " + vc + "<" + display + ">" + rc
+                    s += " " + posc + "<" + display + ">" + rc
                 else:
-                    s += " " + vc + "[" + display + "]" + rc
+                    s += " " + posc + "[" + display + "]" + rc
         var has_subcommands = False
         for i in range(len(self.subcommands)):
             if (
@@ -2057,7 +2058,7 @@ struct Command(Copyable, Movable, Writable):
                 has_subcommands = True
                 break
         if has_subcommands:
-            s += " " + vc + "<COMMAND>" + rc
+            s += " " + posc + "<COMMAND>" + rc
         s += " " + lc + "[OPTIONS]" + rc
         return s
 
@@ -4827,7 +4828,7 @@ struct Command(Copyable, Movable, Writable):
     def _help_tips_section(
         self, header_color: String, reset_code: String
     ) -> String:
-        """Generates the 'Tips:' section with hints and user-defined tips.
+        """Generates the 'tips:' section with hints and user-defined tips.
 
         Automatically adds a ``--`` separator hint when positional
         arguments are registered.  User-defined tips (added via

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -10,15 +10,15 @@ from .utils import (
     _RESET,
     _BOLD_UL,
     _DEFAULT_HEADER_COLOR,
-    _DEFAULT_ARG_COLOR,
+    _DEFAULT_ARGUMENT_COLOR,
     _DEFAULT_WARN_COLOR,
     _DEFAULT_ERROR_COLOR,
-    _DEFAULT_PROG_COLOR,
-    _DEFAULT_SHORT_OPT_COLOR,
-    _DEFAULT_LONG_OPT_COLOR,
+    _DEFAULT_PROGRAM_COLOR,
+    _DEFAULT_SHORT_OPTION_COLOR,
+    _DEFAULT_LONG_OPTION_COLOR,
     _DEFAULT_VALUE_COLOR,
-    _DEFAULT_POS_COLOR,
-    _DEFAULT_CMD_COLOR,
+    _DEFAULT_POSITIONAL_COLOR,
+    _DEFAULT_COMMAND_COLOR,
     _HELP_LINE_WIDTH,
     _HELP_INDENT,
     _HELP_OPT_WIDTH,
@@ -356,15 +356,15 @@ struct Command(Copyable, Movable, Writable):
         self._confirmation_prompt = String("")
         # ── Help & display ──
         self._header_color = _DEFAULT_HEADER_COLOR
-        self._arg_color = _DEFAULT_ARG_COLOR
+        self._arg_color = _DEFAULT_ARGUMENT_COLOR
         self._warn_color = _DEFAULT_WARN_COLOR
         self._error_color = _DEFAULT_ERROR_COLOR
-        self._prog_color = _DEFAULT_PROG_COLOR
-        self._short_opt_color = _DEFAULT_SHORT_OPT_COLOR
-        self._long_opt_color = _DEFAULT_LONG_OPT_COLOR
+        self._prog_color = _DEFAULT_PROGRAM_COLOR
+        self._short_opt_color = _DEFAULT_SHORT_OPTION_COLOR
+        self._long_opt_color = _DEFAULT_LONG_OPTION_COLOR
         self._value_color = _DEFAULT_VALUE_COLOR
-        self._pos_color = _DEFAULT_POS_COLOR
-        self._cmd_color = _DEFAULT_CMD_COLOR
+        self._pos_color = _DEFAULT_POSITIONAL_COLOR
+        self._cmd_color = _DEFAULT_COMMAND_COLOR
         self._custom_usage = String("")
         self._tips = List[String]()
         # ── Shell completions ──
@@ -1637,9 +1637,9 @@ struct Command(Copyable, Movable, Writable):
     def arg_color[name: StringLiteral](mut self):
         """Sets a single colour for ALL option and argument names in help.
 
-        This is a convenience method that sets ``prog_color``,
-        ``short_opt_color``, ``long_opt_color``, ``value_color``,
-        ``pos_color``, and ``cmd_color`` to the same colour at once.
+        This is a convenience method that sets ``program_color``,
+        ``short_option_color``, ``long_option_color``, ``value_color``,
+        ``positional_color``, and ``command_color`` to the same colour at once.
         Use the individual setters for fine-grained control.
 
         Accepted colour names: ``RED``, ``GREEN``, ``YELLOW``, ``BLUE``,
@@ -1706,7 +1706,7 @@ struct Command(Copyable, Movable, Writable):
         """
         self._error_color = _resolve_color[name]()
 
-    def prog_color[name: StringLiteral](mut self):
+    def program_color[name: StringLiteral](mut self):
         """Sets the colour for the program name in the usage line.
 
         Accepted colour names: ``RED``, ``GREEN``, ``YELLOW``, ``BLUE``,
@@ -1718,7 +1718,7 @@ struct Command(Copyable, Movable, Writable):
         """
         self._prog_color = _resolve_color[name]()
 
-    def short_opt_color[name: StringLiteral](mut self):
+    def short_option_color[name: StringLiteral](mut self):
         """Sets the colour for short option names (e.g. ``-h``, ``-p``).
 
         Accepted colour names: ``RED``, ``GREEN``, ``YELLOW``, ``BLUE``,
@@ -1730,7 +1730,7 @@ struct Command(Copyable, Movable, Writable):
         """
         self._short_opt_color = _resolve_color[name]()
 
-    def long_opt_color[name: StringLiteral](mut self):
+    def long_option_color[name: StringLiteral](mut self):
         """Sets the colour for long option names (e.g. ``--help``, ``--port``).
 
         Accepted colour names: ``RED``, ``GREEN``, ``YELLOW``, ``BLUE``,
@@ -1754,7 +1754,7 @@ struct Command(Copyable, Movable, Writable):
         """
         self._value_color = _resolve_color[name]()
 
-    def pos_color[name: StringLiteral](mut self):
+    def positional_color[name: StringLiteral](mut self):
         """Sets the colour for positional argument names.
 
         Accepted colour names: ``RED``, ``GREEN``, ``YELLOW``, ``BLUE``,
@@ -1766,7 +1766,7 @@ struct Command(Copyable, Movable, Writable):
         """
         self._pos_color = _resolve_color[name]()
 
-    def cmd_color[name: StringLiteral](mut self):
+    def command_color[name: StringLiteral](mut self):
         """Sets the colour for subcommand names in the Commands section.
 
         Accepted colour names: ``RED``, ``GREEN``, ``YELLOW``, ``BLUE``,
@@ -3540,9 +3540,9 @@ struct Command(Copyable, Movable, Writable):
         for g in range(len(self._exclusive_groups)):
             var found = List[String]()
             for n in range(len(self._exclusive_groups[g])):
-                var arg_name = self._exclusive_groups[g][n]
-                if result.has(arg_name):
-                    found.append(arg_name)
+                var argument_name = self._exclusive_groups[g][n]
+                if result.has(argument_name):
+                    found.append(argument_name)
             if len(found) > 1:
                 var names_str = String("")
                 for f in range(len(found)):
@@ -3556,11 +3556,11 @@ struct Command(Copyable, Movable, Writable):
             var provided = List[String]()
             var missing = List[String]()
             for n in range(len(self._required_groups[g])):
-                var arg_name = self._required_groups[g][n]
-                if result.has(arg_name):
-                    provided.append(arg_name)
+                var argument_name = self._required_groups[g][n]
+                if result.has(argument_name):
+                    provided.append(argument_name)
                 else:
-                    missing.append(arg_name)
+                    missing.append(argument_name)
             if len(provided) > 0 and len(missing) > 0:
                 var missing_str = String("")
                 for m in range(len(missing)):
@@ -3584,8 +3584,8 @@ struct Command(Copyable, Movable, Writable):
         for g in range(len(self._one_required_groups)):
             var found_any = False
             for n in range(len(self._one_required_groups[g])):
-                var arg_name = self._one_required_groups[g][n]
-                if result.has(arg_name):
+                var argument_name = self._one_required_groups[g][n]
+                if result.has(argument_name):
                     found_any = True
                     break
             if not found_any:
@@ -3832,7 +3832,7 @@ struct Command(Copyable, Movable, Writable):
         for i in range(len(self.args)):
             for j in range(len(self.args[i]._alias_names)):
                 if self.args[i]._alias_names[j].startswith(name):
-                    # Avoid duplicate if the same arg already matched via long_name.
+                    # Avoid duplicate if the same argument already matched via long_name.
                     var already = False
                     for k in range(len(candidates)):
                         if candidates[k] == self.args[i]._long_name:
@@ -4102,59 +4102,61 @@ struct Command(Copyable, Movable, Writable):
         # NO_COLOR env var overrides the color parameter.
         var use_color = color and not Self._no_color_env()
         var header_color = (_BOLD_UL + self._header_color) if use_color else ""
-        var prog_color = self._prog_color if use_color else ""
-        var short_opt_color = self._short_opt_color if use_color else ""
-        var long_opt_color = self._long_opt_color if use_color else ""
+        var program_color = self._prog_color if use_color else ""
+        var short_option_color = self._short_opt_color if use_color else ""
+        var long_option_color = self._long_opt_color if use_color else ""
         var value_color = self._value_color if use_color else ""
-        var pos_color = self._pos_color if use_color else ""
-        var cmd_color = self._cmd_color if use_color else ""
+        var positional_color = self._pos_color if use_color else ""
+        var command_color = self._cmd_color if use_color else ""
         var reset_code = _RESET if use_color else ""
 
         var s = String("")
         s += self._help_usage_line(
-            prog_color,
-            short_opt_color,
-            long_opt_color,
+            program_color,
+            short_option_color,
+            long_option_color,
             value_color,
-            pos_color,
+            positional_color,
             header_color,
             reset_code,
         )
         s += self._help_positionals_section(
-            pos_color,
+            positional_color,
             value_color,
             header_color,
             reset_code,
         )
         s += self._help_options_section(
-            short_opt_color,
-            long_opt_color,
+            short_option_color,
+            long_option_color,
             value_color,
             header_color,
             reset_code,
         )
-        s += self._help_commands_section(cmd_color, header_color, reset_code)
+        s += self._help_commands_section(
+            command_color, header_color, reset_code
+        )
         s += self._help_tips_section(header_color, reset_code)
         return s
 
     def _help_usage_line(
         self,
-        prog_color: String,
-        short_opt_color: String,
-        long_opt_color: String,
+        program_color: String,
+        short_option_color: String,
+        long_option_color: String,
         value_color: String,
-        pos_color: String,
+        positional_color: String,
         header_color: String,
         reset_code: String,
     ) -> String:
         """Generates the description and usage line of help output.
 
         Args:
-            prog_color: ANSI colour code for the program name.
-            short_opt_color: ANSI colour code for short options in summary.
-            long_opt_color: ANSI colour code for long options in summary.
+            program_color: ANSI colour code for the program name.
+            short_option_color: ANSI colour code for short options in summary.
+            long_option_color: ANSI colour code for long options in summary.
             value_color: ANSI colour code for value names in summary.
-            pos_color: ANSI colour code for positional arg names in summary.
+            positional_color: ANSI colour code for positional arg names in summary.
             header_color: ANSI colour code for section headers (empty if colour off).
             reset_code: ANSI reset code (empty if colour off).
 
@@ -4171,7 +4173,7 @@ struct Command(Copyable, Movable, Writable):
             s += self._custom_usage + "\n\n"
             return s
         s += header_color + "Usage:" + reset_code + " "
-        s += prog_color + self.name + reset_code
+        s += program_color + self.name + reset_code
 
         # Collect usage tokens (plain and coloured) for wrapping.
         var usage_tokens_plain = List[String]()
@@ -4186,12 +4188,12 @@ struct Command(Copyable, Movable, Writable):
                 if self.args[i]._is_required:
                     usage_tokens_plain.append("<" + display + ">")
                     usage_tokens_colored.append(
-                        pos_color + "<" + display + ">" + reset_code
+                        positional_color + "<" + display + ">" + reset_code
                     )
                 else:
                     usage_tokens_plain.append("[" + display + "]")
                     usage_tokens_colored.append(
-                        pos_color + "[" + display + "]" + reset_code
+                        positional_color + "[" + display + "]" + reset_code
                     )
 
         # Show <COMMAND> placeholder when subcommands are registered.
@@ -4205,10 +4207,14 @@ struct Command(Copyable, Movable, Writable):
                 break
         if has_subcommands:
             usage_tokens_plain.append("<COMMAND>")
-            usage_tokens_colored.append(pos_color + "<COMMAND>" + reset_code)
+            usage_tokens_colored.append(
+                positional_color + "<COMMAND>" + reset_code
+            )
 
         usage_tokens_plain.append("[OPTIONS]")
-        usage_tokens_colored.append(long_opt_color + "[OPTIONS]" + reset_code)
+        usage_tokens_colored.append(
+            long_option_color + "[OPTIONS]" + reset_code
+        )
 
         # Build the usage line with wrapping at _HELP_LINE_WIDTH.
         var prefix_plain = "usage: " + self.name
@@ -4249,7 +4255,7 @@ struct Command(Copyable, Movable, Writable):
 
     def _help_positionals_section(
         self,
-        pos_color: String,
+        positional_color: String,
         value_color: String,
         header_color: String,
         reset_code: String,
@@ -4260,7 +4266,7 @@ struct Command(Copyable, Movable, Writable):
         to compute dynamic column padding, then assembles the final lines.
 
         Args:
-            pos_color: ANSI colour code for positional argument names.
+            positional_color: ANSI colour code for positional argument names.
             value_color: ANSI colour code for value names (unused here
                 but kept for signature consistency).
             header_color: ANSI colour code for section headers.
@@ -4289,7 +4295,7 @@ struct Command(Copyable, Movable, Writable):
                     name_display += "..."
                 var plain = String("  ") + name_display
                 var colored = (
-                    String("  ") + pos_color + name_display + reset_code
+                    String("  ") + positional_color + name_display + reset_code
                 )
                 pos_plains.append(plain)
                 pos_colors.append(colored)
@@ -4318,8 +4324,8 @@ struct Command(Copyable, Movable, Writable):
 
     def _help_options_section(
         self,
-        short_opt_color: String,
-        long_opt_color: String,
+        short_option_color: String,
+        long_option_color: String,
         value_color: String,
         header_color: String,
         reset_code: String,
@@ -4332,8 +4338,8 @@ struct Command(Copyable, Movable, Writable):
         ``--version`` are always appended to the ungrouped local section.
 
         Args:
-            short_opt_color: ANSI colour code for short option names.
-            long_opt_color: ANSI colour code for long option names.
+            short_option_color: ANSI colour code for short option names.
+            long_option_color: ANSI colour code for long option names.
             value_color: ANSI colour code for value names / metavar.
             header_color: ANSI colour code for section headers.
             reset_code: ANSI reset code.
@@ -4354,7 +4360,7 @@ struct Command(Copyable, Movable, Writable):
                 if self.args[i]._short_name:
                     plain += "-" + self.args[i]._short_name
                     colored += (
-                        short_opt_color
+                        short_option_color
                         + "-"
                         + self.args[i]._short_name
                         + reset_code
@@ -4368,7 +4374,7 @@ struct Command(Copyable, Movable, Writable):
                 if self.args[i]._long_name:
                     var long_part = String("--") + self.args[i]._long_name
                     plain += long_part
-                    colored += long_opt_color + long_part + reset_code
+                    colored += long_option_color + long_part + reset_code
                     if self.args[i]._is_negatable:
                         var neg_part = (
                             String(" / --no-") + self.args[i]._long_name
@@ -4376,7 +4382,7 @@ struct Command(Copyable, Movable, Writable):
                         plain += neg_part
                         colored += (
                             " / "
-                            + long_opt_color
+                            + long_option_color
                             + "--no-"
                             + self.args[i]._long_name
                             + reset_code
@@ -4389,7 +4395,7 @@ struct Command(Copyable, Movable, Writable):
                         plain += alias_part
                         colored += (
                             ", "
-                            + long_opt_color
+                            + long_option_color
                             + "--"
                             + self.args[i]._alias_names[j]
                             + reset_code
@@ -4496,22 +4502,22 @@ struct Command(Copyable, Movable, Writable):
         var help_plain = String("  -h, --help")
         var help_colored = (
             "  "
-            + short_opt_color
+            + short_option_color
             + "-h"
             + reset_code
             + ", "
-            + long_opt_color
+            + long_option_color
             + "--help"
             + reset_code
         )  # Not show -? in help message as it requires quoting in some shells
         var version_plain = String("  -V, --version")
         var version_colored = (
             "  "
-            + short_opt_color
+            + short_option_color
             + "-V"
             + reset_code
             + ", "
-            + long_opt_color
+            + long_option_color
             + "--version"
             + reset_code
         )
@@ -4531,7 +4537,7 @@ struct Command(Copyable, Movable, Writable):
             )
             var comp_colored = (
                 "      "
-                + long_opt_color
+                + long_option_color
                 + "--"
                 + self._completions_name
                 + reset_code
@@ -4642,14 +4648,14 @@ struct Command(Copyable, Movable, Writable):
 
     def _help_commands_section(
         self,
-        cmd_color: String,
+        command_color: String,
         header_color: String,
         reset_code: String,
     ) -> String:
         """Generates the 'Commands:' section listing registered subcommands.
 
         Args:
-            cmd_color: ANSI colour code for subcommand names.
+            command_color: ANSI colour code for subcommand names.
             header_color: ANSI colour code for section headers.
             reset_code: ANSI reset code.
 
@@ -4684,7 +4690,7 @@ struct Command(Copyable, Movable, Writable):
                 for _ai in range(len(self.subcommands[i]._command_aliases)):
                     label += ", " + self.subcommands[i]._command_aliases[_ai]
                 var plain = String("  ") + label
-                var colored = String("  ") + cmd_color + label + reset_code
+                var colored = String("  ") + command_color + label + reset_code
                 cmd_plains.append(plain)
                 cmd_colors.append(colored)
                 cmd_helps.append(self.subcommands[i].description)
@@ -4692,7 +4698,7 @@ struct Command(Copyable, Movable, Writable):
         if self._completions_enabled and self._completions_is_subcommand:
             var cname = self._completions_name
             var plain = String("  ") + cname
-            var colored = String("  ") + cmd_color + cname + reset_code
+            var colored = String("  ") + command_color + cname + reset_code
             cmd_plains.append(plain)
             cmd_colors.append(colored)
             cmd_helps.append(

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -11,6 +11,7 @@ from .utils import (
     _BOLD_UL,
     _BOLD_YELLOW,
     _BOLD_CYAN,
+    _UNDERLINE,
     _DEFAULT_HEADER_COLOR,
     _DEFAULT_ARGUMENT_COLOR,
     _DEFAULT_WARN_COLOR,
@@ -21,7 +22,7 @@ from .utils import (
     _DEFAULT_VALUE_COLOR,
     _DEFAULT_POSITIONAL_COLOR,
     _DEFAULT_COMMAND_COLOR,
-    _HELP_LINE_WIDTH,
+    _help_line_width,
     _HELP_INDENT,
     _HELP_OPT_WIDTH,
     _HELP_GAP,
@@ -1990,11 +1991,11 @@ struct Command(Copyable, Movable, Writable):
     def _plain_usage(self) -> String:
         """Returns a plain-text usage line (no ANSI colours).
 
-        Example output: ``Usage: git clone <repository> [directory] [OPTIONS]``
+        Example output: ``usage: git clone <repository> [directory] [OPTIONS]``
         """
         if self._custom_usage:
-            return String("Usage: ") + self._custom_usage
-        var s = String("Usage: ") + self.name
+            return String("usage: ") + self._custom_usage
+        var s = String("usage: ") + self.name
         for i in range(len(self.args)):
             if self.args[i]._is_positional and not self.args[i]._is_hidden:
                 var display = self.args[i].name
@@ -2015,6 +2016,49 @@ struct Command(Copyable, Movable, Writable):
         if has_subcommands:
             s += " <COMMAND>"
         s += " [OPTIONS]"
+        return s
+
+    def _colored_usage(self) -> String:
+        """Returns a coloured usage line for error output.
+
+        Uses the same colour scheme as help output.  Falls back to
+        plain usage when ``NO_COLOR`` is set.
+
+        Example output: ``usage: prog <COMMAND> [OPTIONS]`` with colours.
+        """
+        if Self._no_color_env():
+            return self._plain_usage()
+
+        var hc = self._header_color
+        var pc = self._prog_color
+        var vc = self._value_color
+        var lc = self._long_opt_color
+        var rc = _RESET
+
+        if self._custom_usage:
+            return hc + "usage:" + rc + " " + self._custom_usage
+
+        var s = hc + "usage:" + rc + " " + pc + self.name + rc
+        for i in range(len(self.args)):
+            if self.args[i]._is_positional and not self.args[i]._is_hidden:
+                var display = self.args[i].name
+                if self.args[i]._is_remainder:
+                    display += "..."
+                if self.args[i]._is_required:
+                    s += " " + vc + "<" + display + ">" + rc
+                else:
+                    s += " " + vc + "[" + display + "]" + rc
+        var has_subcommands = False
+        for i in range(len(self.subcommands)):
+            if (
+                not self.subcommands[i]._is_help_subcommand
+                and not self.subcommands[i]._is_hidden
+            ):
+                has_subcommands = True
+                break
+        if has_subcommands:
+            s += " " + vc + "<COMMAND>" + rc
+        s += " " + lc + "[OPTIONS]" + rc
         return s
 
     # ===------------------------------------------------------------------=== #
@@ -3191,54 +3235,62 @@ struct Command(Copyable, Movable, Writable):
                             )
                 var suggestion = _suggest_similar(arg, sub_names)
 
-                # Multi-line error (pixi / argparse style):
-                #   error: prog: unrecognized command 'foo'
+                # Multi-line error (pixi style):
+                #   error: unrecognized subcommand 'foo'
                 #
-                #     tip: a similar command exists: 'bar'
+                #     tip: a similar subcommand exists: 'bar'
                 #
-                #   Usage: prog <COMMAND> [OPTIONS]
-                var err_msg = "unrecognized command '" + arg + "'"
+                #   usage: prog <COMMAND> [OPTIONS]
+                var err_msg = "unrecognized subcommand '" + arg + "'"
                 if suggestion:
                     err_msg += ". Did you mean '" + suggestion + "'?"
                 if Self._no_color_env():
                     print(
-                        "error: " + self.name + ": " + err_msg,
+                        "error: " + err_msg,
                         file=stderr,
                     )
                     if suggestion:
                         print(file=stderr)
                         print(
-                            "  tip: a similar command exists: '"
+                            "  tip: a similar subcommand exists: '"
                             + suggestion
                             + "'",
                             file=stderr,
                         )
                 else:
+                    # error: unrecognized subcommand 'foo'
+                    # "error:" in red, message in plain, bad arg in red.
                     print(
                         self._error_color
-                        + "error: "
-                        + self.name
-                        + ": "
-                        + err_msg
-                        + _RESET,
+                        + "error:"
+                        + _RESET
+                        + " unrecognized subcommand '"
+                        + self._error_color
+                        + arg
+                        + _RESET
+                        + "'",
                         file=stderr,
                     )
                     if suggestion:
                         print(file=stderr)
+                        #   tip: a similar subcommand exists: 'build'
+                        # "tip:" underlined, suggestion underlined.
                         print(
                             "  "
                             + _BOLD_YELLOW
-                            + "tip: "
+                            + _UNDERLINE
+                            + "tip:"
                             + _RESET
-                            + "a similar command exists: '"
-                            + _BOLD_CYAN
+                            + " a similar subcommand exists: '"
+                            + _BOLD_YELLOW
+                            + _UNDERLINE
                             + suggestion
                             + _RESET
                             + "'",
                             file=stderr,
                         )
                 print(file=stderr)
-                print(self._plain_usage(), file=stderr)
+                print(self._colored_usage(), file=stderr)
                 raise Error(err_msg)
             return -1
 
@@ -4133,6 +4185,9 @@ struct Command(Copyable, Movable, Writable):
         var command_color = self._cmd_color if use_color else ""
         var reset_code = _RESET if use_color else ""
 
+        # Dynamic line width (terminal columns − 2, capped at 120).
+        var line_width = _help_line_width()
+
         var s = String("")
         s += self._help_usage_line(
             program_color,
@@ -4142,12 +4197,14 @@ struct Command(Copyable, Movable, Writable):
             positional_color,
             header_color,
             reset_code,
+            line_width,
         )
         s += self._help_positionals_section(
             positional_color,
             value_color,
             header_color,
             reset_code,
+            line_width,
         )
         s += self._help_options_section(
             short_option_color,
@@ -4155,9 +4212,13 @@ struct Command(Copyable, Movable, Writable):
             value_color,
             header_color,
             reset_code,
+            line_width,
         )
         s += self._help_commands_section(
-            command_color, header_color, reset_code
+            command_color,
+            header_color,
+            reset_code,
+            line_width,
         )
         s += self._help_tips_section(header_color, reset_code)
         return s
@@ -4171,6 +4232,7 @@ struct Command(Copyable, Movable, Writable):
         positional_color: String,
         header_color: String,
         reset_code: String,
+        line_width: Int = 0,
     ) -> String:
         """Generates the description and usage line of help output.
 
@@ -4182,20 +4244,22 @@ struct Command(Copyable, Movable, Writable):
             positional_color: ANSI colour code for positional arg names in summary.
             header_color: ANSI colour code for section headers (empty if colour off).
             reset_code: ANSI reset code (empty if colour off).
+            line_width: Total line width (0 = auto-detect via terminal).
 
         Returns:
             The description (if any) and usage line string.
         """
+        var w_line = line_width if line_width > 0 else _help_line_width()
         var s = String("")
         if self.description:
-            s += _wrap_text_at(self.description, _HELP_LINE_WIDTH) + "\n\n"
+            s += _wrap_text_at(self.description, w_line) + "\n\n"
 
         # Usage line.
         if self._custom_usage:
-            s += header_color + "Usage:" + reset_code + " "
+            s += header_color + "usage:" + reset_code + " "
             s += self._custom_usage + "\n\n"
             return s
-        s += header_color + "Usage:" + reset_code + " "
+        s += header_color + "usage:" + reset_code + " "
         s += program_color + self.name + reset_code
 
         # Collect usage tokens (plain and coloured) for wrapping.
@@ -4239,7 +4303,7 @@ struct Command(Copyable, Movable, Writable):
             long_option_color + "[OPTIONS]" + reset_code
         )
 
-        # Build the usage line with wrapping at _HELP_LINE_WIDTH.
+        # Build the usage line with wrapping at the detected line width.
         var prefix_plain = "usage: " + self.name
         var prefix_width = _display_width(prefix_plain)
         var indent = String("")
@@ -4251,27 +4315,27 @@ struct Command(Copyable, Movable, Writable):
         for ti in range(len(usage_tokens_plain)):
             total_plain += " " + usage_tokens_plain[ti]
 
-        if _display_width(total_plain) <= _HELP_LINE_WIDTH:
+        if _display_width(total_plain) <= w_line:
             # Single line — append coloured tokens directly.
             for ti in range(len(usage_tokens_colored)):
                 s += " " + usage_tokens_colored[ti]
         else:
             # Multi-line: wrap tokens with " \" continuation.
-            var line_width = prefix_width  # current line width (plain)
+            var cur_width = prefix_width  # current line width (plain)
             for ti in range(len(usage_tokens_plain)):
                 var tw = _display_width(usage_tokens_plain[ti])
                 # +1 for the preceding space, +2 for " \" if not last token.
                 var is_last = ti == len(usage_tokens_plain) - 1
                 var trail = 0 if is_last else 2  # reserve for " \"
                 if (
-                    line_width + 1 + tw + trail > _HELP_LINE_WIDTH
-                    and line_width > prefix_width
+                    cur_width + 1 + tw + trail > w_line
+                    and cur_width > prefix_width
                 ):
                     # Wrap: end current line, start new indented line.
                     s += " \\\n" + indent
-                    line_width = prefix_width
+                    cur_width = prefix_width
                 s += " " + usage_tokens_colored[ti]
-                line_width += 1 + tw
+                cur_width += 1 + tw
 
         s += "\n\n"
         return s
@@ -4282,8 +4346,9 @@ struct Command(Copyable, Movable, Writable):
         value_color: String,
         header_color: String,
         reset_code: String,
+        line_width: Int = 0,
     ) -> String:
-        """Generates the 'Arguments:' section listing positional arguments.
+        """Generates the 'arguments:' section listing positional arguments.
 
         Uses a two-pass approach: first collects plain and coloured text
         to compute dynamic column padding, then assembles the final lines.
@@ -4294,6 +4359,7 @@ struct Command(Copyable, Movable, Writable):
                 but kept for signature consistency).
             header_color: ANSI colour code for section headers.
             reset_code: ANSI reset code.
+            line_width: Total line width (0 = auto-detect via terminal).
 
         Returns:
             The positional arguments section, or empty string if none.
@@ -4324,11 +4390,13 @@ struct Command(Copyable, Movable, Writable):
                 pos_colors.append(colored)
                 pos_helps.append(self.args[i].help_text)
 
-        var s = header_color + "Arguments:" + reset_code + "\n"
+        var s = header_color + "arguments:" + reset_code + "\n"
         var pos_indices = List[Int]()
         for k in range(len(pos_plains)):
             pos_indices.append(k)
-        var pos_layout = _section_desc_layout(pos_plains, pos_indices)
+        var pos_layout = _section_desc_layout(
+            pos_plains, pos_indices, line_width
+        )
         var pos_ds = pos_layout[0]
         var pos_dw = pos_layout[1]
         for k in range(len(pos_plains)):
@@ -4352,8 +4420,9 @@ struct Command(Copyable, Movable, Writable):
         value_color: String,
         header_color: String,
         reset_code: String,
+        line_width: Int = 0,
     ) -> String:
-        """Generates the 'Options:', group, and 'Global Options:' sections.
+        """Generates the 'options:', group, and 'global options:' sections.
 
         Separates local options from persistent (global) options and
         displays them under distinct headings.  Options with a ``.group()``
@@ -4366,6 +4435,7 @@ struct Command(Copyable, Movable, Writable):
             value_color: ANSI colour code for value names / metavar.
             header_color: ANSI colour code for section headers.
             reset_code: ANSI reset code.
+            line_width: Total line width (0 = auto-detect via terminal).
 
         Returns:
             The options section string.
@@ -4521,7 +4591,7 @@ struct Command(Copyable, Movable, Writable):
                     help += "[deprecated: " + self.args[i]._deprecated_msg + "]"
                 opt_helps.append(help)
 
-        # Built-in options (always shown under local ungrouped "Options:" section).
+        # Built-in options (always shown under local ungrouped "options:" section).
         var help_plain = String("  -h, --help")
         var help_colored = (
             "  "
@@ -4598,15 +4668,17 @@ struct Command(Copyable, Movable, Writable):
 
         # --- Per-section dynamic padding (capped at _HELP_OPT_WIDTH) ---
 
-        # --- Ungrouped local options (Options:) ---
+        # --- Ungrouped local options (options:) ---
         var ungrouped_idx = List[Int]()
         for k in range(len(opt_plains)):
             if not opt_persistent[k] and not opt_groups[k]:
                 ungrouped_idx.append(k)
-        var ug_layout = _section_desc_layout(opt_plains, ungrouped_idx)
+        var ug_layout = _section_desc_layout(
+            opt_plains, ungrouped_idx, line_width
+        )
         var ug_ds = ug_layout[0]
         var ug_dw = ug_layout[1]
-        var s = header_color + "Options:" + reset_code + "\n"
+        var s = header_color + "options:" + reset_code + "\n"
         for ki in range(len(ungrouped_idx)):
             var k = ungrouped_idx[ki]
             s += (
@@ -4627,7 +4699,7 @@ struct Command(Copyable, Movable, Writable):
             for k in range(len(opt_plains)):
                 if not opt_persistent[k] and opt_groups[k] == gname:
                     grp_idx.append(k)
-            var g_layout = _section_desc_layout(opt_plains, grp_idx)
+            var g_layout = _section_desc_layout(opt_plains, grp_idx, line_width)
             var g_ds = g_layout[0]
             var g_dw = g_layout[1]
             s += "\n" + header_color + gname + ":" + reset_code + "\n"
@@ -4650,10 +4722,10 @@ struct Command(Copyable, Movable, Writable):
             for k in range(len(opt_plains)):
                 if opt_persistent[k]:
                     gl_idx.append(k)
-            var gl_layout = _section_desc_layout(opt_plains, gl_idx)
+            var gl_layout = _section_desc_layout(opt_plains, gl_idx, line_width)
             var gl_ds = gl_layout[0]
             var gl_dw = gl_layout[1]
-            s += "\n" + header_color + "Global Options:" + reset_code + "\n"
+            s += "\n" + header_color + "global options:" + reset_code + "\n"
             for ki in range(len(gl_idx)):
                 var k = gl_idx[ki]
                 s += (
@@ -4674,13 +4746,15 @@ struct Command(Copyable, Movable, Writable):
         command_color: String,
         header_color: String,
         reset_code: String,
+        line_width: Int = 0,
     ) -> String:
-        """Generates the 'Commands:' section listing registered subcommands.
+        """Generates the 'commands:' section listing registered subcommands.
 
         Args:
             command_color: ANSI colour code for subcommand names.
             header_color: ANSI colour code for section headers.
             reset_code: ANSI reset code.
+            line_width: Total line width (0 = auto-detect via terminal).
 
         Returns:
             The commands section string, or empty string if no subcommands.
@@ -4730,10 +4804,12 @@ struct Command(Copyable, Movable, Writable):
         var cmd_indices = List[Int]()
         for k in range(len(cmd_plains)):
             cmd_indices.append(k)
-        var cmd_layout = _section_desc_layout(cmd_plains, cmd_indices)
+        var cmd_layout = _section_desc_layout(
+            cmd_plains, cmd_indices, line_width
+        )
         var cmd_ds = cmd_layout[0]
         var cmd_dw = cmd_layout[1]
-        var s = "\n" + header_color + "Commands:" + reset_code + "\n"
+        var s = "\n" + header_color + "commands:" + reset_code + "\n"
         for k in range(len(cmd_plains)):
             s += (
                 _format_two_column_line(
@@ -4819,7 +4895,7 @@ struct Command(Copyable, Movable, Writable):
         if len(tip_lines) == 0:
             return ""
 
-        var s = "\n" + header_color + "Tips:" + reset_code + "\n"
+        var s = "\n" + header_color + "tips:" + reset_code + "\n"
         for _ti in range(len(tip_lines)):
             s += "  " + tip_lines[_ti] + "\n"
         return s

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -13,6 +13,12 @@ from .utils import (
     _DEFAULT_ARG_COLOR,
     _DEFAULT_WARN_COLOR,
     _DEFAULT_ERROR_COLOR,
+    _DEFAULT_PROG_COLOR,
+    _DEFAULT_SHORT_OPT_COLOR,
+    _DEFAULT_LONG_OPT_COLOR,
+    _DEFAULT_VALUE_COLOR,
+    _DEFAULT_POS_COLOR,
+    _DEFAULT_CMD_COLOR,
     _HELP_LINE_WIDTH,
     _HELP_INDENT,
     _HELP_OPT_WIDTH,
@@ -262,6 +268,18 @@ struct Command(Copyable, Movable, Writable):
     """ANSI code for deprecation warning messages (default: orange)."""
     var _error_color: String
     """ANSI code for parse error messages (default: red)."""
+    var _prog_color: String
+    """ANSI code for the program name in the usage line."""
+    var _short_opt_color: String
+    """ANSI code for short option names (-h, -p)."""
+    var _long_opt_color: String
+    """ANSI code for long option names (--help, --port)."""
+    var _value_color: String
+    """ANSI code for value names / metavar (PORT, <HOST>)."""
+    var _pos_color: String
+    """ANSI code for positional argument names."""
+    var _cmd_color: String
+    """ANSI code for subcommand names in the Commands section."""
     var _custom_usage: String
     """When non-empty, replaces the auto-generated usage line.
     Set via ``usage("...")``."""
@@ -341,6 +359,12 @@ struct Command(Copyable, Movable, Writable):
         self._arg_color = _DEFAULT_ARG_COLOR
         self._warn_color = _DEFAULT_WARN_COLOR
         self._error_color = _DEFAULT_ERROR_COLOR
+        self._prog_color = _DEFAULT_PROG_COLOR
+        self._short_opt_color = _DEFAULT_SHORT_OPT_COLOR
+        self._long_opt_color = _DEFAULT_LONG_OPT_COLOR
+        self._value_color = _DEFAULT_VALUE_COLOR
+        self._pos_color = _DEFAULT_POS_COLOR
+        self._cmd_color = _DEFAULT_CMD_COLOR
         self._custom_usage = String("")
         self._tips = List[String]()
         # ── Shell completions ──
@@ -393,6 +417,12 @@ struct Command(Copyable, Movable, Writable):
         self._arg_color = take._arg_color^
         self._warn_color = take._warn_color^
         self._error_color = take._error_color^
+        self._prog_color = take._prog_color^
+        self._short_opt_color = take._short_opt_color^
+        self._long_opt_color = take._long_opt_color^
+        self._value_color = take._value_color^
+        self._pos_color = take._pos_color^
+        self._cmd_color = take._cmd_color^
         self._custom_usage = take._custom_usage^
         self._tips = take._tips^
         # ── Shell completions ──
@@ -462,6 +492,12 @@ struct Command(Copyable, Movable, Writable):
         self._arg_color = copy._arg_color
         self._warn_color = copy._warn_color
         self._error_color = copy._error_color
+        self._prog_color = copy._prog_color
+        self._short_opt_color = copy._short_opt_color
+        self._long_opt_color = copy._long_opt_color
+        self._value_color = copy._value_color
+        self._pos_color = copy._pos_color
+        self._cmd_color = copy._cmd_color
         self._custom_usage = copy._custom_usage
         self._tips = copy._tips.copy()
         # ── Shell completions ──
@@ -1575,7 +1611,6 @@ struct Command(Copyable, Movable, Writable):
         """
         self._tips.append(tip)
 
-    # TODO: alias_name[name: StringLiteral](mut self) for compile-time checks
     def header_color[name: StringLiteral](mut self):
         """Sets the colour for section headers (Usage, Arguments, Options).
 
@@ -1600,7 +1635,12 @@ struct Command(Copyable, Movable, Writable):
         self._header_color = _resolve_color[name]()
 
     def arg_color[name: StringLiteral](mut self):
-        """Sets the colour for option and argument names in help output.
+        """Sets a single colour for ALL option and argument names in help.
+
+        This is a convenience method that sets ``prog_color``,
+        ``short_opt_color``, ``long_opt_color``, ``value_color``,
+        ``pos_color``, and ``cmd_color`` to the same colour at once.
+        Use the individual setters for fine-grained control.
 
         Accepted colour names: ``RED``, ``GREEN``, ``YELLOW``, ``BLUE``,
         ``MAGENTA``, ``PINK``, ``CYAN``, ``WHITE``, ``ORANGE``.
@@ -1617,7 +1657,14 @@ struct Command(Copyable, Movable, Writable):
         command.arg_color["GREEN"]()
         ```
         """
-        self._arg_color = _resolve_color[name]()
+        var c = _resolve_color[name]()
+        self._arg_color = c
+        self._prog_color = c
+        self._short_opt_color = c
+        self._long_opt_color = c
+        self._value_color = c
+        self._pos_color = c
+        self._cmd_color = c
 
     def warn_color[name: StringLiteral](mut self):
         """Sets the colour for deprecation warning messages.
@@ -1658,6 +1705,78 @@ struct Command(Copyable, Movable, Writable):
         ```
         """
         self._error_color = _resolve_color[name]()
+
+    def prog_color[name: StringLiteral](mut self):
+        """Sets the colour for the program name in the usage line.
+
+        Accepted colour names: ``RED``, ``GREEN``, ``YELLOW``, ``BLUE``,
+        ``MAGENTA``, ``PINK``, ``CYAN``, ``WHITE``, ``ORANGE``.
+        Invalid names are caught at compile time.
+
+        Parameters:
+            name: The colour name.
+        """
+        self._prog_color = _resolve_color[name]()
+
+    def short_opt_color[name: StringLiteral](mut self):
+        """Sets the colour for short option names (e.g. ``-h``, ``-p``).
+
+        Accepted colour names: ``RED``, ``GREEN``, ``YELLOW``, ``BLUE``,
+        ``MAGENTA``, ``PINK``, ``CYAN``, ``WHITE``, ``ORANGE``.
+        Invalid names are caught at compile time.
+
+        Parameters:
+            name: The colour name.
+        """
+        self._short_opt_color = _resolve_color[name]()
+
+    def long_opt_color[name: StringLiteral](mut self):
+        """Sets the colour for long option names (e.g. ``--help``, ``--port``).
+
+        Accepted colour names: ``RED``, ``GREEN``, ``YELLOW``, ``BLUE``,
+        ``MAGENTA``, ``PINK``, ``CYAN``, ``WHITE``, ``ORANGE``.
+        Invalid names are caught at compile time.
+
+        Parameters:
+            name: The colour name.
+        """
+        self._long_opt_color = _resolve_color[name]()
+
+    def value_color[name: StringLiteral](mut self):
+        """Sets the colour for value names / metavar (e.g. ``PORT``, ``<HOST>``).
+
+        Accepted colour names: ``RED``, ``GREEN``, ``YELLOW``, ``BLUE``,
+        ``MAGENTA``, ``PINK``, ``CYAN``, ``WHITE``, ``ORANGE``.
+        Invalid names are caught at compile time.
+
+        Parameters:
+            name: The colour name.
+        """
+        self._value_color = _resolve_color[name]()
+
+    def pos_color[name: StringLiteral](mut self):
+        """Sets the colour for positional argument names.
+
+        Accepted colour names: ``RED``, ``GREEN``, ``YELLOW``, ``BLUE``,
+        ``MAGENTA``, ``PINK``, ``CYAN``, ``WHITE``, ``ORANGE``.
+        Invalid names are caught at compile time.
+
+        Parameters:
+            name: The colour name.
+        """
+        self._pos_color = _resolve_color[name]()
+
+    def cmd_color[name: StringLiteral](mut self):
+        """Sets the colour for subcommand names in the Commands section.
+
+        Accepted colour names: ``RED``, ``GREEN``, ``YELLOW``, ``BLUE``,
+        ``MAGENTA``, ``PINK``, ``CYAN``, ``WHITE``, ``ORANGE``.
+        Invalid names are caught at compile time.
+
+        Parameters:
+            name: The colour name.
+        """
+        self._cmd_color = _resolve_color[name]()
 
     # ── Shell completions ──
 
@@ -3982,28 +4101,60 @@ struct Command(Copyable, Movable, Writable):
         # Resolve colour tokens — empty strings when colour is off.
         # NO_COLOR env var overrides the color parameter.
         var use_color = color and not Self._no_color_env()
-        var arg_color = self._arg_color if use_color else ""
         var header_color = (_BOLD_UL + self._header_color) if use_color else ""
+        var prog_color = self._prog_color if use_color else ""
+        var short_opt_color = self._short_opt_color if use_color else ""
+        var long_opt_color = self._long_opt_color if use_color else ""
+        var value_color = self._value_color if use_color else ""
+        var pos_color = self._pos_color if use_color else ""
+        var cmd_color = self._cmd_color if use_color else ""
         var reset_code = _RESET if use_color else ""
 
         var s = String("")
-        s += self._help_usage_line(arg_color, header_color, reset_code)
-        s += self._help_positionals_section(arg_color, header_color, reset_code)
-        s += self._help_options_section(arg_color, header_color, reset_code)
-        s += self._help_commands_section(arg_color, header_color, reset_code)
+        s += self._help_usage_line(
+            prog_color,
+            short_opt_color,
+            long_opt_color,
+            value_color,
+            pos_color,
+            header_color,
+            reset_code,
+        )
+        s += self._help_positionals_section(
+            pos_color,
+            value_color,
+            header_color,
+            reset_code,
+        )
+        s += self._help_options_section(
+            short_opt_color,
+            long_opt_color,
+            value_color,
+            header_color,
+            reset_code,
+        )
+        s += self._help_commands_section(cmd_color, header_color, reset_code)
         s += self._help_tips_section(header_color, reset_code)
         return s
 
     def _help_usage_line(
         self,
-        arg_color: String,
+        prog_color: String,
+        short_opt_color: String,
+        long_opt_color: String,
+        value_color: String,
+        pos_color: String,
         header_color: String,
         reset_code: String,
     ) -> String:
         """Generates the description and usage line of help output.
 
         Args:
-            arg_color: ANSI colour code for argument names (empty if colour off).
+            prog_color: ANSI colour code for the program name.
+            short_opt_color: ANSI colour code for short options in summary.
+            long_opt_color: ANSI colour code for long options in summary.
+            value_color: ANSI colour code for value names in summary.
+            pos_color: ANSI colour code for positional arg names in summary.
             header_color: ANSI colour code for section headers (empty if colour off).
             reset_code: ANSI reset code (empty if colour off).
 
@@ -4020,7 +4171,7 @@ struct Command(Copyable, Movable, Writable):
             s += self._custom_usage + "\n\n"
             return s
         s += header_color + "Usage:" + reset_code + " "
-        s += arg_color + self.name + reset_code
+        s += prog_color + self.name + reset_code
 
         # Collect usage tokens (plain and coloured) for wrapping.
         var usage_tokens_plain = List[String]()
@@ -4035,12 +4186,12 @@ struct Command(Copyable, Movable, Writable):
                 if self.args[i]._is_required:
                     usage_tokens_plain.append("<" + display + ">")
                     usage_tokens_colored.append(
-                        arg_color + "<" + display + ">" + reset_code
+                        pos_color + "<" + display + ">" + reset_code
                     )
                 else:
                     usage_tokens_plain.append("[" + display + "]")
                     usage_tokens_colored.append(
-                        arg_color + "[" + display + "]" + reset_code
+                        pos_color + "[" + display + "]" + reset_code
                     )
 
         # Show <COMMAND> placeholder when subcommands are registered.
@@ -4054,13 +4205,13 @@ struct Command(Copyable, Movable, Writable):
                 break
         if has_subcommands:
             usage_tokens_plain.append("<COMMAND>")
-            usage_tokens_colored.append(arg_color + "<COMMAND>" + reset_code)
+            usage_tokens_colored.append(pos_color + "<COMMAND>" + reset_code)
 
         usage_tokens_plain.append("[OPTIONS]")
-        usage_tokens_colored.append(arg_color + "[OPTIONS]" + reset_code)
+        usage_tokens_colored.append(long_opt_color + "[OPTIONS]" + reset_code)
 
         # Build the usage line with wrapping at _HELP_LINE_WIDTH.
-        var prefix_plain = "Usage: " + self.name
+        var prefix_plain = "usage: " + self.name
         var prefix_width = _display_width(prefix_plain)
         var indent = String("")
         for _ in range(prefix_width):
@@ -4098,7 +4249,8 @@ struct Command(Copyable, Movable, Writable):
 
     def _help_positionals_section(
         self,
-        arg_color: String,
+        pos_color: String,
+        value_color: String,
         header_color: String,
         reset_code: String,
     ) -> String:
@@ -4108,7 +4260,9 @@ struct Command(Copyable, Movable, Writable):
         to compute dynamic column padding, then assembles the final lines.
 
         Args:
-            arg_color: ANSI colour code for argument names.
+            pos_color: ANSI colour code for positional argument names.
+            value_color: ANSI colour code for value names (unused here
+                but kept for signature consistency).
             header_color: ANSI colour code for section headers.
             reset_code: ANSI reset code.
 
@@ -4135,7 +4289,7 @@ struct Command(Copyable, Movable, Writable):
                     name_display += "..."
                 var plain = String("  ") + name_display
                 var colored = (
-                    String("  ") + arg_color + name_display + reset_code
+                    String("  ") + pos_color + name_display + reset_code
                 )
                 pos_plains.append(plain)
                 pos_colors.append(colored)
@@ -4164,7 +4318,9 @@ struct Command(Copyable, Movable, Writable):
 
     def _help_options_section(
         self,
-        arg_color: String,
+        short_opt_color: String,
+        long_opt_color: String,
+        value_color: String,
         header_color: String,
         reset_code: String,
     ) -> String:
@@ -4176,7 +4332,9 @@ struct Command(Copyable, Movable, Writable):
         ``--version`` are always appended to the ungrouped local section.
 
         Args:
-            arg_color: ANSI colour code for argument names.
+            short_opt_color: ANSI colour code for short option names.
+            long_opt_color: ANSI colour code for long option names.
+            value_color: ANSI colour code for value names / metavar.
             header_color: ANSI colour code for section headers.
             reset_code: ANSI reset code.
 
@@ -4196,7 +4354,10 @@ struct Command(Copyable, Movable, Writable):
                 if self.args[i]._short_name:
                     plain += "-" + self.args[i]._short_name
                     colored += (
-                        arg_color + "-" + self.args[i]._short_name + reset_code
+                        short_opt_color
+                        + "-"
+                        + self.args[i]._short_name
+                        + reset_code
                     )
                     if self.args[i]._long_name:
                         plain += ", "
@@ -4207,7 +4368,7 @@ struct Command(Copyable, Movable, Writable):
                 if self.args[i]._long_name:
                     var long_part = String("--") + self.args[i]._long_name
                     plain += long_part
-                    colored += arg_color + long_part + reset_code
+                    colored += long_opt_color + long_part + reset_code
                     if self.args[i]._is_negatable:
                         var neg_part = (
                             String(" / --no-") + self.args[i]._long_name
@@ -4215,7 +4376,7 @@ struct Command(Copyable, Movable, Writable):
                         plain += neg_part
                         colored += (
                             " / "
-                            + arg_color
+                            + long_opt_color
                             + "--no-"
                             + self.args[i]._long_name
                             + reset_code
@@ -4228,7 +4389,7 @@ struct Command(Copyable, Movable, Writable):
                         plain += alias_part
                         colored += (
                             ", "
-                            + arg_color
+                            + long_opt_color
                             + "--"
                             + self.args[i]._alias_names[j]
                             + reset_code
@@ -4260,14 +4421,14 @@ struct Command(Copyable, Movable, Writable):
                         var mv_colored = String("")
                         for _r in range(repeat - 1):
                             mv_plain += " " + mv
-                            mv_colored += " " + arg_color + mv + reset_code
+                            mv_colored += " " + value_color + mv + reset_code
                         # Last (or only) occurrence — attach "..." if append.
                         var last = mv + ("..." if append_dots else "")
                         mv_plain += open_bracket + sep + last + close_bracket
                         mv_colored += (
                             open_bracket
                             + sep
-                            + arg_color
+                            + value_color
                             + last
                             + reset_code
                             + close_bracket
@@ -4288,7 +4449,7 @@ struct Command(Copyable, Movable, Writable):
                         colored += (
                             open_bracket
                             + sep
-                            + arg_color
+                            + value_color
                             + suffix
                             + reset_code
                             + close_bracket
@@ -4304,14 +4465,14 @@ struct Command(Copyable, Movable, Writable):
                         var ph_colored = String("")
                         for _r in range(repeat - 1):
                             ph_plain += " " + tag
-                            ph_colored += " " + arg_color + tag + reset_code
+                            ph_colored += " " + value_color + tag + reset_code
                         # Last (or only) — attach "..." if append.
                         var last = tag + ("..." if append_dots else "")
                         ph_plain += open_bracket + sep + last + close_bracket
                         ph_colored += (
                             open_bracket
                             + sep
-                            + arg_color
+                            + value_color
                             + last
                             + reset_code
                             + close_bracket
@@ -4335,22 +4496,22 @@ struct Command(Copyable, Movable, Writable):
         var help_plain = String("  -h, --help")
         var help_colored = (
             "  "
-            + arg_color
+            + short_opt_color
             + "-h"
             + reset_code
             + ", "
-            + arg_color
+            + long_opt_color
             + "--help"
             + reset_code
         )  # Not show -? in help message as it requires quoting in some shells
         var version_plain = String("  -V, --version")
         var version_colored = (
             "  "
-            + arg_color
+            + short_opt_color
             + "-V"
             + reset_code
             + ", "
-            + arg_color
+            + long_opt_color
             + "--version"
             + reset_code
         )
@@ -4370,12 +4531,12 @@ struct Command(Copyable, Movable, Writable):
             )
             var comp_colored = (
                 "      "
-                + arg_color
+                + long_opt_color
                 + "--"
                 + self._completions_name
                 + reset_code
                 + " "
-                + arg_color
+                + value_color
                 + "<SHELL>"
                 + reset_code
             )
@@ -4481,14 +4642,14 @@ struct Command(Copyable, Movable, Writable):
 
     def _help_commands_section(
         self,
-        arg_color: String,
+        cmd_color: String,
         header_color: String,
         reset_code: String,
     ) -> String:
         """Generates the 'Commands:' section listing registered subcommands.
 
         Args:
-            arg_color: ANSI colour code for argument names.
+            cmd_color: ANSI colour code for subcommand names.
             header_color: ANSI colour code for section headers.
             reset_code: ANSI reset code.
 
@@ -4523,7 +4684,7 @@ struct Command(Copyable, Movable, Writable):
                 for _ai in range(len(self.subcommands[i]._command_aliases)):
                     label += ", " + self.subcommands[i]._command_aliases[_ai]
                 var plain = String("  ") + label
-                var colored = String("  ") + arg_color + label + reset_code
+                var colored = String("  ") + cmd_color + label + reset_code
                 cmd_plains.append(plain)
                 cmd_colors.append(colored)
                 cmd_helps.append(self.subcommands[i].description)
@@ -4531,7 +4692,7 @@ struct Command(Copyable, Movable, Writable):
         if self._completions_enabled and self._completions_is_subcommand:
             var cname = self._completions_name
             var plain = String("  ") + cname
-            var colored = String("  ") + arg_color + cname + reset_code
+            var colored = String("  ") + cmd_color + cname + reset_code
             cmd_plains.append(plain)
             cmd_colors.append(colored)
             cmd_helps.append(

--- a/src/argmojo/utils.mojo
+++ b/src/argmojo/utils.mojo
@@ -24,17 +24,17 @@ comptime _BOLD_MAGENTA = "\x1b[1;35m"
 
 # Default colours.
 comptime _DEFAULT_HEADER_COLOR = _YELLOW
-comptime _DEFAULT_ARG_COLOR = _MAGENTA
+comptime _DEFAULT_ARGUMENT_COLOR = _MAGENTA
 comptime _DEFAULT_WARN_COLOR = _ORANGE
 comptime _DEFAULT_ERROR_COLOR = _RED
 
 # Default colours for detailed help fields (argparse-like differentiation).
-comptime _DEFAULT_PROG_COLOR = _BOLD_MAGENTA
-comptime _DEFAULT_SHORT_OPT_COLOR = _BOLD_GREEN
-comptime _DEFAULT_LONG_OPT_COLOR = _BOLD_CYAN
+comptime _DEFAULT_PROGRAM_COLOR = _BOLD_MAGENTA
+comptime _DEFAULT_SHORT_OPTION_COLOR = _BOLD_GREEN
+comptime _DEFAULT_LONG_OPTION_COLOR = _BOLD_CYAN
 comptime _DEFAULT_VALUE_COLOR = _BOLD_YELLOW
-comptime _DEFAULT_POS_COLOR = _BOLD_GREEN
-comptime _DEFAULT_CMD_COLOR = _BOLD_CYAN
+comptime _DEFAULT_POSITIONAL_COLOR = _BOLD_GREEN
+comptime _DEFAULT_COMMAND_COLOR = _BOLD_CYAN
 
 # ── Help formatting layout constants ─────────────────────────────────────────
 # Fixed layout values for the two-column help formatter, optimized for

--- a/src/argmojo/utils.mojo
+++ b/src/argmojo/utils.mojo
@@ -5,6 +5,7 @@ from std.ffi import external_call
 # ── ANSI colour codes ────────────────────────────────────────────────────────
 comptime _RESET = "\x1b[0m"
 comptime _BOLD_UL = "\x1b[1;4m"  # bold + underline (no colour)
+comptime _UNDERLINE = "\x1b[4m"  # underline only (no bold, no colour)
 
 # Bright foreground colours.
 comptime _RED = "\x1b[91m"
@@ -37,15 +38,49 @@ comptime _DEFAULT_POSITIONAL_COLOR = _BOLD_GREEN
 comptime _DEFAULT_COMMAND_COLOR = _BOLD_CYAN
 
 # ── Help formatting layout constants ─────────────────────────────────────────
-# Fixed layout values for the two-column help formatter.
-# Aligned with Python argparse defaults (max_help_position=24):
+# Aligned with Python argparse defaults (max_help_position=24, width=columns-2).
 # INDENT + min(longest, OPT_WIDTH) + GAP gives a maximum description
 # start column of 28, close to argparse's default of 24.
-comptime _HELP_LINE_WIDTH: Int = 80
 comptime _HELP_INDENT: Int = 2
 comptime _HELP_OPT_WIDTH: Int = 24
 comptime _HELP_GAP: Int = 2
 comptime _HELP_TRAIL: Int = 2
+
+# TIOCGWINSZ ioctl number (platform-specific).
+comptime _TIOCGWINSZ_MACOS: Int = 0x40087468
+comptime _TIOCGWINSZ_LINUX: Int = 0x5413
+
+
+def _help_line_width() -> Int:
+    """Returns the help line width: ``min(terminal_columns - 2, 120)``.
+
+    Queries the terminal via ``ioctl(TIOCGWINSZ)`` on stdout (fd 1).
+    Falls back to 80 if the terminal width cannot be determined.
+    The result is clamped to [40, 120] and then reduced by 2
+    (matching argparse's ``width = columns - 2``).
+    """
+    # struct winsize { unsigned short ws_row, ws_col, ws_xpixel, ws_ypixel; }
+    # = 8 bytes total.  We only need ws_col (bytes 2-3).
+    var buf = List[UInt8](length=8, fill=0)
+    var ptr = buf.unsafe_ptr()
+    # Try macOS ioctl number first, then Linux.
+    var rc = external_call["ioctl", Int, Int, Int, Int](
+        1, _TIOCGWINSZ_MACOS, Int(ptr)
+    )
+    if rc != 0:
+        rc = external_call["ioctl", Int, Int, Int, Int](
+            1, _TIOCGWINSZ_LINUX, Int(ptr)
+        )
+    if rc == 0:
+        # ws_col is at offset 2 (little-endian unsigned short).
+        var cols = Int(buf[2]) | (Int(buf[3]) << 8)
+        if cols > 0:
+            var clamped = cols if cols >= 40 else 40
+            if clamped > 120:
+                clamped = 120
+            return clamped - 2
+
+    return 80  # ultimate fallback
 
 
 # ── Utility functions ────────────────────────────────────────────────────────
@@ -307,6 +342,7 @@ def _wrap_description(text: String, desc_width: Int, align_col: Int) -> String:
 def _section_desc_layout(
     plains: List[String],
     indices: List[Int],
+    line_width: Int = 0,
 ) -> Tuple[Int, Int]:
     """Compute description start column and width for a help section.
 
@@ -316,10 +352,12 @@ def _section_desc_layout(
     Args:
         plains: All plain-text option strings in the parent list.
         indices: Indices into *plains* that belong to this section.
+        line_width: Total line width (0 = auto-detect via terminal).
 
     Returns:
         A tuple ``(desc_start, desc_width)``.
     """
+    var w_line = line_width if line_width > 0 else _help_line_width()
     var mx: Int = 0
     for i in range(len(indices)):
         var w = _display_width(plains[indices[i]]) - _HELP_INDENT
@@ -327,7 +365,7 @@ def _section_desc_layout(
             mx = w
     var capped = mx if mx <= _HELP_OPT_WIDTH else _HELP_OPT_WIDTH
     var desc_start = _HELP_INDENT + capped + _HELP_GAP
-    var desc_width = _HELP_LINE_WIDTH - desc_start - _HELP_TRAIL
+    var desc_width = w_line - desc_start - _HELP_TRAIL
     return (desc_start, desc_width)
 
 

--- a/src/argmojo/utils.mojo
+++ b/src/argmojo/utils.mojo
@@ -37,12 +37,13 @@ comptime _DEFAULT_POSITIONAL_COLOR = _BOLD_GREEN
 comptime _DEFAULT_COMMAND_COLOR = _BOLD_CYAN
 
 # ── Help formatting layout constants ─────────────────────────────────────────
-# Fixed layout values for the two-column help formatter, optimized for
-# readable output on standard 80-column terminals.
-# Per-section layout: INDENT + min(longest, OPT_WIDTH) + GAP + desc + TRAIL = LINE_WIDTH
+# Fixed layout values for the two-column help formatter.
+# Aligned with Python argparse defaults (max_help_position=24):
+# INDENT + min(longest, OPT_WIDTH) + GAP gives a maximum description
+# start column of 28, close to argparse's default of 24.
 comptime _HELP_LINE_WIDTH: Int = 80
 comptime _HELP_INDENT: Int = 2
-comptime _HELP_OPT_WIDTH: Int = 32
+comptime _HELP_OPT_WIDTH: Int = 24
 comptime _HELP_GAP: Int = 2
 comptime _HELP_TRAIL: Int = 2
 

--- a/src/argmojo/utils.mojo
+++ b/src/argmojo/utils.mojo
@@ -16,11 +16,25 @@ comptime _CYAN = "\x1b[96m"
 comptime _WHITE = "\x1b[97m"
 comptime _ORANGE = "\x1b[33m"  # dark yellow — renders as orange on most terminals
 
+# Bold foreground colours (for argparse-like detailed help coloring).
+comptime _BOLD_GREEN = "\x1b[1;32m"
+comptime _BOLD_CYAN = "\x1b[1;36m"
+comptime _BOLD_YELLOW = "\x1b[1;33m"
+comptime _BOLD_MAGENTA = "\x1b[1;35m"
+
 # Default colours.
 comptime _DEFAULT_HEADER_COLOR = _YELLOW
 comptime _DEFAULT_ARG_COLOR = _MAGENTA
 comptime _DEFAULT_WARN_COLOR = _ORANGE
 comptime _DEFAULT_ERROR_COLOR = _RED
+
+# Default colours for detailed help fields (argparse-like differentiation).
+comptime _DEFAULT_PROG_COLOR = _BOLD_MAGENTA
+comptime _DEFAULT_SHORT_OPT_COLOR = _BOLD_GREEN
+comptime _DEFAULT_LONG_OPT_COLOR = _BOLD_CYAN
+comptime _DEFAULT_VALUE_COLOR = _BOLD_YELLOW
+comptime _DEFAULT_POS_COLOR = _BOLD_GREEN
+comptime _DEFAULT_CMD_COLOR = _BOLD_CYAN
 
 # ── Help formatting layout constants ─────────────────────────────────────────
 # Fixed layout values for the two-column help formatter, optimized for

--- a/tests/test_completion.mojo
+++ b/tests/test_completion.mojo
@@ -1303,8 +1303,8 @@ def test_typo_hidden_subcommand_not_suggested() raises:
     # But the error message no longer contains available commands (they are
     # printed to stderr in multi-line format instead).
     assert_true(
-        "unrecognized command" in err_msg,
-        msg="Should mention unrecognized command",
+        "unrecognized subcommand" in err_msg,
+        msg="Should mention unrecognized subcommand",
     )
     assert_true(
         "debu" in err_msg,

--- a/tests/test_completion.mojo
+++ b/tests/test_completion.mojo
@@ -1300,10 +1300,15 @@ def test_typo_hidden_subcommand_not_suggested() raises:
         "debug" in err_msg,
         msg="Hidden sub 'debug' should NOT appear in typo suggestion",
     )
-    # But the error should still mention available commands (only clone).
+    # But the error message no longer contains available commands (they are
+    # printed to stderr in multi-line format instead).
     assert_true(
-        "clone" in err_msg,
-        msg="Visible sub 'clone' should still be in error message",
+        "unrecognized command" in err_msg,
+        msg="Should mention unrecognized command",
+    )
+    assert_true(
+        "debu" in err_msg,
+        msg="Should mention the unrecognized 'debu'",
     )
 
 

--- a/tests/test_groups.mojo
+++ b/tests/test_groups.mojo
@@ -866,13 +866,13 @@ def test_group_basic() raises:
         msg="help should contain 'Network:' group heading: " + help,
     )
     assert_true(
-        "Options:" in help,
-        msg="help should contain 'Options:' for ungrouped args: " + help,
+        "options:" in help,
+        msg="help should contain 'options:' for ungrouped args: " + help,
     )
 
 
 def test_group_ungrouped_separate_from_grouped() raises:
-    """Ungrouped options appear under 'Options:' and grouped under their
+    """Ungrouped options appear under 'options:' and grouped under their
     own heading — they don't mix."""
     var command = Command("test", "Test app")
     command.add_argument(
@@ -887,11 +887,11 @@ def test_group_ungrouped_separate_from_grouped() raises:
 
     var help = command._generate_help(color=False)
     # --verbose should appear before "Network:" heading.
-    var opts_pos = help.find("Options:")
+    var opts_pos = help.find("options:")
     var net_pos = help.find("Network:")
     var verbose_pos = help.find("--verbose")
     var host_pos = help.find("--host")
-    assert_true(opts_pos >= 0, msg="Options: heading missing")
+    assert_true(opts_pos >= 0, msg="options: heading missing")
     assert_true(net_pos >= 0, msg="Network: heading missing")
     assert_true(
         verbose_pos < net_pos,
@@ -967,11 +967,11 @@ def test_group_no_groups_unchanged() raises:
     )
 
     var help = command._generate_help(color=False)
-    assert_true("Options:" in help, msg="Options: heading should exist")
+    assert_true("options:" in help, msg="options: heading should exist")
     # Should have --verbose and --output under the same section.
     var verbose_pos = help.find("--verbose")
     var output_pos = help.find("--output")
-    var options_pos = help.find("Options:")
+    var options_pos = help.find("options:")
     assert_true(verbose_pos > options_pos, msg="--verbose under Options:")
     assert_true(output_pos > options_pos, msg="--output under Options:")
 
@@ -985,23 +985,23 @@ def test_group_builtin_options_ungrouped() raises:
     )
 
     var help = command._generate_help(color=False)
-    var options_pos = help.find("Options:")
+    var options_pos = help.find("options:")
     var network_pos = help.find("Network:")
     var help_pos = help.find("--help")
     var version_pos = help.find("--version")
     # --help and --version should be under Options:, before Network:.
     assert_true(
         help_pos > options_pos and help_pos < network_pos,
-        msg="--help should be under Options: before Network:",
+        msg="--help should be under options: before Network:",
     )
     assert_true(
         version_pos > options_pos and version_pos < network_pos,
-        msg="--version should be under Options: before Network:",
+        msg="--version should be under options: before Network:",
     )
 
 
 def test_group_with_persistent() raises:
-    """Persistent (global) args go under Global Options:, not under groups."""
+    """Persistent (global) args go under global options:, not under groups."""
     var command = Command("test", "Test app")
     command.add_argument(
         Argument("verbose", help="Verbose output")
@@ -1018,17 +1018,17 @@ def test_group_with_persistent() raises:
     command.add_subcommand(sub^)
 
     var help = command._generate_help(color=False)
-    assert_true("Options:" in help, msg="Options: heading missing")
+    assert_true("options:" in help, msg="options: heading missing")
     assert_true("Network:" in help, msg="Network: heading missing")
     assert_true(
-        "Global Options:" in help, msg="Global Options: heading missing"
+        "global options:" in help, msg="global options: heading missing"
     )
-    # --verbose should be under Global Options:, after Network:.
-    var global_pos = help.find("Global Options:")
+    # --verbose should be under global options:, after Network:.
+    var global_pos = help.find("global options:")
     var verbose_pos = help.find("--verbose")
     assert_true(
         verbose_pos > global_pos,
-        msg="--verbose (persistent) should be under Global Options:",
+        msg="--verbose (persistent) should be under global options:",
     )
 
 
@@ -1056,7 +1056,7 @@ def test_group_independent_padding() raises:
 
 
 def test_group_with_colored_output() raises:
-    """Group headings use the same header_color styling as Options:/Arguments:.
+    """Group headings use the same header_color styling as options:/arguments:.
     """
     var command = Command("test", "Test app")
     command.add_argument(
@@ -1154,7 +1154,7 @@ def test_group_with_subcommand_help() raises:
         "Network:" in sub_help, msg="Network: heading in subcommand help"
     )
     assert_true(
-        "Options:" in sub_help, msg="Options: heading in subcommand help"
+        "options:" in sub_help, msg="options: heading in subcommand help"
     )
 
 

--- a/tests/test_help.mojo
+++ b/tests/test_help.mojo
@@ -1,6 +1,6 @@
 """Tests for argmojo help and display features:
   • Help output formatting (hidden args, value_name, padding, alignment)
-  • ANSI colour customisation (header_color, arg_color, etc.)
+  • ANSI colour customisation (header_color, argument_color, etc.)
   • Subcommand help (Commands section, aliases, hidden subs, tips)
   • CJK-aware help alignment (_display_width)
   • NO_COLOR environment variable
@@ -386,12 +386,12 @@ def test_custom_header_color() raises:
 
 
 def test_custom_arg_color() raises:
-    """Setting arg_color changes the arg-name ANSI code in help output."""
+    """Setting argument_color changes the arg-name ANSI code in help output."""
     var command = Command("app", "My app")
     command.add_argument(
         Argument("verbose", help="Be verbose").long["verbose"]().flag()
     )
-    command.arg_color["GREEN"]()
+    command.argument_color["GREEN"]()
 
     var help = command._generate_help(color=True)
     # GREEN = \x1b[92m
@@ -407,11 +407,11 @@ def test_custom_arg_color() raises:
 
 
 def test_custom_both_colors() raises:
-    """Setting both header_color and arg_color at the same time."""
+    """Setting both header_color and argument_color at the same time."""
     var command = Command("app", "My app")
     command.add_argument(Argument("file", help="Input").long["file"]())
     command.header_color["BLUE"]()
-    command.arg_color["GREEN"]()
+    command.argument_color["GREEN"]()
 
     var help = command._generate_help(color=True)
     assert_true("\x1b[94m" in help, msg="Header should be blue (94)")
@@ -461,7 +461,7 @@ def test_pink_alias_for_magenta() raises:
     """'PINK' is an alias for MAGENTA (\\x1b[95m)."""
     var command = Command("app", "My app")
     command.add_argument(Argument("f", help="File").long["file"]())
-    command.arg_color["PINK"]()
+    command.argument_color["PINK"]()
 
     var help = command._generate_help(color=True)
     assert_true(
@@ -478,7 +478,7 @@ def test_invalid_color_caught_at_compile_time() raises:
     """
     var command = Command("app", "My app")
     command.header_color["RED"]()
-    command.arg_color["GREEN"]()
+    command.argument_color["GREEN"]()
     command.warn_color["YELLOW"]()
     command.error_color["MAGENTA"]()
 
@@ -510,7 +510,7 @@ def test_custom_color_plain_mode_unaffected() raises:
     var command = Command("app", "My app")
     command.add_argument(Argument("x", help="X option").long["x"]())
     command.header_color["RED"]()
-    command.arg_color["BLUE"]()
+    command.argument_color["BLUE"]()
 
     var help = command._generate_help(color=False)
     assert_false("\x1b" in help, msg="Plain mode should have no ANSI codes")

--- a/tests/test_help.mojo
+++ b/tests/test_help.mojo
@@ -346,9 +346,9 @@ def test_help_contains_ansi_colors() raises:
     assert_true("verbose" in colored, msg="colored help should have 'verbose'")
     assert_true("verbose" in plain, msg="plain help should have 'verbose'")
     assert_true(
-        "Options:" in colored, msg="colored help should have 'Options:'"
+        "options:" in colored, msg="colored help should have 'options:'"
     )
-    assert_true("Options:" in plain, msg="plain help should have 'Options:'")
+    assert_true("options:" in plain, msg="plain help should have 'options:'")
 
 
 def test_help_color_false_no_codes() raises:
@@ -360,8 +360,8 @@ def test_help_color_false_no_codes() raises:
 
     var help = command._generate_help(color=False)
     # Section headers should appear without any escape sequences.
-    assert_true("Usage: test" in help, msg="Usage line should be plain")
-    assert_true("Options:\n" in help, msg="Options header should be plain")
+    assert_true("usage: test" in help, msg="Usage line should be plain")
+    assert_true("options:\n" in help, msg="Options header should be plain")
     # No escape character anywhere.
     assert_false("\x1b" in help, msg="No escape chars in plain mode")
 
@@ -514,7 +514,7 @@ def test_custom_color_plain_mode_unaffected() raises:
 
     var help = command._generate_help(color=False)
     assert_false("\x1b" in help, msg="Plain mode should have no ANSI codes")
-    assert_true("Options:" in help, msg="Plain mode should still have content")
+    assert_true("options:" in help, msg="Plain mode should still have content")
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -578,7 +578,7 @@ def test_nargs_with_value_name() raises:
 
 
 def test_root_help_shows_commands_section() raises:
-    """Tests that root help includes a Commands: section when subcommands are registered.
+    """Tests that root help includes a commands: section when subcommands are registered.
     """
     var app = Command("app", "My CLI tool")
     app.add_argument(
@@ -593,7 +593,7 @@ def test_root_help_shows_commands_section() raises:
     app.add_subcommand(init^)
 
     var help = app._generate_help(color=False)
-    assert_true("Commands:" in help, msg="Help should have Commands: section")
+    assert_true("commands:" in help, msg="Help should have commands: section")
     assert_true("search" in help, msg="Help should list 'search' subcommand")
     assert_true("init" in help, msg="Help should list 'init' subcommand")
     assert_true(
@@ -607,7 +607,7 @@ def test_root_help_shows_commands_section() raises:
 
 
 def test_root_help_no_commands_when_no_subcommands() raises:
-    """Tests that Commands: section is omitted when no subcommands are registered.
+    """Tests that commands: section is omitted when no subcommands are registered.
     """
     var command = Command("test", "Test app")
     command.add_argument(
@@ -615,7 +615,7 @@ def test_root_help_no_commands_when_no_subcommands() raises:
     )
 
     var help = command._generate_help(color=False)
-    assert_false("Commands:" in help, msg="No Commands: without subcommands")
+    assert_false("commands:" in help, msg="No commands: without subcommands")
 
 
 def test_root_help_commands_excludes_help_sub() raises:
@@ -626,7 +626,7 @@ def test_root_help_commands_excludes_help_sub() raises:
     # 'help' subcommand is auto-added.
 
     var help = app._generate_help(color=False)
-    assert_true("Commands:" in help, msg="Should have Commands: section")
+    assert_true("commands:" in help, msg="Should have commands: section")
     assert_true("search" in help, msg="search should appear")
     # Check that 'help' doesn't appear as a listed command entry.
     # (It may appear in other contexts like --help, but not as a subcommand line.)
@@ -634,7 +634,7 @@ def test_root_help_commands_excludes_help_sub() raises:
     var found_help_cmd = False
     var in_commands = False
     for i in range(len(lines)):
-        if lines[i].startswith("Commands:"):
+        if lines[i].startswith("commands:"):
             in_commands = True
             continue
         if in_commands:
@@ -685,7 +685,7 @@ def test_root_help_usage_no_command_placeholder_without_subs() raises:
 
 
 def test_persistent_args_under_global_options() raises:
-    """Tests that persistent args appear under a 'Global Options:' heading."""
+    """Tests that persistent args appear under a 'global options:' heading."""
     var app = Command("app", "My app")
     app.add_argument(
         Argument("verbose", help="Verbose output")
@@ -701,22 +701,22 @@ def test_persistent_args_under_global_options() raises:
 
     var help = app._generate_help(color=False)
     assert_true(
-        "Global Options:" in help,
-        msg="Should have Global Options: section",
+        "global options:" in help,
+        msg="Should have global options: section",
     )
-    assert_true("Options:" in help, msg="Should have Options: section")
+    assert_true("options:" in help, msg="Should have options: section")
     # --output should be under Options, --verbose under Global Options.
     # Check ordering: Options comes before Global Options.
-    var opt_pos = help.find("Options:")
-    var global_pos = help.find("Global Options:")
+    var opt_pos = help.find("options:")
+    var global_pos = help.find("global options:")
     assert_true(
         opt_pos < global_pos,
-        msg="Options: should come before Global Options:",
+        msg="options: should come before global options:",
     )
 
 
 def test_no_global_options_without_persistent() raises:
-    """Tests that Global Options: section is absent when no persistent args."""
+    """Tests that global options: section is absent when no persistent args."""
     var app = Command("app", "My app")
     app.add_argument(
         Argument("verbose", help="Verbose output").long["verbose"]().flag()
@@ -725,8 +725,8 @@ def test_no_global_options_without_persistent() raises:
 
     var help = app._generate_help(color=False)
     assert_false(
-        "Global Options:" in help,
-        msg="No Global Options: without persistent args",
+        "global options:" in help,
+        msg="No global options: without persistent args",
     )
 
 
@@ -741,7 +741,7 @@ def test_child_help_shows_full_command_path() raises:
 
     # Simulate: app search --help
     # The child copy gets name set to "app search", so --help would
-    # show "Usage: app search ..." in help.
+    # show "usage: app search ..." in help.
     # We test indirectly by checking what parse_arguments sets on the child copy.
     # Create the child copy as parse_arguments would.
     # Note: subcommands[0] is auto-added 'help'; search is at index 1.
@@ -784,8 +784,8 @@ def test_child_help_shows_inherited_persistent_args() raises:
 
     var help = child_copy._generate_help(color=False)
     assert_true(
-        "Global Options:" in help,
-        msg="Child help should have Global Options:",
+        "global options:" in help,
+        msg="Child help should have global options:",
     )
     assert_true(
         "--verbose" in help,
@@ -1046,7 +1046,7 @@ def test_custom_usage_in_plain_help() raises:
 
     var help = cmd._generate_help(color=False)
     assert_true(
-        "Usage: git [-v | --version] [-C <path>] <command> [<args>]" in help,
+        "usage: git [-v | --version] [-C <path>] <command> [<args>]" in help,
         msg="Custom usage should appear in plain help: " + help,
     )
 
@@ -1057,7 +1057,7 @@ def test_custom_usage_in_colored_help() raises:
     cmd.usage("git [-v | --version] [-C <path>] <command> [<args>]")
 
     var help = cmd._generate_help(color=True)
-    # The custom text should appear (wrapped in ANSI codes for "Usage:")
+    # The custom text should appear (wrapped in ANSI codes for "usage:")
     assert_true(
         "git [-v | --version]" in help,
         msg="Custom usage text should appear in colored help: " + help,
@@ -1075,13 +1075,13 @@ def test_custom_usage_replaces_auto_generated() raises:
 
     var help = cmd._generate_help(color=False)
     assert_true(
-        "Usage: myapp FILE [--output FILE]" in help,
+        "usage: myapp FILE [--output FILE]" in help,
         msg="Custom usage should replace auto-generated: " + help,
     )
     # The auto-generated "<file> [OPTIONS]" should NOT appear in usage line
     var lines = help.split("\n")
     for i in range(len(lines)):
-        if "Usage:" in lines[i]:
+        if "usage:" in lines[i]:
             assert_false(
                 "<file>" in lines[i],
                 msg="Auto-generated positional should not appear in usage line",
@@ -1098,7 +1098,7 @@ def test_default_usage_when_no_custom() raises:
 
     var help = cmd._generate_help(color=False)
     assert_true(
-        "Usage: test <file> [OPTIONS]" in help,
+        "usage: test <file> [OPTIONS]" in help,
         msg="Default usage should show auto-generated format: " + help,
     )
 
@@ -1112,7 +1112,7 @@ def test_default_usage_with_optional_positional() raises:
 
     var help = cmd._generate_help(color=False)
     assert_true(
-        "Usage: test [path] [OPTIONS]" in help,
+        "usage: test [path] [OPTIONS]" in help,
         msg="Optional positional should be in brackets: " + help,
     )
 
@@ -1125,7 +1125,7 @@ def test_default_usage_with_subcommands() raises:
 
     var help = app._generate_help(color=False)
     assert_true(
-        "Usage: app <COMMAND> [OPTIONS]" in help,
+        "usage: app <COMMAND> [OPTIONS]" in help,
         msg="Subcommand usage should show <COMMAND>: " + help,
     )
 
@@ -1138,7 +1138,7 @@ def test_custom_usage_preserved_in_copy() raises:
     var copied = original.copy()
     var help = copied._generate_help(color=False)
     assert_true(
-        "Usage: git [options] <command> [<args>]" in help,
+        "usage: git [options] <command> [<args>]" in help,
         msg="Custom usage should be preserved in copy: " + help,
     )
 
@@ -1152,7 +1152,7 @@ def test_custom_usage_with_subcommands() raises:
 
     var help = app._generate_help(color=False)
     assert_true(
-        "Usage: app [-v] <command>" in help,
+        "usage: app [-v] <command>" in help,
         msg="Custom usage should override even with subcommands: " + help,
     )
     # Auto-generated <COMMAND> should NOT appear
@@ -1173,7 +1173,7 @@ def test_custom_usage_description_still_shown() raises:
         msg="Description should still appear: " + help,
     )
     assert_true(
-        "Usage: myapp [options]" in help,
+        "usage: myapp [options]" in help,
         msg="Custom usage should appear after description: " + help,
     )
 

--- a/tests/test_help.mojo
+++ b/tests/test_help.mojo
@@ -209,8 +209,8 @@ def test_dynamic_padding_long_options() raises:
 
     var help = command._generate_help(color=False)
     # The longest user arg is "--very-long-option-name <very-long-option-name>"
-    # which overflows the 32-char option column.  Its description should
-    # appear on the next line, aligned with other descriptions at column 38.
+    # which overflows the 24-char option column. Its description should appear
+    # on the next line, aligned with other descriptions.
     var desc_col_long: Int = -1
     var desc_col_short: Int = -1
     var lines = help.splitlines()
@@ -423,7 +423,8 @@ def test_custom_both_colors() raises:
 
 
 def test_default_colors_unchanged() raises:
-    """Without any setter, help uses default yellow headers + distinct arg colors."""
+    """Without any setter, help uses default yellow headers + distinct arg colors.
+    """
     var command = Command("app", "My app")
     command.add_argument(Argument("name", help="Your name").long["name"]())
 

--- a/tests/test_help.mojo
+++ b/tests/test_help.mojo
@@ -423,14 +423,28 @@ def test_custom_both_colors() raises:
 
 
 def test_default_colors_unchanged() raises:
-    """Without any setter, help uses default yellow headers + magenta args."""
+    """Without any setter, help uses default yellow headers + distinct arg colors."""
     var command = Command("app", "My app")
     command.add_argument(Argument("name", help="Your name").long["name"]())
 
     var help = command._generate_help(color=True)
-    # Default header = yellow \x1b[93m , default arg = magenta \x1b[95m
+    # Default header = yellow \x1b[93m
     assert_true("\x1b[93m" in help, msg="Default header should be yellow (93)")
-    assert_true("\x1b[95m" in help, msg="Default arg should be magenta (95)")
+    # Default short_opt = bold green \x1b[1;32m
+    assert_true(
+        "\x1b[1;32m" in help,
+        msg="Default short opt should be bold green (1;32)",
+    )
+    # Default long_opt = bold cyan \x1b[1;36m
+    assert_true(
+        "\x1b[1;36m" in help,
+        msg="Default long opt should be bold cyan (1;36)",
+    )
+    # Default prog = bold magenta \x1b[1;35m
+    assert_true(
+        "\x1b[1;35m" in help,
+        msg="Default prog should be bold magenta (1;35)",
+    )
 
 
 def test_color_uppercase_only() raises:

--- a/tests/test_hybrid.mojo
+++ b/tests/test_hybrid.mojo
@@ -108,7 +108,7 @@ def test_to_command_with_colors() raises:
     """Builder color customisation on to_command() works."""
     var cmd = Deploy.to_command()
     cmd.header_color["CYAN"]()
-    cmd.arg_color["GREEN"]()
+    cmd.argument_color["GREEN"]()
 
     var args: List[String] = ["command", "--replicas", "5", "prod"]
     var result = cmd.parse_arguments(args)

--- a/tests/test_subcommands.mojo
+++ b/tests/test_subcommands.mojo
@@ -938,8 +938,8 @@ def test_unknown_subcommand_error_no_positionals() raises:
         caught = True
         var msg = String(e)
         assert_true(
-            "unrecognized command" in msg,
-            msg="Should mention unrecognized command",
+            "unrecognized subcommand" in msg,
+            msg="Should mention unrecognized subcommand",
         )
         assert_true("foo" in msg, msg="Should mention 'foo'")
     assert_true(caught, msg="Should have raised for unknown subcommand")
@@ -999,10 +999,10 @@ def test_unknown_subcommand_error_excludes_help_sub() raises:
         caught = True
         var msg = String(e)
         assert_true(
-            "unrecognized command" in msg,
-            msg="Should mention unrecognized command",
+            "unrecognized subcommand" in msg,
+            msg="Should mention unrecognized subcommand",
         )
-        # The error message now only contains the unrecognized command name,
+        # The error message now only contains the unrecognized subcommand name,
         # not an "Available commands:" list, so 'help' cannot leak.
         assert_false(
             "help" in msg,

--- a/tests/test_subcommands.mojo
+++ b/tests/test_subcommands.mojo
@@ -938,12 +938,10 @@ def test_unknown_subcommand_error_no_positionals() raises:
         caught = True
         var msg = String(e)
         assert_true(
-            "Unknown command" in msg,
-            msg="Should mention unknown command",
+            "unrecognized command" in msg,
+            msg="Should mention unrecognized command",
         )
         assert_true("foo" in msg, msg="Should mention 'foo'")
-        assert_true("search" in msg, msg="Should list available 'search'")
-        assert_true("init" in msg, msg="Should list available 'init'")
     assert_true(caught, msg="Should have raised for unknown subcommand")
 
 
@@ -1001,20 +999,15 @@ def test_unknown_subcommand_error_excludes_help_sub() raises:
         caught = True
         var msg = String(e)
         assert_true(
-            "Unknown command" in msg,
-            msg="Should mention unknown command",
+            "unrecognized command" in msg,
+            msg="Should mention unrecognized command",
         )
-        assert_true("search" in msg, msg="Should list 'search'")
-        # 'help' should not appear in available commands.
-        # But the full msg could contain "help" in other contexts.
-        # Check the "Available commands:" part specifically.
-        var avail_start = msg.find("Available commands: ")
-        if avail_start >= 0:
-            var avail_part = String(msg[byte=avail_start:])
-            assert_false(
-                "help" in avail_part,
-                msg="'help' sub should not appear in available commands",
-            )
+        # The error message now only contains the unrecognized command name,
+        # not an "Available commands:" list, so 'help' cannot leak.
+        assert_false(
+            "help" in msg,
+            msg="'help' should not appear in error message",
+        )
     assert_true(caught, msg="Should have raised")
 
 


### PR DESCRIPTION
This PR refines ArgMojo’s CLI UX by updating help output formatting (layout, casing, and more granular ANSI coloring) and by changing unknown-subcommand errors to a multi-line, “pixi-style” diagnostic. Tests and supporting utilities are updated to match the new output.

**Changes:**
- Switch help section headers (e.g., usage/options/commands) to lowercase and adjust layout to be more argparse-like (including a narrower option column).
- Add dynamic help wrapping based on detected terminal width and introduce more detailed default color roles (program/short/long/value/positional/command).
- Rework unknown-subcommand errors to omit “Available commands” in the exception text and instead print a structured stderr message with a usage line.