### PR TITLE
[core][doc] Update documents for release + Parser fixes + faster compiles

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -122,6 +122,7 @@ jobs:
             && mojo run -I src -D ASSERT=all tests/test_hybrid.mojo \
             && mojo run -I src -D ASSERT=all tests/test_subcommands.mojo \
             && mojo run -I src -D ASSERT=all tests/test_subcommands_declarative.mojo \
+            && mojo run -I src -D ASSERT=all tests/test_dispatch.mojo \
             && mojo run -I src -D ASSERT=all tests/test_schema_validation.mojo \
             && bash tests/check_schema_errors.sh; then
               echo "=== tests passed on attempt $attempt ==="

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ ArgMojo currently supports:
 - **Positional arguments**: matched by position
 - **Default values**: fallback when an argument is not provided
 - **Required arguments**: validation that mandatory arguments are present
+- **Typed result accessors**: `get_string()`, `get_int()`, `get_float()`, `get_flag()`, `get_count()`, `get_list()`, `get_map()` read a value back in its own type
+- **User-input detection**: `was_provided()` tells a value the user actually supplied (on the command line, at a prompt, or through `.implies()`) from one that came from a `.default()`
 - **Auto-generated help**: `--help` / `-h` / `-?` with dynamic column alignment, pixi-style ANSI colours, and customisable header/argument colours
 - **Help on no arguments**: optionally show help when invoked with no arguments
 - **Version display**: `--version` / `-V` (also auto-generated)

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ ArgMojo currently supports:
 - **Default-if-no-value**: `--compress` uses a fallback; `--compress=bzip2` overrides
 - **Require equals syntax**: `--key=value` required, `--key value` rejected
 - **Remainder positional**: `.remainder()` consumes all remaining tokens
-- **Allow hyphen values**: `.allow_hyphen_values()` accepts `-` as a regular value (stdin convention)
+- **Allow hyphen values**: `.allow_hyphen_values()` accepts dash-prefixed tokens as values, including registered options (`--cflag --verbose`) and the stdin `-` convention
 - **Partial parsing**: `parse_known_arguments()` collects unrecognised options instead of erroring
 - **Compile-time validation**: builder parameters validated at `mojo build` time via `comptime assert`
 - **Registration-time validation**: group constraint typos caught when the program starts, not when the user runs it

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ ArgMojo currently supports:
 - **Confirmation option**: `confirmation_option()` to add a `--yes`/`-y` skip-confirmation flag
 - **Argument parents**: `add_parent()` to share argument definitions across commands
 - **Custom usage line**: `usage()` to override the auto-generated usage string
-- **Response files**: `@args.txt` expansion (temporarily disabled due to a Mojo compiler bug)
+- **Response files**: `@args.txt` expansion (currently disabled due to a Mojo compiler bug, see the [changelog](docs/changelog.md))
 - **CJK-aware help alignment**: CJK characters treated as 2-column-wide
 - **CJK full-width auto-correction**: fullwidth `－－ｖｅｒｂｏｓｅ` → `--verbose` with a warning
 - **CJK punctuation detection**: em-dash `——verbose` → `--verbose`

--- a/docs/argmojo_overall_planning.md
+++ b/docs/argmojo_overall_planning.md
@@ -244,7 +244,7 @@ examples/
 | Usage line customisation (`command.usage("...")` → override auto-generated usage line)                | ✓      | ✓     |
 | Password / masked input (`.password()` → hide typed characters during prompt via POSIX termios)       | ✓      | ✓     |
 
-> ⚠ Response file support is temporarily disabled due to a Mojo compiler deadlock under `-D ASSERT=all`. The implementation is preserved and will be re-enabled when the compiler bug is fixed.
+> ⚠ Response file support is currently disabled due to a Mojo compiler deadlock under `-D ASSERT=all` (still reproducing on Mojo v1.0.0). The implementation is preserved and will be re-enabled when the compiler bug is fixed.
 
 ### 4.3 API Design (Current)
 
@@ -591,7 +591,7 @@ Before adding Phase 5 features, further decompose `parse_arguments()` for readab
 - [x] **Partial parsing** — `parse_known_arguments()` collects unrecognised options instead of erroring; access via `result.get_unknown_arguments()` (argparse `parse_known_args`) (PR #13)
 - [x] **Require equals syntax** — `.require_equals()` forces `--key=value`, disallows `--key value` (clap `require_equals`) (PR #12)
 - [x] **Default-if-no-value** — `.default_if_no_value["val"]()`: `--opt` uses fallback; `--opt=val` uses val; absent uses default (argparse `const`) (PR #12)
-- [x] **Response file** — `mytool @args.txt` expands file contents as arguments (argparse `fromfile_prefix_chars`, javac, MSBuild) (PR #12) ⚠ *Temporarily disabled — Mojo compiler deadlock under `-D ASSERT=all`*
+- [x] **Response file** — `mytool @args.txt` expands file contents as arguments (argparse `fromfile_prefix_chars`, javac, MSBuild) (PR #12) ⚠ *Currently disabled — Mojo compiler deadlock under `-D ASSERT=all`, still on Mojo v1.0.0*
 - [x] **Argument parents** — `add_parent(parent)` copies all arguments and group constraints from a parent Command, sharing definitions across multiple commands (argparse `parents`) (PR #25)
 - [x] **Interactive prompting** — prompt user for missing required args instead of erroring (Click `prompt=True`) (PR #23)
 - [x] **Password / masked input** — hide typed characters for sensitive values (Click `hide_input=True`)
@@ -838,19 +838,26 @@ ArgMojo follows a consistent naming philosophy. When in doubt, apply these prior
 
 ## 8. Notes on Mojo versions
 
-Here are some important Mojo-specific patterns used throughout this project. Mojo is rapidly evolving, so these may need to be updated in the future.
+Here are some important Mojo-specific patterns used throughout this project. Mojo is rapidly evolving, so these may need to be updated in the future. As of ArgMojo v0.8.0, the codebase targets **Mojo v1.0.0**, the first stable release.
 
 These are all worthy being checked in [Mojo Miji](https://mojo-lang.com/miji) too.
 
-| Pattern                | What & Why                                          |
-| ---------------------- | --------------------------------------------------- |
-| `"""Tests..."""`       | Docstring convention                                |
-| `@fieldwise_init`      | Replaces `@value`                                   |
-| `var self`             | Used for builder methods instead of `owned self`    |
-| `String()`             | Explicit conversion; `str()` is not available       |
-| `[a, b, c]` for `List` | List literal syntax instead of variadic constructor |
-| `.copy()`              | Explicit copy for non-ImplicitlyCopyable types      |
-| `Movable` conformance  | Required for structs stored in containers           |
+| Pattern                             | What & Why                                                                 |
+| ----------------------------------- | --------------------------------------------------------------------------- |
+| `"""Tests..."""`                    | Docstring convention                                                       |
+| `@fieldwise_init`                   | Replaces `@value`                                                          |
+| `var self`                          | Used for builder methods instead of `owned self`                           |
+| `String()`                          | Explicit conversion; `str()` is not available                              |
+| `[a, b, c]` for `List`              | List literal syntax instead of variadic constructor                        |
+| `.copy()`                           | Explicit copy for non-ImplicitlyCopyable types                             |
+| `Movable` conformance               | Required for structs stored in containers                                  |
+| `Deinitable`                        | Renamed from `ImplicitlyDestructible` in Mojo v1.0.0                       |
+| `__init__(out self, *, deinit move: Self)` | Move constructor; the argument was called `take` before Mojo v1.0.0 |
+| `reflect[T]`                        | Unified reflection API: `field_count()`, `field_names()`, `field_types()`, `field_ref[i]()`, `name()` |
+| `comptime assert conforms_to(...)`  | Replaces `constrained[]` and the internal `_constrained_field_conforms_to`  |
+| `Pointer(to=x).unsafe_write(v)`     | Replaces `UnsafePointer(to=x).init_pointee_move(v)`                        |
+| `Array[T, N]`                       | Fixed-size, stack-allocated buffer; preferred over `List` for FFI scratch space |
+| Explicit `__deinit__()`             | Needed to break the deduction cycle of recursive structs, e.g., a `Command` holding `List[Command]` |
 
 ## 9. Pending Renames
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,36 +4,78 @@ This document tracks all notable changes to ArgMojo, including new features, API
 
 ## 20260811 (v0.8.0)
 
-ArgMojo v0.8.0 migrates the codebase to the first stable Mojo release, **v1.0.0**. It also fixes an FFI signature collision that could break the build of the users' projects, and removes several heap allocations from the terminal-handling paths.
+ArgMojo v0.8.0 moves to the first stable Mojo release, **v1.0.0**. It also fixes a dozen parser bugs, repairs an FFI signature clash that could break the build of a project using ArgMojo, cuts compile time by about a fifth, and fills several gaps in the declarative API.
 
 ArgMojo v0.8.0 targets Mojo v1.0.0.
 
+### ⭐️ New in v0.8.0
+
+1. Add `ParseResult.was_provided(name)` — True only when the user really supplied the argument, be it on the command line, at a prompt, or through an `implies()` rule. `has(name)` cannot tell you that, because a default is stored in the same place as a parsed value. Group constraints use it internally, and it is often what you want in your own code too:
+
+   ```mojo
+   if result.was_provided("format"):
+       print("the user asked for " + result.get_string("format"))
+   else:
+       print("falling back to the default format")
+   ```
+
+2. Add `ParseResult.get_float(name)` — reads a value as `Float64`, the way `get_int()` reads it as `Int`.
+3. `Option[Float64]` and `Positional[Float64]` now work end to end, defaults included. `has_range` stays integer-only, so combining it with `Float64` is rejected at compile time instead of failing later with a puzzling "expected an integer".
+4. `Count` can be unwrapped with `Int()`, as `Flag` can with `Bool()`. Write `Int(args.verbose)` instead of `args.verbose.value`.
+5. The four declarative wrappers now take a consistent set of parameters. `alias_name` was on `Option` only and `deprecated` on `Option` and `Flag` only; both are now available wherever they make sense. `Positional` gains `hidden`, `deprecated`, `prompt`, `prompt_text`, `password`, and the range parameters (`has_range`, `range_min`, `range_max`, `clamp`) that `Option` already had. Until now, needing any one of these on a positional meant dropping to the builder API for that one field.
+
 ### 🔧 Fixes in v0.8.0
 
-1. Fix a latent FFI signature collision in `_read_password_asterisk()`. The `read(2)` binding passed its buffer as `Int(ptr)`, which declares the symbol `read` as `(Int, Int, Int) -> Int`. The standard library declares the same symbol as `(Int, Pointer, Int) -> Int`, so any module that links both of them failed to lower to LLVM IR. The buffer is now passed as a real pointer (PR #59).
+1. Fix an FFI signature clash in `_read_password_asterisk()`. The `read(2)` binding passed its buffer as `Int(ptr)`, which declares `read` as `(Int, Int, Int) -> Int`, while the standard library declares the same symbol as `(Int, Pointer, Int) -> Int`. Any module linking both failed to lower to LLVM IR. The buffer is passed as a real pointer now (PR #59).
+2. Group constraints counted a default as user input. `mutually_exclusive()`, `required_together()`, `one_required()` and `required_if()` all asked `has()`, which is True for an argument that merely carries a `.default()` — so `--json` alone could conflict with a `--format` nobody had typed. All four consult `was_provided()` now.
+3. A required positional could be satisfied by a *later* positional's default. Filling the later slot pads the positional list up to that index, and the earlier, still-empty slot then looked provided: `src` (required) followed by `dst` (with a default) parsed happily with no arguments at all. A default on the required argument itself still satisfies it, as in clap.
+4. `app --=hello` used to set the first positional. The empty name left after splitting on `=` matched `_long_name == ""`, which is true for every positional and every short-only option. It is now reported as `Invalid option '--=hello': missing option name`.
+5. An argument carrying both `.prompt()` and `.default()` was never prompted, because defaults were applied first and prompting skips anything that already holds a value. Prompting runs first now, and the default is what an empty answer — or a non-interactive stdin — falls back to, which is what the "(default)" hint always promised.
+6. Defaults now reach the accessor that belongs to the argument. Every default used to be written to the string store, so `.flag().default["true"]()` was invisible to `get_flag()`, and `.append().default["x"]()` left `get_list()` empty while `get_string()` returned the value. Defaults go to `_flags`, `_counts`, `_lists`, `_maps` or `_values` according to the kind of the argument.
+7. Bad defaults are caught at registration instead of reaching the user. `add_argument()` now raises if a default is not one of the declared `.choice[…]()` values, if a `.flag()` default is not a boolean literal, if a `.count()` default is not an integer, or if a `.map_option()` default is not in `key=value` form; `default_if_no_value` is checked against the choices too. The declarative wrappers already checked the choices at compile time; the builder API checked nothing.
+8. An option no longer swallows another option as its value: `--output --verbose` used to store the literal string `"--verbose"`. Only *registered* options and the `--` marker are refused, so `--offset -5` and `--pattern -foo` still work, and `.allow_hyphen_values()` opts out entirely. The guard covers short options and `.number_of_values[N]()` as well.
+9. Persistent-argument conflicts were detected in only one registration order. The check lived in `add_subcommand()`, so calling `add_subcommand()` first and `add_argument(... .persistent())` afterwards slipped past it, and the flag then appeared twice in the child's help. `add_argument()` runs the mirror check now, and the injection at dispatch time skips an argument the child already owns.
+10. Non-ASCII passwords came back corrupted. `_read_password_asterisk()` rebuilt the typed string byte by byte through `chr()`, which treats each byte as a code point and re-encodes it, so `é` (`C3 A9`) arrived as `Ã©` (`C3 83 C2 A9`) and never matched. The bytes are decoded as UTF-8 in one step now, and the buffer is zeroed before it is freed.
+11. An `implies()` rule could fire from a default value — fix 2 again, by another route. The trigger was `has(trigger)`, so a `--mode` that merely defaults to `fast` still set `--parallel`; since an implied argument counts as user input, typing only `--quiet` then reported a conflict with a `--parallel` nobody had asked for. Implications fire on `was_provided(trigger)`.
+12. `parse_known_arguments()` applied defaults before implications, the reverse of `parse_arguments()`, so the two entry points could disagree about which arguments counted as supplied. Both run implications first now.
 
 ### 🔄 Mojo v1.0.0 migration (PR #59)
 
-- Bump the Mojo dependency from `==1.0.0b2` to `>=1.0.0, <1.1.0` in `pixi.toml`, so that ArgMojo builds against any Mojo v1.0.x release.
+- Bump the Mojo dependency from `==1.0.0b2` to `>=1.0.0, <1.1.0` in `pixi.toml`, so ArgMojo builds against any Mojo v1.0.x release.
 - Replace the removed `_constrained_field_conforms_to` helper with `comptime assert conforms_to(...)` plus `_field_conforms_to_error`, which is how the standard library now writes reflection-driven trait defaults.
 - Drop the `trait_downcast[…]()` calls in `Parsable`. A `comptime if conforms_to(...)` guard (or a `comptime assert`) is now enough for the compiler to resolve trait methods on a reflected field.
 - Replace `__struct_field_ref(i, x)` with the public `reflect[Self].field_ref[i](x)`.
-- Rename `ImplicitlyDestructible` to `Deinitable`, and drop `Movable` from the `Defaultable & Copyable & Movable` bounds, because the compiler now reports it as redundant.
+- Rename `ImplicitlyDestructible` to `Deinitable`, and drop `Movable` from the `Defaultable & Copyable & Movable` bounds, which the compiler now reports as redundant.
 - Rename the move constructor argument from `deinit take:` to `deinit move:` in `Argument`, `Command`, `ParseResult`, and the four argument wrappers.
 - Replace `UnsafePointer(to=f).init_pointee_move(v)` with `Pointer(to=f).unsafe_write(v)`.
-- Give `Command` and `ParseResult` an explicit, empty `__deinit__()`. Both structs hold a `List[Self]` field, and deducing `List[Command]: Deinitable` now requires `Command: Deinitable` — which is exactly what is being deduced. Declaring the destructor breaks this cycle, and the fields are still destroyed automatically.
-- Introduce temporary variables where a `String` is rebuilt from a slice of itself (e.g., `key = String(key[byte=:eq])`), because such statements now trip the exclusivity checker.
-- Dispatch the declarative wrappers on `reflect[T].name()` compared against the reflected names of the supported types, instead of against string literals. In Mojo v1.0.0, `Int` became an alias of `Scalar[DType.int]` and therefore reflects as `"SIMD[DType.int, 1]"`. Comparing a reflected name with another reflected name keeps working across such renames.
+- Give `Command` and `ParseResult` an explicit, empty `__deinit__()`. Both hold a `List[Self]` field, and deducing `List[Command]: Deinitable` now requires `Command: Deinitable` — exactly what is being deduced. Declaring the destructor breaks the cycle, and the fields are still destroyed automatically.
+- Introduce temporary variables where a `String` is rebuilt from a slice of itself (e.g. `key = String(key[byte=:eq])`), because such statements now trip the exclusivity checker.
+- Dispatch the declarative wrappers on `reflect[T].name()` compared against the reflected names of the supported types, instead of against string literals. In Mojo v1.0.0, `Int` became an alias of `Scalar[DType.int]` and so reflects as `"SIMD[DType.int, 1]"`; comparing one reflected name with another keeps working across such renames.
 - Update `tests/test_wrappers.mojo` to call the move constructor as `(move=a^)`.
 
 ### ⚡️ Performance in v0.8.0
 
-- Replace the fixed-size `List` scratch buffers with the inline `Array` type. This removes four heap allocations from the terminal-handling paths: the 8-byte `ioctl(TIOCGWINSZ)` buffer in `_help_line_width()`, the 96-byte termios buffers in `_disable_echo()` and `_read_password_asterisk()`, and the 1-byte read buffer of the password loop. `_disable_echo()` now returns `Optional[Array[UInt32, 24]]`, instead of signalling failure with an empty list (PR #59).
+- Compiling a program that uses ArgMojo is about 20% faster. Measured cold, with the compiler cache wiped, over the eight examples: 50.2 s down to 39.8 s in total, or 6.08 s down to 4.81 s per example. Nothing about the behaviour changes — help text, the three completion scripts and the error messages are byte-for-byte identical before and after. Four changes get there:
+  - `examples/build.sh` builds against the `argmojo.mojoc` it already produces (`-I .`) instead of recompiling `src/argmojo` into all eight binaries (`-I src`). This is the bulk of it: 50.2 s → 42.7 s on its own. Its timing summary now reports hundredths of a second and a total, rather than whole seconds from `date +%s`.
+  - Argument lookup returns an index instead of a copy. `_find_by_long()` and `_find_by_short()` deep-copied the whole `Argument` on *each* option token, only to read two or three fields; they are `_find_index_by_long()` / `_find_index_by_short()` now, and callers bind the result with `ref`. The per-loop copies in `_prompt_missing_arguments()`, `_validate()`, `_apply_defaults()` and the three completion generators became `ref` bindings too. This is the largest runtime saving in the release as well: dozens of heap allocations disappear from every parse.
+  - Long `+` chains became `String(...)` calls. Building a message as `"a" + x + "b" + y + ...` emits a separate inlined concatenation for every `+`; passing the same pieces to `String(...)` emits one call. 154 sites across `command.mojo`.
+  - `_looks_like_number()` and `_levenshtein()` compare bytes rather than one-character strings. `token[byte=j:j+1] >= "0"` writes out a full string comparison per character; a `UInt8` against a byte constant is one instruction. `_looks_like_number()` alone dropped from 17,850 lines of unoptimised IR to 4,431.
+
+  Together the source changes take the unoptimised IR of a one-argument program from 332,047 lines down to 264,929 (−20%).
+- Replace the fixed-size `List` scratch buffers with the inline `Array` type, removing four heap allocations from the terminal-handling paths: the 8-byte `ioctl(TIOCGWINSZ)` buffer in `_help_line_width()`, the 96-byte termios buffers in `_disable_echo()` and `_read_password_asterisk()`, and the 1-byte read buffer of the password loop. `_disable_echo()` returns `Optional[Array[UInt32, 24]]` now, instead of signalling failure with an empty list (PR #59).
 - Use a stack-allocated `Array[String, 2]` for the argument-name scratch buffer in `required_if()` (PR #59).
+
+### 📖 Documentation in v0.8.0
+
+- `docs/declarative_api_planning.md` gains a "Known Gaps" section: what went wrong in the wrappers, what has been fixed, and why the rest is still open.
+- The user manual documents `has()` versus `was_provided()`, which accessor reads back each kind of default, the registration-time rules for default values, how values that look like options are treated, the value types the declarative wrappers accept, and the `Bool()` / `Int()` unwrapping shortcuts.
+- `Argument.remainder()` now says what happens when the remainder is the first positional: collection starts at the very first token, so `--help` is swallowed as a remainder value and the command has no help flag. That is what a wrapper command such as `env` wants, but it is worth knowing before you hit it. Declare a positional ahead of the remainder, or call `help_on_no_arguments()`.
+- The `_allow_hyphen_values` field docstring claimed it accepts "the literal token `-`". It has always accepted any dash-prefixed token, and it now also switches off the check described in fix 8.
 
 ### ⚠️ Known issues in v0.8.0
 
-- Response-file expansion (`response_file_prefix()`) is **still disabled**. The Mojo compiler deadlock that blocked it in v0.4.0 also reproduces on Mojo v1.0.0: if we re-enable the call in `parse_arguments()`, the compilation of `tests/test_parse.mojo` hangs at 0% CPU under `-D ASSERT=all`. Interestingly, `tests/test_response_file.mojo` itself *does* compile and pass (17/17) with the call re-enabled. So the trigger depends on the surrounding set of instantiations, and not on the expansion code alone. The implementation is kept as module-level free functions, and `tests/test_response_file.mojo` remains excluded from the `test` and `t` tasks.
+- `mojo doc` (v1.0.0) does not recognise a struct parameter named `max`: it reports `unknown parameter 'max' in doc string`, then miscounts the index of every parameter declared after it. Two structs that differ only in that name are enough to show it — `max` warns, `maximum` does not — so the bug is in the tool. `Count`'s `max` is therefore described in the struct's prose docstring rather than its `Parameters:` block; renaming it would break every `Count[..., max=N]` already written. See §11 of `docs/declarative_api_planning.md`.
+- Response-file expansion (`response_file_prefix()`) is **still disabled**. The Mojo compiler deadlock that blocked it in v0.4.0 also reproduces on Mojo v1.0.0: re-enable the call in `parse_arguments()` and the compilation of `tests/test_parse.mojo` hangs at 0% CPU under `-D ASSERT=all`. Curiously, `tests/test_response_file.mojo` itself *does* compile and pass (17/17) with the call re-enabled, so the trigger depends on the surrounding set of instantiations rather than on the expansion code alone. The implementation is kept as module-level free functions, and `tests/test_response_file.mojo` remains excluded from the `test` and `t` tasks.
 
 ## 20260618 (v0.7.0)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,7 +2,7 @@
 
 This document tracks all notable changes to ArgMojo, including new features, API changes, bug fixes, and documentation updates.
 
-## 20260811 (v0.8.0)
+## 20260812 (v0.8.0)
 
 ArgMojo v0.8.0 moves to the first stable Mojo release, **v1.0.0**. It also fixes a dozen parser bugs, repairs an FFI signature clash that could break the build of a project using ArgMojo, cuts compile time by about a fifth, and fills several gaps in the declarative API.
 
@@ -70,6 +70,7 @@ ArgMojo v0.8.0 targets Mojo v1.0.0.
 - `docs/declarative_api_planning.md` gains a "Known Gaps" section: what went wrong in the wrappers, what has been fixed, and why the rest is still open.
 - The user manual documents `has()` versus `was_provided()`, which accessor reads back each kind of default, the registration-time rules for default values, how values that look like options are treated, the value types the declarative wrappers accept, and the `Bool()` / `Int()` unwrapping shortcuts.
 - `Argument.remainder()` now says what happens when the remainder is the first positional: collection starts at the very first token, so `--help` is swallowed as a remainder value and the command has no help flag. That is what a wrapper command such as `env` wants, but it is worth knowing before you hit it. Declare a positional ahead of the remainder, or call `help_on_no_arguments()`.
+- CI now runs `tests/test_dispatch.mojo` too. It was in the local `test` task but in none of the workflow jobs, so the auto-dispatch tests added in v0.6.0 had never run on a pull request.
 - The `_allow_hyphen_values` field docstring claimed it accepts "the literal token `-`". It has always accepted any dash-prefixed token, and it now also switches off the check described in fix 8.
 
 ### ⚠️ Known issues in v0.8.0

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,38 +4,40 @@ This document tracks all notable changes to ArgMojo, including new features, API
 
 ## 20260811 (v0.8.0)
 
-ArgMojo v0.8.0 migrates the codebase to the first stable Mojo release, **v1.0.0**.
+ArgMojo v0.8.0 migrates the codebase to the first stable Mojo release, **v1.0.0**. It also fixes an FFI signature collision that could break the build of the users' projects, and removes several heap allocations from the terminal-handling paths.
 
-### 🐞 Bug fixes
+ArgMojo v0.8.0 targets Mojo v1.0.0.
 
-- Fix a latent FFI signature collision in `_read_password_asterisk()`. The `read(2)` binding passed its buffer as `Int(ptr)`, declaring `read` as `(Int, Int, Int) -> Int`, which conflicts with the standard library's `(Int, Pointer, Int) -> Int` declaration of the same symbol. Any module that linked both failed to lower to LLVM IR. The buffer is now passed as a real pointer.
+### 🔧 Fixes in v0.8.0
 
-### 🔄 Mojo v1.0.0 migration
+1. Fix a latent FFI signature collision in `_read_password_asterisk()`. The `read(2)` binding passed its buffer as `Int(ptr)`, which declares the symbol `read` as `(Int, Int, Int) -> Int`. The standard library declares the same symbol as `(Int, Pointer, Int) -> Int`, so any module that links both of them failed to lower to LLVM IR. The buffer is now passed as a real pointer (PR #59).
 
-- Bump the Mojo dependency to `>=1.0.0, <1.1.0` in `pixi.toml`.
-- Replace the removed `_constrained_field_conforms_to` helper with `comptime assert conforms_to(...)` plus `_field_conforms_to_error`, matching how the standard library now writes reflection-driven trait defaults.
-- Drop `trait_downcast[…]()` calls in `Parsable`. A `comptime if conforms_to(...)` guard (or `comptime assert`) is now enough for the compiler to resolve trait methods on a reflected field.
+### 🔄 Mojo v1.0.0 migration (PR #59)
+
+- Bump the Mojo dependency from `==1.0.0b2` to `>=1.0.0, <1.1.0` in `pixi.toml`, so that ArgMojo builds against any Mojo v1.0.x release.
+- Replace the removed `_constrained_field_conforms_to` helper with `comptime assert conforms_to(...)` plus `_field_conforms_to_error`, which is how the standard library now writes reflection-driven trait defaults.
+- Drop the `trait_downcast[…]()` calls in `Parsable`. A `comptime if conforms_to(...)` guard (or a `comptime assert`) is now enough for the compiler to resolve trait methods on a reflected field.
 - Replace `__struct_field_ref(i, x)` with the public `reflect[Self].field_ref[i](x)`.
-- Rename `ImplicitlyDestructible` to `Deinitable`, and drop `Movable` from `Defaultable & Copyable & Movable` bounds, which the compiler now flags as redundant.
-- Rename the move constructor argument from `deinit take:` to `deinit move:` across `Argument`, `Command`, `ParseResult`, and the four argument wrappers.
+- Rename `ImplicitlyDestructible` to `Deinitable`, and drop `Movable` from the `Defaultable & Copyable & Movable` bounds, because the compiler now reports it as redundant.
+- Rename the move constructor argument from `deinit take:` to `deinit move:` in `Argument`, `Command`, `ParseResult`, and the four argument wrappers.
 - Replace `UnsafePointer(to=f).init_pointee_move(v)` with `Pointer(to=f).unsafe_write(v)`.
-- Give `Command` and `ParseResult` explicit no-op `__deinit__` methods. Both hold a `List[Self]` field, and deducing `List[Command]: Deinitable` now requires `Command: Deinitable` — the very thing being deduced. Declaring the destructor breaks the cycle; fields are still destroyed automatically.
-- Introduce temporaries where a `String` is rebuilt from a slice of itself (`key = String(key[byte=:eq])`), which now trips the exclusivity checker.
-- Dispatch the declarative wrappers on `reflect[T].name()` compared against the reflected names of the supported types themselves, rather than against string literals. `Int` became an alias for `Scalar[DType.int]` in v1.0.0, so it reflects as `"SIMD[DType.int, 1]"`; comparing reflected name to reflected name keeps working across such renames.
+- Give `Command` and `ParseResult` an explicit, empty `__deinit__()`. Both structs hold a `List[Self]` field, and deducing `List[Command]: Deinitable` now requires `Command: Deinitable` — which is exactly what is being deduced. Declaring the destructor breaks this cycle, and the fields are still destroyed automatically.
+- Introduce temporary variables where a `String` is rebuilt from a slice of itself (e.g., `key = String(key[byte=:eq])`), because such statements now trip the exclusivity checker.
+- Dispatch the declarative wrappers on `reflect[T].name()` compared against the reflected names of the supported types, instead of against string literals. In Mojo v1.0.0, `Int` became an alias of `Scalar[DType.int]` and therefore reflects as `"SIMD[DType.int, 1]"`. Comparing a reflected name with another reflected name keeps working across such renames.
 - Update `tests/test_wrappers.mojo` to call the move constructor as `(move=a^)`.
 
-### ⚡️ Performance
+### ⚡️ Performance in v0.8.0
 
-- Replace the fixed-size `List` scratch buffers with inline `Array`, removing four heap allocations from the terminal-handling paths: the 8-byte `ioctl(TIOCGWINSZ)` buffer in `_help_line_width()`, the 96-byte termios buffers in `_disable_echo()` and `_read_password_asterisk()`, and the 1-byte read buffer in the password loop. `_disable_echo()` now returns `Optional[Array[UInt32, 24]]` instead of signalling failure with an empty list.
-- Use a stack `Array[String, 2]` for the argument-name scratch buffer in `required_if()`.
+- Replace the fixed-size `List` scratch buffers with the inline `Array` type. This removes four heap allocations from the terminal-handling paths: the 8-byte `ioctl(TIOCGWINSZ)` buffer in `_help_line_width()`, the 96-byte termios buffers in `_disable_echo()` and `_read_password_asterisk()`, and the 1-byte read buffer of the password loop. `_disable_echo()` now returns `Optional[Array[UInt32, 24]]`, instead of signalling failure with an empty list (PR #59).
+- Use a stack-allocated `Array[String, 2]` for the argument-name scratch buffer in `required_if()` (PR #59).
 
-### ⚠️ Known issues
+### ⚠️ Known issues in v0.8.0
 
-- Response-file expansion (`response_file_prefix()`) is **still disabled**. The Mojo compiler deadlock that blocked it in v0.4.0 continues to reproduce on v1.0.0: re-enabling the call from `parse_arguments()` hangs compilation of `tests/test_parse.mojo` at 0% CPU under `-D ASSERT=all`. Notably `tests/test_response_file.mojo` itself *does* compile and pass (17/17) with the call re-enabled, so the trigger depends on the surrounding instantiation set rather than on the expansion code alone. The implementation is preserved as module-level free functions and `tests/test_response_file.mojo` remains excluded from the `test` and `t` tasks.
+- Response-file expansion (`response_file_prefix()`) is **still disabled**. The Mojo compiler deadlock that blocked it in v0.4.0 also reproduces on Mojo v1.0.0: if we re-enable the call in `parse_arguments()`, the compilation of `tests/test_parse.mojo` hangs at 0% CPU under `-D ASSERT=all`. Interestingly, `tests/test_response_file.mojo` itself *does* compile and pass (17/17) with the call re-enabled. So the trigger depends on the surrounding set of instantiations, and not on the expansion code alone. The implementation is kept as module-level free functions, and `tests/test_response_file.mojo` remains excluded from the `test` and `t` tasks.
 
 ## 20260618 (v0.7.0)
 
-ArgMojo v0.7.0 migrates the codebase to Mojo v1.0.0b2.
+ArgMojo v0.7.0 migrates the codebase to Mojo v1.0.0b2 (PR #58).
 
 ## 20260510 (v0.6.0)
 

--- a/docs/declarative_api_planning.md
+++ b/docs/declarative_api_planning.md
@@ -26,18 +26,18 @@ I want the declarative API to satisfy five goals:
 
 Available compile-time reflection primitives:
 
-| API                                 | Purpose                                                    |
-| ----------------------------------- | ---------------------------------------------------------- |
-| `reflect[T]`                        | Reflection handle for struct T                             |
-| `reflect[T].field_count()`          | Number of fields in struct T                               |
-| `reflect[T].field_names()`          | Indexable list of field name strings                       |
-| `reflect[T].field_types()`          | Indexable list of field types                              |
-| `reflect[T].name()`                 | String name of type T                                      |
-| `reflect[T].field_ref[idx](x)`      | Reference to field by compile-time index                   |
-| `conforms_to(type, Trait)`          | Compile-time trait conformance check                       |
-| ~~`@fieldwise_init`~~               | ~~Auto-generate constructor from fields~~[^fieldwise_init] |
-| `comptime for idx in range(N)`      | Compile-time loop                                          |
-| `comptime if condition`             | Compile-time conditional                                   |
+| API                            | Purpose                                                    |
+| ------------------------------ | ---------------------------------------------------------- |
+| `reflect[T]`                   | Reflection handle for struct T                             |
+| `reflect[T].field_count()`     | Number of fields in struct T                               |
+| `reflect[T].field_names()`     | Indexable list of field name strings                       |
+| `reflect[T].field_types()`     | Indexable list of field types                              |
+| `reflect[T].name()`            | String name of type T                                      |
+| `reflect[T].field_ref[idx](x)` | Reference to field by compile-time index                   |
+| `conforms_to(type, Trait)`     | Compile-time trait conformance check                       |
+| ~~`@fieldwise_init`~~          | ~~Auto-generate constructor from fields~~[^fieldwise_init] |
+| `comptime for idx in range(N)` | Compile-time loop                                          |
+| `comptime if condition`        | Compile-time conditional                                   |
 
 A `comptime if conforms_to(...)` guard is enough for the compiler to resolve
 trait methods on a reflected field, so no explicit downcast is needed.
@@ -1383,9 +1383,10 @@ I think this is the right call — these features describe *relationships betwee
   - [ ] Positional ordering enforcement
   - [ ] Type-metadata mismatch detection
   - [x] Choices vs default consistency (`comptime assert` in `Option` and `Positional`)
-  - [x] Range min ≤ max (`comptime assert range_min <= range_max` in `Option`)
+  - [x] Range min ≤ max (`comptime assert range_min <= range_max` in `Option` and `Positional`)
+  - [x] `has_range` rejected on `Float64` (range validation is integer-only — see the open item under §11)
   - [x] Test: positive schema validation (test_schema_validation.mojo, 5 tests)
-  - [x] Test: negative schema validation (check_schema_errors.sh, 6 compile-error tests)
+  - [x] Test: negative schema validation (check_schema_errors.sh, 9 compile-error tests)
 - [ ] Add `depends_on`/`conflicts_with` parameters to `Option` and `Flag` (§6.4)
   - [ ] Compile-time validation of referenced field names
   - [ ] Translation to builder `required_together()`/`mutually_exclusive()` in `to_command()`
@@ -1394,7 +1395,7 @@ I think this is the right call — these features describe *relationships betwee
   - [ ] Explore compile-time completion script generation
 - [ ] Some command-level features can be exposed via declarative parameters (e.g. `help_on_no_arguments=True`), but others (e.g. `confirmation_option()`) require builder-level access. Document best practices for when to use `to_command()` for command-level behavior.
 - [ ] Implement `validate(self) raises` method on `Parsable` (mirroring Swift's `validate()`) — post-parse cross-field validation without requiring the builder API
-- [ ] Add more built-in types for `Option` (e.g. `Float`) and ensure they work end-to-end with both declarative and builder patterns. This requires more methods in `ParseResult` (e.g. `get_float()`) and corresponding write-back logic in `from_parse_result()`.
+- [x] Add more built-in types for `Option` (e.g. `Float`) — `Float64` is supported on both `Option[T]` and `Positional[T]`, backed by `ParseResult.get_float()`. Remaining unsupported types are listed in §11.
 
 ### Phase 5: Polish
 
@@ -1403,5 +1404,87 @@ I think this is the right call — these features describe *relationships betwee
 - [x] Examples: simple pure-declarative (`search.mojo`), hybrid (`deploy.mojo`), full parse (`convert.mojo`)
 - [x] User manual additions
 - [x] README update with declarative examples
+
+## 11. Known Gaps (v0.8.0)
+
+Before the v0.8.0 release I went through the four wrapper types parameter by
+parameter and compared them against what the builder API already offers. The
+cheap, self-contained differences are fixed. The rest are below, each with the
+reason I left it, so that I do not have to reconstruct the same list next
+time.
+
+### Fixed in v0.8.0
+
+| Gap                                                                        | Resolution                                                     |
+| -------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `Option[T]` / `Positional[T]` took only `String`, `Int`, `List`, and `Dict` | `Float64` added to both, backed by the new `get_float()`       |
+| `alias_name` existed only on `Option`                                      | Added to `Flag` and `Count`                                    |
+| `deprecated` existed only on `Option` and `Flag`                           | Added to `Count` and `Positional`                              |
+| `hidden` missing from `Positional`                                         | Added                                                          |
+| `prompt` / `prompt_text` / `password` existed only on `Option`             | Added to `Positional`                                          |
+| `has_range` / `range_min` / `range_max` / `clamp` missing from `Positional` | Added, with the `range_min <= range_max` check `Option` has     |
+| No way to unwrap a value except `.value` and `Flag.__bool__`               | `Count` conforms to `Intable`, so `Int(args.verbose)` works    |
+
+### Still open
+
+#### Range validation is integer-only
+
+`_validate` parses the value with `atol` and keeps the bounds as `Int`, so
+`has_range` cannot express `0.0 <= ratio <= 1.0`. I reject `has_range` together
+with `Float64` at compile time — the alternative was letting it through and
+failing at runtime with a confusing "expected an integer".
+
+Doing it properly means either widening `Argument._range_min` / `_range_max` to
+`Float64`, which changes how every existing range is rendered in help text and
+error messages (`[1, 65535]` becomes `[1.0, 65535.0]`), or keeping a second
+pair of bounds behind a `_range_is_float` flag. Neither is small, and integer
+ranges cover what ranges are actually used for: ports, levels, counts.
+
+#### `Count`'s `max` cannot go in the Parameters block
+
+`mojo doc` (v1.0.0) does not recognise a struct parameter named `max`. It
+reports `unknown parameter 'max' in doc string`, then miscounts the index of
+every parameter declared after it. I reduced it to two structs differing only
+in that name: `max` warns, `maximum` does not, so this is a tooling bug rather
+than an argmojo one. The parameter is described in the struct's prose docstring
+instead. Renaming it to `max_count` would keep `mojo doc` quiet at the cost of
+breaking every `Count[..., max=N]` already written, so the name stays until the
+tool is fixed.
+
+The related trap is that `--diagnose-missing-doc-strings` only flags a missing
+*docstring*, never a missing *parameter entry*. That is why `Count.max` sat
+undocumented without anything complaining about it. Checking parameter coverage
+needs a separate script that compares each struct's parameter list against its
+`Parameters:` block.
+
+#### Types the wrappers still refuse
+
+`Bool` (use `Flag`), `Float32`, the sized integers (`Int8` … `UInt64`), and
+`List[Int]` all fall through to the `comptime assert False` arm of
+`read_from_result`. Each one needs a matching `ParseResult` accessor first. My
+guess is that `Float32` and `List[Int]` will be the two that get requested.
+
+#### Constraints stay builder-only
+
+This is still a deliberate decision (§8), and the one I am least sure about.
+`mutually_exclusive`, `required_together`, `one_required`, `required_if`, and
+`implies` describe relationships *between* fields, which do not fit a per-field
+attribute; `depends_on` / `conflicts_with` (§6.4) would cover the two commonest
+cases. Now that `was_provided()` gives the group checks a precise notion of
+"the user supplied this", it is worth another look — but the escape hatch
+through `to_command()` works today.
+
+#### `run()` is never dispatched automatically
+
+`parse()` returns the struct and stops, so you still write
+`if result.subcommand == "build": ...` by hand. Walking the subcommand chain
+automatically needs compile-time variadic type tuples, which Mojo does not
+have. Tracked in §5.4.3 — a missing language feature, not an oversight.
+
+#### No `Parsable.validate()`
+
+Swift's argument parser calls a `validate()` hook after parsing; the equivalent
+here would let you write cross-field checks without dropping to the builder.
+It is listed in Phase 4 and I have not started it.
 
 [^fieldwise_init]: removed — compiler auto-synthesises move init from `Movable` conformance; the `Parsable` trait now provides a reflection-based default `__init__` via `mark_initialized` + `comptime for`.

--- a/docs/declarative_api_planning.md
+++ b/docs/declarative_api_planning.md
@@ -22,22 +22,25 @@ I want the declarative API to satisfy five goals:
 
 5. **Five innovations** — I think there are five features I can offer beyond what Swift Argument Parser does (see [§6](#6-innovations)).
 
-## 2. Mojo Reflection Capabilities (v0.26.2)
+## 2. Mojo Reflection Capabilities (v1.0.0)
 
 Available compile-time reflection primitives:
 
 | API                                 | Purpose                                                    |
 | ----------------------------------- | ---------------------------------------------------------- |
-| `struct_field_count[T]()`           | Number of fields in struct T                               |
-| `struct_field_names[T]()`           | Indexable list of field name strings                       |
-| `struct_field_types[T]()`           | Indexable list of field types                              |
-| `get_type_name[T]()`                | String name of type T                                      |
-| `__struct_field_ref(idx, instance)` | Reference to field by compile-time index                   |
+| `reflect[T]`                        | Reflection handle for struct T                             |
+| `reflect[T].field_count()`          | Number of fields in struct T                               |
+| `reflect[T].field_names()`          | Indexable list of field name strings                       |
+| `reflect[T].field_types()`          | Indexable list of field types                              |
+| `reflect[T].name()`                 | String name of type T                                      |
+| `reflect[T].field_ref[idx](x)`      | Reference to field by compile-time index                   |
 | `conforms_to(type, Trait)`          | Compile-time trait conformance check                       |
-| `trait_downcast[Trait](value)`      | Cast value to trait-conforming type                        |
 | ~~`@fieldwise_init`~~               | ~~Auto-generate constructor from fields~~[^fieldwise_init] |
 | `comptime for idx in range(N)`      | Compile-time loop                                          |
 | `comptime if condition`             | Compile-time conditional                                   |
+
+A `comptime if conforms_to(...)` guard is enough for the compiler to resolve
+trait methods on a reflected field, so no explicit downcast is needed.
 
 **Key limitation**: No proc macros, no custom decorators, no `#[derive(...)]`. So all declarative behavior has to be implemented via parametric functions that reflect over user-defined structs.
 
@@ -363,10 +366,10 @@ from argmojo import Parsable, Option, Flag, Positional
 
 ### 4.2 The `Parsable` Trait
 
-The `Parsable` trait is the **heart** of the declarative API. Unlike the old `Parser[T]` design, there is no separate orchestrator struct — the trait's default methods handle everything: building, parsing, validation, and hybrid bridging. This is possible because Mojo 0.26.2 supports `struct_field_count[Self]()` inside trait default `@staticmethod` methods.
+The `Parsable` trait is the **heart** of the declarative API. Unlike the old `Parser[T]` design, there is no separate orchestrator struct — the trait's default methods handle everything: building, parsing, validation, and hybrid bridging. This is possible because Mojo supports `reflect[Self].field_count()` inside trait default `@staticmethod` methods.
 
 ```mojo
-trait Parsable(Defaultable, Movable):
+trait Parsable(Defaultable, Deinitable, Movable):
     """Trait for structs that can be parsed from CLI arguments.
     
     Default methods use compile-time reflection over Self to translate
@@ -511,7 +514,7 @@ The four parsing methods follow a 2×2 naming convention:
 
 All reflection logic lives directly inside the `Parsable` trait's default methods — there are **no standalone helper functions**:
 
-- **`to_command()`** — creates a `Command`, iterates Self's fields via `comptime for` + `struct_field_types[Self]()`, downcasts each `ArgumentLike`-conforming field, and calls `field.add_to_command(name, command)`. Registers subcommands via `subcommands()` hook.
+- **`to_command()`** — creates a `Command`, iterates Self's fields via `comptime for` + `reflect[Self].field_types()`, picks each `ArgumentLike`-conforming field, and calls `field.add_to_command(name, command)`. Registers subcommands via `subcommands()` hook.
 - **`from_parse_result(result)`** — creates `Self()`, iterates fields, downcasts each `ArgumentLike`-conforming field, and calls `field.read_from_result(name, result)`. Called by `parse()`, `parse_arguments()`, `parse_from_command()`, `parse_full()`, `parse_full_from_command()`, and directly by users for subcommand dispatch.
 
 This design keeps `parsable.mojo` self-contained: the trait IS the entire declarative API.
@@ -521,7 +524,7 @@ This design keeps `parsable.mojo` self-contained: the trait IS the entire declar
 > **Update**: As of Phase 1 implementation, users **no longer need to write `__init__`**.
 > The `Parsable` trait provides a default `__init__` that uses
 > `__mlir_op.lit.ownership.mark_initialized` + `comptime for` +
-> `UnsafePointer.init_pointee_move(type_of(field)())` to auto-initialise
+> `Pointer.unsafe_write(type_of(field)())` to auto-initialise
 > every field via reflection. The compiler auto-synthesises the move init
 > from `Movable` conformance. Users only need to declare fields and
 > provide `description()`.
@@ -1117,11 +1120,11 @@ struct MyArgs(Parsable):
 | `depends_on="password"`      | `command.required_if("password", "username")`                |
 | `conflicts_with="json,yaml"` | `command.mutually_exclusive(["this_field", "json", "yaml"])` |
 
-**Compile-time name validation**: Since `depends_on` and `conflicts_with` are `StringLiteral` parameters, and all field names are known at compile time via `struct_field_names`, I can verify at compile time that every referenced name actually exists in the struct:
+**Compile-time name validation**: Since `depends_on` and `conflicts_with` are `StringLiteral` parameters, and all field names are known at compile time via `reflect[T].field_names()`, I can verify at compile time that every referenced name actually exists in the struct:
 
 ```mojo
 # In to_command(), at comptime:
-# depends_on="password" → verify "password" is in struct_field_names[T]()
+# depends_on="password" → verify "password" is in reflect[T].field_names()
 # If not → comptime assert failure with a clear error message
 ```
 

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -129,7 +129,7 @@ from argmojo import Argument, Command
   - [Command-Level Methods](#command-level-methods)
   - [Notes (Cross-Library Method Name Reference)](#notes-cross-library-method-name-reference)
 
-<!-- Response Files (temporarily disabled — Mojo compiler deadlock with -D ASSERT=all) -->
+<!-- Response Files (currently disabled — Mojo compiler deadlock with -D ASSERT=all, still on Mojo v1.0.0) -->
 
 ## Getting Started
 
@@ -306,7 +306,7 @@ Argument("name", help="...")
 ```
 
 > [!NOTE]
-> (*) Response files are temporarily disabled due to a Mojo compiler bug. [^respfile]
+> (*) Response files are currently disabled due to a Mojo compiler bug. [^respfile]
 >
 > **Reading guide:** Indentation shows "goes after" — e.g. `.clamp()` is
 > indented under `.range[min,max]()` because it requires range.  The three main
@@ -3178,7 +3178,7 @@ All other validation (required arguments, choices, range) still applies. Only th
 
 > **Note:** Unknown options using `=` syntax (e.g., `--color=auto`) are captured as a single token. For space-separated syntax (`--color auto`), only `--color` is recorded as unknown; `auto` flows to positional arguments because the parser cannot tell whether the unknown option takes a value. Use `=` syntax when forwarding unknown options reliably.
 
-<!-- Response Files section temporarily disabled — Mojo compiler deadlock with -D ASSERT=all.
+<!-- Response Files section currently disabled — Mojo compiler deadlock with -D ASSERT=all (still on Mojo v1.0.0).
      The implementation is preserved as module-level functions and will be re-enabled
      when the Mojo compiler bug is fixed.
      
@@ -4290,7 +4290,7 @@ See the footnotes at the bottom of this document.
 [^append]: Implies `.append()` automatically.
 [^cmd]: Command-level method — called on `Command`, not chained on `Argument`.
 [^vname]: Accepts compile-time parameter: `.value_name[wrapped: Bool = True]("NAME")` — `True` wraps in `<NAME>`, `False` displays bare `NAME`.
-[^respfile]: Response files temporarily disabled due to Mojo compiler bug.
+[^respfile]: Response files are currently disabled due to a Mojo compiler bug (a compilation deadlock under `-D ASSERT=all`). It still reproduces on Mojo v1.0.0. The implementation is kept in the source code and will be re-enabled once the compiler bug is fixed.
 [^pw]: Also available as `.password[True]()` to echo `*` per keystroke (sudo-rs style), or `.password[False]()` (same as plain `.password()`).
 [^xref-1]: Cobra / pflag uses imperative `cmd.MarkFlag…()` calls on the command, not builder-chaining on the flag definition.
 [^xref-2]: clap positional args are defined by `.index(1)`, `.index(2)`, etc., or by omitting `.long()` / `.short()`.

--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -161,16 +161,18 @@ def main() raises:
 
 After calling `command.parse()` or `command.parse_arguments()`, you get a `ParseResult` with these typed accessors:
 
-| Method                      | Returns                | Description                                           |
-| --------------------------- | ---------------------- | ----------------------------------------------------- |
-| `result.get_flag("name")`   | `Bool`                 | Returns `True` if the flag was set, else `False`.     |
-| `result.get_string("name")` | `String`               | Returns the string value. Raises if not found.        |
-| `result.get_int("name")`    | `Int`                  | Parses the value as an integer. Raises on error.      |
-| `result.get_count("name")`  | `Int`                  | Returns the count (0 if never provided).              |
-| `result.get_list("name")`   | `List[String]`         | Returns collected values (empty list if none).        |
-| `result.get_map("name")`    | `Dict[String, String]` | Returns key-value pairs (empty dict if none).         |
-| `result.has("name")`        | `Bool`                 | Returns `True` if the argument was provided.          |
-| `result.print_summary()`    | `None`                 | Prints a human-readable summary of all parsed values. |
+| Method                        | Returns                | Description                                                   |
+| ----------------------------- | ---------------------- | ------------------------------------------------------------- |
+| `result.get_flag("name")`     | `Bool`                 | Returns `True` if the flag was set, else `False`.             |
+| `result.get_string("name")`   | `String`               | Returns the string value. Raises if not found.                |
+| `result.get_int("name")`      | `Int`                  | Parses the value as an integer. Raises on error.              |
+| `result.get_float("name")`    | `Float64`              | Parses the value as a floating-point number. Raises on error. |
+| `result.get_count("name")`    | `Int`                  | Returns the count (0 if never provided).                      |
+| `result.get_list("name")`     | `List[String]`         | Returns collected values (empty list if none).                |
+| `result.get_map("name")`      | `Dict[String, String]` | Returns key-value pairs (empty dict if none).                 |
+| `result.has("name")`          | `Bool`                 | Returns `True` if a value is available (including a default). |
+| `result.was_provided("name")` | `Bool`                 | Returns `True` only if the user really supplied it.           |
+| `result.print_summary()`      | `None`                 | Prints a human-readable summary of all parsed values.         |
 
 **`get_string()`** works for both named options and positional arguments — positional values are looked up by the name given in `Argument("name", ...)`.
 
@@ -196,7 +198,18 @@ var tags = result.get_list("tag")  # List[String]
 # Check presence
 if result.has("output"):
     print("Output was specified:", result.get_string("output"))
+
+# Tell a typed value apart from a default one
+if result.was_provided("format"):
+    print("The user chose:", result.get_string("format"))
 ```
+
+The two presence checks are not the same. `has()` tells you that a value is
+there to be read, and that includes a value that came from `.default()`.
+`was_provided()` is narrower: it is `True` only for a value the user typed on
+the command line, entered at an interactive prompt, or received through an
+`implies()` rule, and `False` for a default. Group constraints go through
+`was_provided()`, which is why a default never sets off a conflict on its own.
 
 ## Builder Method Overview
 
@@ -471,7 +484,28 @@ myapp "hello" --format csv   # format = "csv",   path = "."
 myapp "hello" ./src          # format = "table", path = "./src"
 ```
 
-Works for both named options and positional arguments.
+Works for every kind of argument, and the default always lands where that
+argument's own accessor reads it:
+
+| Argument kind   | Default is read back with    | Example               |
+| --------------- | ---------------------------- | --------------------- |
+| plain option    | `get_string()` / `get_int()` | `.default["table"]()` |
+| positional      | `get_string()`               | `.default["."]()`     |
+| `.flag()`       | `get_flag()`                 | `.default["true"]()`  |
+| `.count()`      | `get_count()`                | `.default["2"]()`     |
+| `.append()`     | `get_list()`                 | `.default["x"]()`     |
+| `.map_option()` | `get_map()`                  | `.default["A=1"]()`   |
+
+A default that does not fit its argument is rejected when you call
+`add_argument()`, rather than when your user runs the program. A `.flag()`
+default must be a boolean literal (`true`/`false`, `1`/`0`, `yes`/`no`,
+`on`/`off`); a `.count()` default must be an integer; a `.map_option()` default
+must be in `key=value` form; and if the argument has `.choice[]()`, the default
+must be one of those choices.
+
+Keep in mind that a default is not user input. `was_provided()` returns `False`
+for it, and it never satisfies a group constraint on its own — though it does
+satisfy `.required()` on the argument that carries it.
 
 ### Required Arguments
 
@@ -3140,6 +3174,42 @@ cat input.txt  # file = "input.txt"
 
 > **Note:** `.remainder()` automatically enables `.allow_hyphen_values()` — no need to set it separately on remainder positionals.
 
+#### Values that look like options <!-- omit from toc -->
+
+An option never takes a *registered* option as its value. If you write
+`--output --verbose` and `--verbose` is a real flag of your program, the
+parser reports a missing value rather than storing the string `"--verbose"`
+in `output`:
+
+```shell
+myapp --output --verbose
+# error: Option '--output' requires a value, but found the option '--verbose'
+```
+
+Only registered options and the `--` end-of-options marker are refused. A
+value that merely begins with a hyphen is still accepted, so negative numbers
+and unknown dash-prefixed literals keep working:
+
+```shell
+myapp --offset -5        # offset = "-5"
+myapp --pattern -foo     # pattern = "-foo"
+```
+
+`.allow_hyphen_values()` turns the check off for that argument, which is what
+you want for an option that forwards a flag to another tool:
+
+```mojo
+command.add_argument(
+    Argument("pass-through", help="Flag forwarded to the compiler")
+    .long["cflag"]()
+    .allow_hyphen_values()
+)
+```
+
+```shell
+myapp --cflag --verbose  # pass-through = "--verbose"
+```
+
 ### Partial Parsing (`parse_known_arguments()`)
 
 `parse_known_arguments()` works like `parse_arguments()` but **does not raise an error** for unrecognised options. Instead, unknown tokens are collected and can be retrieved from the result.
@@ -4011,6 +4081,18 @@ Four wrapper types encode argument metadata as compile-time parameters:
 | `Count`         | `-vvv` (repeated)            | `var debug: Count[short="d", help="Debug level", max=3]`          |
 
 Each wrapper accepts the same parameters as the corresponding builder methods (e.g. `choices`, `default`, `append`, `range_min`/`range_max`, `group`, `prompt`, `password`, etc.) as compile-time keyword parameters. See `src/argmojo/argument_wrappers.mojo` for the full parameter list.
+
+As for the value type `T`, `Option[T]` and `Positional[T]` accept `String`, `Int`, `Float64` and `List[String]`, and `Option[T]` additionally accepts `Dict[String, String]` when `map_option=True`. Anything else is rejected at compile time with a message listing what is allowed. There is no `Option[Bool]` — use `Flag` for that.
+
+To read a value back, use `.value`. `Flag` and `Count` also define `__bool__` and `__int__`, so they can be converted directly:
+
+```mojo
+if args.verbose:                      # Flag → Bool
+    print("level:", Int(args.debug))  # Count → Int
+print(args.ratio.value)               # everything else via .value
+```
+
+One restriction worth flagging: range validation is integer-only. `has_range` parses the value with `atol` and cannot express a fractional bound, so `has_range=True` together with `Float64` is refused at compile time instead of failing at run time with a confusing "expected an integer". Check fractional bounds yourself after parsing.
 
 ### The `Parsable` Trait
 

--- a/examples/build.sh
+++ b/examples/build.sh
@@ -50,13 +50,22 @@ list_examples() {
 # ── Build + time one example ─────────────────────────────────────────────
 #   build_one <name> <source>
 #   Sets TIMES[name]=seconds
+# `-I .` builds against the precompiled argmojo.mojoc produced by the
+# packaging step above, rather than recompiling src/argmojo from source
+# into every one of the eight binaries.  Measured on this repo, that is
+# roughly 10% off the total.
+#
+# `date +%s` only has whole-second resolution, which rounds a 5.4 s build
+# and a 5.6 s build to different integers while hiding real differences
+# inside a second.  Python gives sub-second numbers so the summary can
+# actually be compared between runs.
 build_one() {
     local name="$1" src="$2"
     local t0 t1 elapsed
-    t0=$(date +%s)
-    mojo build -I src "$src" -o "$name"
-    t1=$(date +%s)
-    elapsed=$((t1 - t0))
+    t0=$(python3 -c 'import time; print(time.time())')
+    mojo build -I . "$src" -o "$name"
+    t1=$(python3 -c 'import time; print(time.time())')
+    elapsed=$(python3 -c "print(f'{$t1 - $t0:.2f}')")
     TIMES+=("$name:${elapsed}s")
 }
 
@@ -76,12 +85,19 @@ print_summary() {
     echo "├────────────┬─────────────────────────────┤"
     printf "│ %-10s │ %-27s │\n" "Example" "Compile time"
     echo "├────────────┼─────────────────────────────┤"
-    local entry
+    local entry total=0
     for entry in "${TIMES[@]}"; do
         local n="${entry%%:*}"
         local t="${entry#*:}"
         printf "│ %-10s │ %27s │\n" "$n" "$t"
+        total=$(python3 -c "print(f'{$total + ${t%s}:.2f}')")
     done
+    if [ "${#TIMES[@]}" -gt 1 ]; then
+        echo "├────────────┼─────────────────────────────┤"
+        printf "│ %-10s │ %27s │\n" "total" "${total}s"
+        printf "│ %-10s │ %27s │\n" "mean" \
+            "$(python3 -c "print(f'{$total / ${#TIMES[@]}:.2f}s')")"
+    fi
     echo "└────────────┴─────────────────────────────┘"
 }
 

--- a/src/argmojo/argument.mojo
+++ b/src/argmojo/argument.mojo
@@ -125,8 +125,11 @@ struct Argument(Copyable, Movable, Writable):
     """If True, this option requires ``--key=value`` syntax;
     ``--key value`` (space-separated) is not allowed."""
     var _allow_hyphen_values: Bool
-    """If True, the literal token ``-`` is accepted as a valid value for
-    this argument (conventionally meaning stdin/stdout)."""
+    """If True, any token starting with ``-`` is accepted as a value for
+    this argument — not only the bare ``-`` that conventionally means
+    stdin/stdout.  This also switches off the safety check that otherwise
+    refuses a value matching a registered option, so ``--output --verbose``
+    stores ``"--verbose"`` instead of raising."""
     var _is_persistent: Bool
     """If True, this argument is automatically inherited by every subcommand.
     Persistent flags/options are injected into child command parsers at
@@ -531,6 +534,15 @@ struct Argument(Copyable, Movable, Writable):
         remainder argument are **not** parsed as options; they are stored
         verbatim.
 
+        If the remainder is the **first** positional (no other positional
+        is declared before it), collection starts at the very first token,
+        so ``--help`` and ``--version`` are swallowed as remainder values
+        too and no help is printed.  That is the point of a wrapper command
+        such as ``env`` or ``nohup``, but it does mean the user has no way
+        to ask for help by flag.  Declare at least one positional ahead of
+        the remainder, or call ``help_on_no_arguments()`` so that the bare
+        command still prints help.
+
         Examples::
 
             # myapp build -- -Wall -O2 src/main.c
@@ -801,6 +813,15 @@ struct Argument(Copyable, Movable, Writable):
         any other dash-prefixed literal value.
 
         Can be used on positional arguments and value-taking options.
+
+        Without this, a dash-prefixed token is still accepted as a value
+        when it cannot be an option — a negative number such as ``-5``, or
+        an unregistered token such as ``-foo``.  What the default rejects
+        is a value that *is* a registered option (``--output --verbose``)
+        or the ``--`` separator, because that is nearly always a forgotten
+        value rather than an intended one.  Enabling this method turns that
+        rejection off, so use it only where dash-prefixed values are
+        genuinely expected.
 
         Examples::
 

--- a/src/argmojo/argument_wrappers.mojo
+++ b/src/argmojo/argument_wrappers.mojo
@@ -219,6 +219,17 @@ struct Option[
             comptime assert (
                 Self.range_min <= Self.range_max
             ), "Option range_min must be <= range_max"
+
+        # 2. Range validation is integer-only: `_validate` parses the value
+        #    with `atol` and holds the bounds as `Int`.  A Float64 value
+        #    would be rejected at runtime as "not an integer", so refuse the
+        #    combination here where the message can point at the cause.
+        comptime if Self.has_range:
+            comptime assert reflect[Self.T].name() != reflect[Float64].name(), (
+                "Option[Float64] cannot use has_range: range validation is"
+                " integer-only.  Drop has_range, or use Int."
+            )
+
         comptime if Self.choices != "" and Self.default != "":
             comptime assert ("," + Self.choices + ",").find(
                 "," + Self.default + ","
@@ -314,14 +325,16 @@ struct Option[
             self.value = rebind[Self.T](result.get_map(field_name)).copy()
         elif type_name == reflect[Int].name():
             self.value = rebind[Self.T](result.get_int(field_name)).copy()
+        elif type_name == reflect[Float64].name():
+            self.value = rebind[Self.T](result.get_float(field_name)).copy()
         elif type_name == reflect[String].name():
             self.value = rebind[Self.T](result.get_string(field_name)).copy()
         else:
             comptime assert False, (
                 "Unsupported Option[T] type in read_from_result: "
                 + reflect[Self.T].name()
-                + ". Supported: String, Int, List[String], Dict[String,"
-                " String]."
+                + ". Supported: String, Int, Float64, List[String],"
+                " Dict[String, String]."
             )
 
 
@@ -336,6 +349,7 @@ struct Flag[
     long: StringLiteral = "",
     short: StringLiteral = "",
     help: StringLiteral = "",
+    alias_name: StringLiteral = "",
     # -- Argument type --
     negatable: Bool = False,
     # -- Parsing behaviour --
@@ -354,6 +368,7 @@ struct Flag[
         long: Long flag name. Empty = auto from field name.
         short: Short flag character.
         help: Help text shown in ``--help`` output.
+        alias_name: Comma-separated alias long names.
         negatable: If True, generate ``--flag`` / ``--no-flag`` pair.
         persistent: Inherited by subcommands.
         hidden: Hide from help output.
@@ -448,6 +463,9 @@ struct Flag[
         argument._long_name = long_name
         comptime if Self.short != "":
             argument._short_name = String(Self.short)
+        comptime if Self.alias_name != "":
+            for a in String(Self.alias_name).split(","):
+                argument._alias_names.append(String(a))
         comptime if Self.negatable:
             argument._is_negatable = True
         comptime if Self.persistent:
@@ -490,11 +508,21 @@ struct Positional[
     default: StringLiteral = "",
     required: Bool = False,
     choices: StringLiteral = "",
+    range_min: Int = 0,
+    range_max: Int = 0,
+    has_range: Bool = False,
+    clamp: Bool = False,
     # -- Parsing behaviour --
     allow_hyphen: Bool = False,
     # -- Display & help --
     value_name: StringLiteral = "",
+    hidden: Bool = False,
+    deprecated: StringLiteral = "",
     group: StringLiteral = "",
+    # -- Interactive prompting --
+    prompt: Bool = False,
+    prompt_text: StringLiteral = "",
+    password: Bool = False,
 ](ArgumentLike, Copyable, Defaultable, Movable):
     """A positional argument (matched by order, not by name).
 
@@ -509,9 +537,18 @@ struct Positional[
         default: Default value as a string literal.
         required: If True, the positional must be provided.
         choices: Comma-separated allowed values.
+        range_min: Minimum numeric value (requires ``has_range=True``).
+        range_max: Maximum numeric value (requires ``has_range=True``).
+        has_range: Enable range validation.
+        clamp: Clamp to range instead of raising an error.
         allow_hyphen: Allow hyphen-prefixed values.
         value_name: Display name in help.
+        hidden: Hide from help output.
+        deprecated: Deprecation warning message.
         group: Help group heading.
+        prompt: Interactively prompt if missing.
+        prompt_text: Custom prompt message.
+        password: Mask input when prompting.
 
     Examples:
 
@@ -577,6 +614,22 @@ struct Positional[
                 + "'"
             )
 
+        # 2. Range bounds must be ordered.
+        comptime if Self.has_range:
+            comptime assert (
+                Self.range_min <= Self.range_max
+            ), "Positional range_min must be <= range_max"
+
+        # 3. Range validation is integer-only: `_validate` parses the value
+        #    with `atol` and holds the bounds as `Int`.  A Float64 value
+        #    would be rejected at runtime as "not an integer", so refuse the
+        #    combination here where the message can point at the cause.
+        comptime if Self.has_range:
+            comptime assert reflect[Self.T].name() != reflect[Float64].name(), (
+                "Positional[Float64] cannot use has_range: range validation is"
+                " integer-only.  Drop has_range, or use Int."
+            )
+
         # == Translate fields of the wrapper struct into Argument properties ==
         var argument = Argument(field_name, help=String(Self.help)).positional()
         comptime if Self.remainder:
@@ -590,12 +643,30 @@ struct Positional[
         comptime if Self.choices != "":
             for c in String(Self.choices).split(","):
                 argument._choice_values.append(String(c))
+        comptime if Self.has_range:
+            argument._has_range = True
+            argument._range_min = Self.range_min
+            argument._range_max = Self.range_max
+        comptime if Self.clamp:
+            argument._is_clamp = True
         comptime if Self.allow_hyphen:
             argument._allow_hyphen_values = True
         comptime if Self.value_name != "":
             argument._value_name = String(Self.value_name)
+        comptime if Self.hidden:
+            argument._is_hidden = True
+        comptime if Self.deprecated != "":
+            argument._deprecated_msg = String(Self.deprecated)
         comptime if Self.group != "":
             argument._group = String(Self.group)
+        comptime if Self.prompt:
+            argument._prompt = True
+        comptime if Self.prompt_text != "":
+            argument._prompt = True
+            argument._prompt_text = String(Self.prompt_text)
+        comptime if Self.password:
+            argument._prompt = True
+            argument._hide_input = True
         command.add_argument(argument^)
 
     def read_from_result(
@@ -619,13 +690,15 @@ struct Positional[
             self.value = rebind[Self.T](result.get_list(field_name)).copy()
         elif type_name == reflect[Int].name():
             self.value = rebind[Self.T](result.get_int(field_name)).copy()
+        elif type_name == reflect[Float64].name():
+            self.value = rebind[Self.T](result.get_float(field_name)).copy()
         elif type_name == reflect[String].name():
             self.value = rebind[Self.T](result.get_string(field_name)).copy()
         else:
             comptime assert False, (
                 "Unsupported Positional[T] type in read_from_result: "
                 + reflect[Self.T].name()
-                + ". Supported: String, Int, List[String]."
+                + ". Supported: String, Int, Float64, List[String]."
             )
 
 
@@ -640,25 +713,39 @@ struct Count[
     long: StringLiteral = "",
     short: StringLiteral = "",
     help: StringLiteral = "",
+    alias_name: StringLiteral = "",
     # -- Argument type --
     max: Int = 0,
     # -- Parsing behaviour --
     persistent: Bool = False,
     # -- Display & help --
     hidden: Bool = False,
+    deprecated: StringLiteral = "",
     group: StringLiteral = "",
-](ArgumentLike, Copyable, Defaultable, Movable):
+](ArgumentLike, Copyable, Defaultable, Intable, Movable):
     """A count flag (each occurrence increments the value).
 
     Commonly used for verbosity: ``-v`` -> 1, ``-vv`` -> 2, ``-vvv`` -> 3.
-    Set ``max`` to cap the count (0 means no ceiling).
+
+    Provides ``__int__`` so you can write ``Int(args.verbose)`` instead of
+    ``args.verbose.value``.
+
+    ``max`` caps the count: 0 means no ceiling, and occurrences beyond the
+    ceiling are clamped to it with a warning.  It is described here rather
+    than in the Parameters block below because ``mojo doc`` (v1.0.0) does
+    not recognise a parameter named ``max`` — it reports "unknown parameter"
+    and then miscounts the indices of every parameter after it.  Renaming
+    the parameter would fix the tooling complaint at the cost of breaking
+    every ``Count[..., max=N]`` already written, so the name stays.
 
     Parameters:
         long: Long flag name. Empty = auto from field name.
         short: Short flag character.
         help: Help text shown in ``--help`` output.
+        alias_name: Comma-separated alias long names.
         persistent: Inherited by subcommands.
         hidden: Hide from help output.
+        deprecated: Deprecation warning message.
         group: Help group heading.
 
     Examples:
@@ -688,6 +775,17 @@ struct Count[
             val: The initial count value.
         """
         self.value = val
+
+    def __int__(self) -> Int:
+        """Returns the count, so ``Int(args.verbose)`` works directly.
+
+        Mirrors ``Flag.__bool__``: the wrapper should not force
+        ``args.verbose.value`` on every use.
+
+        Returns:
+            The number of times the flag was given.
+        """
+        return self.value
 
     def __init__(out self, *, copy: Self):
         """Copies from an existing instance.
@@ -739,6 +837,9 @@ struct Count[
         argument._long_name = long_name
         comptime if Self.short != "":
             argument._short_name = String(Self.short)
+        comptime if Self.alias_name != "":
+            for a in String(Self.alias_name).split(","):
+                argument._alias_names.append(String(a))
         comptime if Self.max > 0:
             argument._has_count_max = True
             argument._count_max = Self.max
@@ -746,6 +847,8 @@ struct Count[
             argument._is_persistent = True
         comptime if Self.hidden:
             argument._is_hidden = True
+        comptime if Self.deprecated != "":
+            argument._deprecated_msg = String(Self.deprecated)
         comptime if Self.group != "":
             argument._group = String(Self.group)
         command.add_argument(argument^)

--- a/src/argmojo/command.mojo
+++ b/src/argmojo/command.mojo
@@ -34,7 +34,9 @@ from .utils import (
     _restore_echo,
     _fullwidth_to_halfwidth,
     _has_fullwidth_chars,
+    _is_bool_literal,
     _looks_like_number,
+    _parse_bool_literal,
     _resolve_color,
     _section_desc_layout,
     _split_on_fullwidth_spaces,
@@ -111,11 +113,11 @@ def _read_response_file(
     docstring for rationale.
     """
     if depth >= max_depth:
-        var msg = (
-            "Response file nesting too deep (max "
-            + String(max_depth)
-            + "): "
-            + filepath
+        var msg = String(
+            "Response file nesting too deep (max ",
+            String(max_depth),
+            "): ",
+            filepath,
         )
         print("error: " + command_name + ": " + msg, file=stderr)
         raise Error(msg)
@@ -570,85 +572,264 @@ struct Command(Copyable, Movable, Writable):
             and not self._allow_positional_with_subcommands
         ):
             raise Error(
-                "Cannot add positional argument '"
-                + argument.name
-                + "' to '"
-                + self.name
-                + "' which already has subcommands. Call"
-                " allow_positional_with_subcommands() to opt in"
+                String(
+                    "Cannot add positional argument '",
+                    argument.name,
+                    "' to '",
+                    self.name,
+                    (
+                        "' which already has subcommands. Call"
+                        " allow_positional_with_subcommands() to opt in"
+                    ),
+                )
             )
         # Guard: require_equals / default_if_no_value + multi-value is unsupported.
         if (
             argument._require_equals or argument._has_default_if_no_value
         ) and argument._number_of_values > 0:
             raise Error(
-                "Argument '"
-                + argument.name
-                + "': .require_equals() / .default_if_no_value() cannot be"
-                " combined with .number_of_values[N]() (multi-value options)"
+                String(
+                    "Argument '",
+                    argument.name,
+                    (
+                        "': .require_equals() / .default_if_no_value() cannot"
+                        " be combined with .number_of_values[N]() (multi-value"
+                        " options)"
+                    ),
+                )
             )
         # Guard: remainder must not be combined with long/short (it is positional-only).
         if argument._is_remainder and (
             argument._long_name or argument._short_name
         ):
             raise Error(
-                "Argument '"
-                + argument.name
-                + "': .remainder() is for positional arguments only; remove"
-                " .long() / .short()"
+                String(
+                    "Argument '",
+                    argument.name,
+                    (
+                        "': .remainder() is for positional arguments only;"
+                        " remove .long() / .short()"
+                    ),
+                )
             )
         # Guard: at most one remainder positional is allowed.
         if argument._is_remainder:
             for _ri in range(len(self.arguments)):
                 if self.arguments[_ri]._is_remainder:
                     raise Error(
-                        "Argument '"
-                        + argument.name
-                        + "': only one .remainder() positional is allowed"
-                        " (already set on '"
-                        + self.arguments[_ri].name
-                        + "')"
+                        String(
+                            "Argument '",
+                            argument.name,
+                            (
+                                "': only one .remainder() positional is allowed"
+                                " (already set on '"
+                            ),
+                            self.arguments[_ri].name,
+                            "')",
+                        )
                     )
         # Guard: no positional may be added after a remainder.
         if argument._is_positional and not argument._is_remainder:
             for _ri in range(len(self.arguments)):
                 if self.arguments[_ri]._is_remainder:
                     raise Error(
-                        "Argument '"
-                        + argument.name
-                        + "': cannot add a positional argument after"
-                        " a .remainder() positional ('"
-                        + self.arguments[_ri].name
-                        + "')"
+                        String(
+                            "Argument '",
+                            argument.name,
+                            (
+                                "': cannot add a positional argument after"
+                                " a .remainder() positional ('"
+                            ),
+                            self.arguments[_ri].name,
+                            "')",
+                        )
                     )
         # Guard: .prompt() conflicts with help_on_no_arguments().
         if argument._prompt and self._help_on_no_arguments:
             raise Error(
-                "Argument '"
-                + argument.name
-                + "': .prompt() cannot be used on a command with"
-                " help_on_no_arguments() — when no arguments are"
-                " provided, help is shown and prompting never runs."
-                " Remove help_on_no_arguments() or .prompt()"
+                String(
+                    "Argument '",
+                    argument.name,
+                    (
+                        "': .prompt() cannot be used on a command with"
+                        " help_on_no_arguments() — when no arguments are"
+                        " provided, help is shown and prompting never runs."
+                        " Remove help_on_no_arguments() or .prompt()"
+                    ),
+                )
             )
         # Guard: .password() only makes sense on value-taking arguments.
         if argument._hide_input and (argument._is_flag or argument._is_count):
             raise Error(
-                "Argument '"
-                + argument.name
-                + "': .password() cannot be used on a flag or count"
-                " argument — it only applies to value-taking arguments"
+                String(
+                    "Argument '",
+                    argument.name,
+                    (
+                        "': .password() cannot be used on a flag or count"
+                        " argument — it only applies to value-taking arguments"
+                    ),
+                )
             )
+        # Guard: the default value has to make sense for the argument kind.
+        # Checking here means a bad default is reported when the developer
+        # registers the argument, not when an end user runs the program.
+        if argument._has_default:
+            if len(argument._choice_values) > 0:
+                var default_allowed = False
+                for _ci in range(len(argument._choice_values)):
+                    if argument._choice_values[_ci] == argument._default_value:
+                        default_allowed = True
+                        break
+                if not default_allowed:
+                    var allowed = String("")
+                    for _ci in range(len(argument._choice_values)):
+                        if _ci > 0:
+                            allowed += ", "
+                        allowed += String(
+                            "'", argument._choice_values[_ci], "'"
+                        )
+                    raise Error(
+                        String(
+                            "Argument '",
+                            argument.name,
+                            "': default value '",
+                            argument._default_value,
+                            "' is not one of the choices (",
+                            allowed,
+                            ")",
+                        )
+                    )
+            if argument._is_count:
+                try:
+                    _ = atol(argument._default_value)
+                except:
+                    raise Error(
+                        String(
+                            "Argument '",
+                            argument.name,
+                            "': .count() default must be an integer, got '",
+                            argument._default_value,
+                            "'",
+                        )
+                    )
+            elif argument._is_flag and not _is_bool_literal(
+                argument._default_value
+            ):
+                raise Error(
+                    String(
+                        "Argument '",
+                        argument.name,
+                        (
+                            "': .flag() default must be a boolean literal"
+                            " (true/false, 1/0, yes/no, on/off), got '"
+                        ),
+                        argument._default_value,
+                        "'",
+                    )
+                )
+            elif argument._is_map and argument._default_value.find("=") < 0:
+                raise Error(
+                    String(
+                        "Argument '",
+                        argument.name,
+                        (
+                            "': .map_option() default must be in key=value"
+                            " form, got '"
+                        ),
+                        argument._default_value,
+                        "'",
+                    )
+                )
+        # Guard: default_if_no_value must also honour the declared choices.
+        if (
+            argument._has_default_if_no_value
+            and len(argument._choice_values) > 0
+        ):
+            var dnv_allowed = False
+            for _ci in range(len(argument._choice_values)):
+                if (
+                    argument._choice_values[_ci]
+                    == argument._default_if_no_value
+                ):
+                    dnv_allowed = True
+                    break
+            if not dnv_allowed:
+                var allowed2 = String("")
+                for _ci in range(len(argument._choice_values)):
+                    if _ci > 0:
+                        allowed2 += ", "
+                    allowed2 += String("'", argument._choice_values[_ci], "'")
+                raise Error(
+                    String(
+                        "Argument '",
+                        argument.name,
+                        "': default_if_no_value '",
+                        argument._default_if_no_value,
+                        "' is not one of the choices (",
+                        allowed2,
+                        ")",
+                    )
+                )
+        # Guard: a persistent argument must not collide with a local argument
+        # of a subcommand that is already registered.  `add_subcommand()` runs
+        # the same check the other way round; without this one the outcome
+        # would depend on the order the two calls happen to be made in, and a
+        # late `.persistent()` argument would be injected on top of the
+        # child's own, showing up twice in its help.
+        if argument._is_persistent:
+            for _si in range(len(self.subcommands)):
+                for _ci in range(len(self.subcommands[_si].arguments)):
+                    ref ca = self.subcommands[_si].arguments[_ci]
+                    if (
+                        argument._long_name
+                        and ca._long_name
+                        and argument._long_name == ca._long_name
+                    ):
+                        raise Error(
+                            String(
+                                "Persistent flag '--",
+                                argument._long_name,
+                                "' on '",
+                                self.name,
+                                "' conflicts with '--",
+                                ca._long_name,
+                                "' on subcommand '",
+                                self.subcommands[_si].name,
+                                "'",
+                            )
+                        )
+                    if (
+                        argument._short_name
+                        and ca._short_name
+                        and argument._short_name == ca._short_name
+                    ):
+                        raise Error(
+                            String(
+                                "Persistent flag '-",
+                                argument._short_name,
+                                "' on '",
+                                self.name,
+                                "' conflicts with '-",
+                                ca._short_name,
+                                "' on subcommand '",
+                                self.subcommands[_si].name,
+                                "'",
+                            )
+                        )
         # Guard: duplicate internal name.
         for _di in range(len(self.arguments)):
             if self.arguments[_di].name == argument.name:
                 raise Error(
-                    "Argument '"
-                    + argument.name
-                    + "': duplicate name — an argument with the same"
-                    " name is already registered on '"
-                    + self.name
-                    + "'"
+                    String(
+                        "Argument '",
+                        argument.name,
+                        (
+                            "': duplicate name — an argument with the same"
+                            " name is already registered on '"
+                        ),
+                        self.name,
+                        "'",
+                    )
                 )
         # Guard: duplicate long name (including alias collisions).
         if argument._long_name:
@@ -658,15 +839,17 @@ struct Command(Copyable, Movable, Writable):
                     and self.arguments[_di]._long_name == argument._long_name
                 ):
                     raise Error(
-                        "Argument '"
-                        + argument.name
-                        + "': duplicate long flag '--"
-                        + argument._long_name
-                        + "' — already used by argument '"
-                        + self.arguments[_di].name
-                        + "' on '"
-                        + self.name
-                        + "'"
+                        String(
+                            "Argument '",
+                            argument.name,
+                            "': duplicate long flag '--",
+                            argument._long_name,
+                            "' — already used by argument '",
+                            self.arguments[_di].name,
+                            "' on '",
+                            self.name,
+                            "'",
+                        )
                     )
                 # Check new argument's long name against existing aliases.
                 for _ai in range(len(self.arguments[_di]._alias_names)):
@@ -675,15 +858,17 @@ struct Command(Copyable, Movable, Writable):
                         == argument._long_name
                     ):
                         raise Error(
-                            "Argument '"
-                            + argument.name
-                            + "': long flag '--"
-                            + argument._long_name
-                            + "' collides with alias of argument '"
-                            + self.arguments[_di].name
-                            + "' on '"
-                            + self.name
-                            + "'"
+                            String(
+                                "Argument '",
+                                argument.name,
+                                "': long flag '--",
+                                argument._long_name,
+                                "' collides with alias of argument '",
+                                self.arguments[_di].name,
+                                "' on '",
+                                self.name,
+                                "'",
+                            )
                         )
         # Guard: new argument's aliases against existing long names and aliases.
         for _ni in range(len(argument._alias_names)):
@@ -694,15 +879,17 @@ struct Command(Copyable, Movable, Writable):
                     == argument._alias_names[_ni]
                 ):
                     raise Error(
-                        "Argument '"
-                        + argument.name
-                        + "': alias '--"
-                        + argument._alias_names[_ni]
-                        + "' collides with long flag of argument '"
-                        + self.arguments[_di].name
-                        + "' on '"
-                        + self.name
-                        + "'"
+                        String(
+                            "Argument '",
+                            argument.name,
+                            "': alias '--",
+                            argument._alias_names[_ni],
+                            "' collides with long flag of argument '",
+                            self.arguments[_di].name,
+                            "' on '",
+                            self.name,
+                            "'",
+                        )
                     )
                 for _ai in range(len(self.arguments[_di]._alias_names)):
                     if (
@@ -710,15 +897,17 @@ struct Command(Copyable, Movable, Writable):
                         == argument._alias_names[_ni]
                     ):
                         raise Error(
-                            "Argument '"
-                            + argument.name
-                            + "': alias '--"
-                            + argument._alias_names[_ni]
-                            + "' collides with alias of argument '"
-                            + self.arguments[_di].name
-                            + "' on '"
-                            + self.name
-                            + "'"
+                            String(
+                                "Argument '",
+                                argument.name,
+                                "': alias '--",
+                                argument._alias_names[_ni],
+                                "' collides with alias of argument '",
+                                self.arguments[_di].name,
+                                "' on '",
+                                self.name,
+                                "'",
+                            )
                         )
         # Guard: duplicate short name.
         if argument._short_name:
@@ -728,15 +917,17 @@ struct Command(Copyable, Movable, Writable):
                     and self.arguments[_di]._short_name == argument._short_name
                 ):
                     raise Error(
-                        "Argument '"
-                        + argument.name
-                        + "': duplicate short flag '-"
-                        + argument._short_name
-                        + "' — already used by argument '"
-                        + self.arguments[_di].name
-                        + "' on '"
-                        + self.name
-                        + "'"
+                        String(
+                            "Argument '",
+                            argument.name,
+                            "': duplicate short flag '-",
+                            argument._short_name,
+                            "' — already used by argument '",
+                            self.arguments[_di].name,
+                            "' on '",
+                            self.name,
+                            "'",
+                        )
                     )
         self.arguments.append(argument^)
 
@@ -777,14 +968,18 @@ struct Command(Copyable, Movable, Writable):
             for _pi in range(len(self.arguments)):
                 if self.arguments[_pi]._is_positional:
                     raise Error(
-                        "Cannot add subcommand '"
-                        + sub.name
-                        + "' to '"
-                        + self.name
-                        + "' which already has positional argument '"
-                        + self.arguments[_pi].name
-                        + "'. Call"
-                        " allow_positional_with_subcommands() to opt in"
+                        String(
+                            "Cannot add subcommand '",
+                            sub.name,
+                            "' to '",
+                            self.name,
+                            "' which already has positional argument '",
+                            self.arguments[_pi].name,
+                            (
+                                "'. Call"
+                                " allow_positional_with_subcommands() to opt in"
+                            ),
+                        )
                     )
         # Conflict check: persistent parent arguments must not share names with
         # any local arg in the child — that would make the option ambiguous
@@ -801,15 +996,17 @@ struct Command(Copyable, Movable, Writable):
                     and pa._long_name == ca._long_name
                 ):
                     raise Error(
-                        "Persistent flag '--"
-                        + pa._long_name
-                        + "' on '"
-                        + self.name
-                        + "' conflicts with '--"
-                        + ca._long_name
-                        + "' on subcommand '"
-                        + sub.name
-                        + "'"
+                        String(
+                            "Persistent flag '--",
+                            pa._long_name,
+                            "' on '",
+                            self.name,
+                            "' conflicts with '--",
+                            ca._long_name,
+                            "' on subcommand '",
+                            sub.name,
+                            "'",
+                        )
                     )
                 if (
                     pa._short_name
@@ -817,15 +1014,17 @@ struct Command(Copyable, Movable, Writable):
                     and pa._short_name == ca._short_name
                 ):
                     raise Error(
-                        "Persistent flag '-"
-                        + pa._short_name
-                        + "' on '"
-                        + self.name
-                        + "' conflicts with '-"
-                        + ca._short_name
-                        + "' on subcommand '"
-                        + sub.name
-                        + "'"
+                        String(
+                            "Persistent flag '-",
+                            pa._short_name,
+                            "' on '",
+                            self.name,
+                            "' conflicts with '-",
+                            ca._short_name,
+                            "' on subcommand '",
+                            sub.name,
+                            "'",
+                        )
                     )
         # Auto-register the 'help' subcommand as the first entry once.
         # This keeps help discoverable at a fixed position (index 0) while
@@ -958,7 +1157,11 @@ struct Command(Copyable, Movable, Writable):
                     break
             if not found:
                 raise Error(
-                    "mutually_exclusive(): unknown argument '" + names[ni] + "'"
+                    String(
+                        "mutually_exclusive(): unknown argument '",
+                        names[ni],
+                        "'",
+                    )
                 )
             unique.append(names[ni])
         self._exclusive_groups.append(unique^)
@@ -1008,7 +1211,11 @@ struct Command(Copyable, Movable, Writable):
                     break
             if not found:
                 raise Error(
-                    "required_together(): unknown argument '" + names[ni] + "'"
+                    String(
+                        "required_together(): unknown argument '",
+                        names[ni],
+                        "'",
+                    )
                 )
             unique.append(names[ni])
         self._required_groups.append(unique^)
@@ -1058,7 +1265,7 @@ struct Command(Copyable, Movable, Writable):
                     break
             if not found:
                 raise Error(
-                    "one_required(): unknown argument '" + names[ni] + "'"
+                    String("one_required(): unknown argument '", names[ni], "'")
                 )
             unique.append(names[ni])
         self._one_required_groups.append(unique^)
@@ -1093,9 +1300,11 @@ struct Command(Copyable, Movable, Writable):
         """
         if target == condition:
             raise Error(
-                "required_if(): target and condition must differ, got '"
-                + target
-                + "'"
+                String(
+                    "required_if(): target and condition must differ, got '",
+                    target,
+                    "'",
+                )
             )
         # Fixed-size, never grown and never escapes: an `Array` keeps this
         # validation scratch buffer inline on the stack (no heap allocation).
@@ -1108,7 +1317,7 @@ struct Command(Copyable, Movable, Writable):
                     break
             if not found:
                 raise Error(
-                    "required_if(): unknown argument '" + checks[ci] + "'"
+                    String("required_if(): unknown argument '", checks[ci], "'")
                 )
         var pair: List[String] = [target, condition]
         self._conditional_reqs.append(pair^)
@@ -1154,7 +1363,9 @@ struct Command(Copyable, Movable, Writable):
                 trigger_found = True
                 break
         if not trigger_found:
-            raise Error("implies(): unknown trigger argument '" + trigger + "'")
+            raise Error(
+                String("implies(): unknown trigger argument '", trigger, "'")
+            )
 
         var implied_found = False
         var implied_kind = String("flag")  # "flag" or "count"
@@ -1165,19 +1376,25 @@ struct Command(Copyable, Movable, Writable):
                     implied_kind = "count"
                 elif not self.arguments[i]._is_flag:
                     raise Error(
-                        "implies(): implied argument '"
-                        + implied
-                        + "' must be a flag() or count()"
+                        String(
+                            "implies(): implied argument '",
+                            implied,
+                            "' must be a flag() or count()",
+                        )
                     )
                 break
         if not implied_found:
-            raise Error("implies(): unknown implied argument '" + implied + "'")
+            raise Error(
+                String("implies(): unknown implied argument '", implied, "'")
+            )
 
         # Cycle detection: check if `trigger` is reachable from `implied`.
         # If so, adding implied→...→trigger would form a cycle.
         if trigger == implied:
             raise Error(
-                "Implication cycle detected: '" + trigger + "' implies itself"
+                String(
+                    "Implication cycle detected: '", trigger, "' implies itself"
+                )
             )
         # DFS from `implied` following existing edges.
         var visited = List[String]()
@@ -1191,11 +1408,13 @@ struct Command(Copyable, Movable, Writable):
                     var target = self._implications[i][1]
                     if target == trigger:
                         raise Error(
-                            "Implication cycle detected: adding '"
-                            + trigger
-                            + "' implies '"
-                            + implied
-                            + "' would create a cycle"
+                            String(
+                                "Implication cycle detected: adding '",
+                                trigger,
+                                "' implies '",
+                                implied,
+                                "' would create a cycle",
+                            )
                         )
                     # Only visit each node once.
                     var already = False
@@ -1344,12 +1563,18 @@ struct Command(Copyable, Movable, Writable):
         for _pi in range(len(self.arguments)):
             if self.arguments[_pi]._prompt:
                 raise Error(
-                    "help_on_no_arguments() cannot be used on a command"
-                    " that has .prompt() arguments (argument '"
-                    + self.arguments[_pi].name
-                    + "'). When no arguments are provided, help is"
-                    " shown and prompting never runs. Remove"
-                    " help_on_no_arguments() or .prompt()"
+                    String(
+                        (
+                            "help_on_no_arguments() cannot be used on a command"
+                            " that has .prompt() arguments (argument '"
+                        ),
+                        self.arguments[_pi].name,
+                        (
+                            "'). When no arguments are provided, help is"
+                            " shown and prompting never runs. Remove"
+                            " help_on_no_arguments() or .prompt()"
+                        ),
+                    )
                 )
         self._help_on_no_arguments = True
 
@@ -1941,11 +2166,13 @@ struct Command(Copyable, Movable, Writable):
                         var corrected = parts[_fw_j]
                         if corrected.startswith("-"):
                             self._warn(
-                                "detected full-width characters in '"
-                                + token
-                                + "', auto-corrected to '"
-                                + corrected
-                                + "'"
+                                String(
+                                    "detected full-width characters in '",
+                                    token,
+                                    "', auto-corrected to '",
+                                    corrected,
+                                    "'",
+                                )
                             )
                         corrected_arguments.append(corrected)
                 else:
@@ -1961,11 +2188,13 @@ struct Command(Copyable, Movable, Writable):
                 var corrected = _correct_cjk_punctuation(token)
                 if corrected != token and corrected.startswith("-"):
                     self._warn(
-                        "detected CJK punctuation in '"
-                        + token
-                        + "', auto-corrected to '"
-                        + corrected
-                        + "'"
+                        String(
+                            "detected CJK punctuation in '",
+                            token,
+                            "', auto-corrected to '",
+                            corrected,
+                            "'",
+                        )
                     )
                     punc_arguments.append(corrected)
                 else:
@@ -2036,9 +2265,9 @@ struct Command(Copyable, Movable, Writable):
                 if self.arguments[i]._is_remainder:
                     display += "..."
                 if self.arguments[i]._is_required:
-                    s += " <" + display + ">"
+                    s += String(" <", display, ">")
                 else:
-                    s += " [" + display + "]"
+                    s += String(" [", display, "]")
         var has_subcommands = False
         for i in range(len(self.subcommands)):
             if (
@@ -2074,7 +2303,7 @@ struct Command(Copyable, Movable, Writable):
         if self._custom_usage:
             return hc + "usage:" + rc + " " + self._custom_usage
 
-        var s = hc + "usage:" + rc + " " + pc + self.name + rc
+        var s = String(hc, "usage:", rc, " ", pc, self.name, rc)
         for i in range(len(self.arguments)):
             if (
                 self.arguments[i]._is_positional
@@ -2084,9 +2313,9 @@ struct Command(Copyable, Movable, Writable):
                 if self.arguments[i]._is_remainder:
                     display += "..."
                 if self.arguments[i]._is_required:
-                    s += " " + posc + "<" + display + ">" + rc
+                    s += String(" ", posc, "<", display, ">", rc)
                 else:
-                    s += " " + posc + "[" + display + "]" + rc
+                    s += String(" ", posc, "[", display, "]", rc)
         var has_subcommands = False
         for i in range(len(self.subcommands)):
             if (
@@ -2096,8 +2325,8 @@ struct Command(Copyable, Movable, Writable):
                 has_subcommands = True
                 break
         if has_subcommands:
-            s += " " + posc + "<COMMAND>" + rc
-        s += " " + lc + "[OPTIONS]" + rc
+            s += String(" ", posc, "<COMMAND>", rc)
+        s += String(" ", lc, "[OPTIONS]", rc)
         return s
 
     # ===------------------------------------------------------------------=== #
@@ -2242,7 +2471,9 @@ struct Command(Copyable, Movable, Writable):
                 if self.subcommands[i].name == result.subcommand:
                     var subcommand_path = result.subcommand
                     if command_path != "":
-                        subcommand_path = command_path + " " + result.subcommand
+                        subcommand_path = String(
+                            command_path, " ", result.subcommand
+                        )
                     if result.has_subcommand_result():
                         self.subcommands[i]._dispatch_with_path(
                             result.get_subcommand_result(), subcommand_path
@@ -2251,15 +2482,19 @@ struct Command(Copyable, Movable, Writable):
                         # Invariant: the parser always creates a child
                         # ParseResult when a subcommand is matched.
                         raise Error(
-                            "Missing parse result for subcommand '"
-                            + subcommand_path
-                            + "'"
+                            String(
+                                "Missing parse result for subcommand '",
+                                subcommand_path,
+                                "'",
+                            )
                         )
                     return
             var missing_path = result.subcommand
             if command_path != "":
-                missing_path = command_path + " " + result.subcommand
-            raise Error("No matching subcommand for '" + missing_path + "'")
+                missing_path = String(command_path, " ", result.subcommand)
+            raise Error(
+                String("No matching subcommand for '", missing_path, "'")
+            )
         # No subcommand — execute this command's handler.
         if self._run_function:
             self._run_function.value()(result)
@@ -2268,7 +2503,11 @@ struct Command(Copyable, Movable, Writable):
             print(self._generate_help())
         else:
             raise Error(
-                "No run function registered for command '" + command_path + "'"
+                String(
+                    "No run function registered for command '",
+                    command_path,
+                    "'",
+                )
             )
 
     # ===------------------------------------------------------------------=== #
@@ -2368,13 +2607,25 @@ struct Command(Copyable, Movable, Writable):
         self._run_parse_loop(tokens_to_parse, result, False)
 
         # === POST-PARSE PHASE === #
-        # Apply defaults, propagate implications, prompt for remaining
-        # values, re-apply implications (in case prompts triggered new
-        # ones), confirm if required, then validate constraints.
-        self._apply_defaults(result)
+        # The order below is load-bearing; each step depends on the last.
+        #
+        # 1. Implications first, so an argument implied by something the user
+        #    typed already has its value before anything asks whether it is
+        #    missing.
+        # 2. Prompting before defaults: `.prompt()` skips any argument that
+        #    already has a value, so filling defaults first would mean an
+        #    argument carrying both `.prompt()` and `.default()` is never
+        #    prompted at all.  With this order the default is what the user
+        #    gets by answering with an empty line.
+        # 3. Implications again, because a prompt answer is user input and can
+        #    trigger a rule the first pass could not see.
+        # 4. Defaults last among the value-filling steps.  Nothing after them
+        #    treats a value as user input, which is exactly the point: a
+        #    default must never fire an implication or satisfy a group.
         self._apply_implications(result)
         self._prompt_missing_arguments(result)
         self._apply_implications(result)
+        self._apply_defaults(result)
         self._confirm(result)
         self._validate(result)
 
@@ -2422,12 +2673,13 @@ struct Command(Copyable, Movable, Writable):
         # unknown-option errors and routes them to ``_unknown_arguments``).
         self._run_parse_loop(tokens_to_parse, result, True)
 
-        # Post-parse: defaults, implications, validation.  Prompting and
-        # confirmation are intentionally skipped — callers of
-        # ``parse_known_arguments`` typically forward unknown options to
-        # a downstream tool and should not be interrupted by prompts.
-        self._apply_defaults(result)
+        # Post-parse: implications, defaults, validation — the same order as
+        # ``parse_arguments`` so that both entry points agree on what counts
+        # as user input.  Prompting and confirmation are intentionally
+        # skipped: callers of ``parse_known_arguments`` typically forward
+        # unknown options to a downstream tool and should not be interrupted.
         self._apply_implications(result)
+        self._apply_defaults(result)
         self._validate(result)
 
         return result^
@@ -2499,6 +2751,12 @@ struct Command(Copyable, Movable, Writable):
 
             # Remainder mode: once the current positional slot is the
             # remainder slot, swallow ALL remaining tokens verbatim.
+            # This sits above the --help/--version branches on purpose: a
+            # remainder is meant to forward the tail of the command line
+            # untouched, so those tokens must not be intercepted.  When the
+            # remainder is the first positional the condition is true from
+            # the start, and the command has no help flag at all — see
+            # `Argument.remainder()`.
             if (
                 remainder_pos_idx >= 0
                 and len(result._positionals) >= remainder_pos_idx
@@ -2534,9 +2792,11 @@ struct Command(Copyable, Movable, Writable):
                     exit(0)
                 else:
                     self._error(
-                        "--"
-                        + self._completions_name
-                        + " requires a shell name: bash, zsh, or fish"
+                        String(
+                            "--",
+                            self._completions_name,
+                            " requires a shell name: bash, zsh, or fish",
+                        )
                     )
                     exit(2)
 
@@ -2655,6 +2915,18 @@ struct Command(Copyable, Movable, Writable):
             result._positionals.append(token)
             i += 1
 
+        # Record which positional slots the user actually filled.  Slot `k`
+        # belongs to `_positional_names[k]`; tokens past the last named slot
+        # belong to the remainder positional, whose own slot is already
+        # marked.  `_apply_defaults` pads `_positionals` with empty strings
+        # later on, which is why provenance has to be captured here.
+        for k in range(len(result._positionals)):
+            if k < len(result._positional_names):
+                # A temporary breaks the aliasing between the mutable `result`
+                # and the name borrowed out of its own list.
+                var pos_name = result._positional_names[k]
+                result._mark_provided(pos_name)
+
     def _parse_long_option(
         self, raw_tokens: List[String], start: Int, mut result: ParseResult
     ) raises -> Int:
@@ -2687,6 +2959,15 @@ struct Command(Copyable, Movable, Writable):
             var key_part = String(key[byte=:eq_pos])
             key = key_part^
             has_eq = True
+
+        # An empty name (`--` followed by nothing but `=value`) matches no
+        # option. Without this guard the lookup below compares against
+        # `_long_name == ""`, which is true for every positional and every
+        # short-only option, so `--=x` would silently bind to one of them.
+        if key.byte_length() == 0:
+            self._error(
+                String("Invalid option '", token, "': missing option name")
+            )
 
         # Check for --no-X negation pattern (with prefix matching).
         var is_negation = False
@@ -2721,35 +3002,42 @@ struct Command(Copyable, Movable, Writable):
                     for j in range(len(neg_candidates)):
                         if j > 0:
                             opts += ", "
-                        opts += "'--no-" + neg_candidates[j] + "'"
+                        opts += String("'--no-", neg_candidates[j], "'")
                     self._error(
-                        "Ambiguous option '--no-"
-                        + base_key
-                        + "' could match: "
-                        + opts
+                        String(
+                            "Ambiguous option '--no-",
+                            base_key,
+                            "' could match: ",
+                            opts,
+                        )
                     )
 
-        var matched: Argument = self._find_by_long(key)
+        var matched_idx = self._find_index_by_long(key)
+        ref matched = self.arguments[matched_idx]
         # Emit deprecation warning if applicable.
         if matched._deprecated_msg:
             self._warn(
-                "'--" + key + "' is deprecated: " + matched._deprecated_msg
+                String("'--", key, "' is deprecated: ", matched._deprecated_msg)
             )
         if is_negation:
             result._flags[matched.name] = False
+            result._mark_provided(matched.name)
         elif matched._is_count and not has_eq:
             Self._increment_count(matched.name, result)
         elif matched._is_flag and not has_eq:
             result._flags[matched.name] = True
+            result._mark_provided(matched.name)
         elif matched._number_of_values > 0:
             # nargs: consume exactly N values.
             if has_eq:
                 self._error(
-                    "Option '--"
-                    + key
-                    + "' takes "
-                    + String(matched._number_of_values)
-                    + " values; '=' syntax is not supported"
+                    String(
+                        "Option '--",
+                        key,
+                        "' takes ",
+                        String(matched._number_of_values),
+                        " values; '=' syntax is not supported",
+                    )
                 )
             i = self._consume_nargs(matched, raw_tokens, i, "--" + key, result)
         else:
@@ -2760,16 +3048,23 @@ struct Command(Copyable, Movable, Writable):
                         value = matched._default_if_no_value
                     else:
                         self._error(
-                            "Option '--"
-                            + key
-                            + "' requires '=' syntax (use --"
-                            + key
-                            + "=VALUE)"
+                            String(
+                                "Option '--",
+                                key,
+                                "' requires '=' syntax (use --",
+                                key,
+                                "=VALUE)",
+                            )
                         )
                 else:
                     i += 1
                     if i >= len(raw_tokens):
-                        self._error("Option '--" + key + "' requires a value")
+                        self._error(
+                            String("Option '--", key, "' requires a value")
+                        )
+                    self._reject_option_as_value(
+                        matched, "--" + key, raw_tokens[i]
+                    )
                     value = raw_tokens[i]
             self._store_scalar_value(matched, value, result)
         i += 1
@@ -2794,16 +3089,18 @@ struct Command(Copyable, Movable, Writable):
             The index of the next token to process.
         """
         var i = start
-        var matched = self._find_by_short(key)
+        var matched_idx = self._find_index_by_short(key)
+        ref matched = self.arguments[matched_idx]
         # Emit deprecation warning if applicable.
         if matched._deprecated_msg:
             self._warn(
-                "'-" + key + "' is deprecated: " + matched._deprecated_msg
+                String("'-", key, "' is deprecated: ", matched._deprecated_msg)
             )
         if matched._is_count:
             Self._increment_count(matched.name, result)
         elif matched._is_flag:
             result._flags[matched.name] = True
+            result._mark_provided(matched.name)
         elif matched._number_of_values > 0:
             # nargs: consume exactly N values.
             i = self._consume_nargs(matched, raw_tokens, i, "-" + key, result)
@@ -2815,7 +3112,8 @@ struct Command(Copyable, Movable, Writable):
             else:
                 i += 1
                 if i >= len(raw_tokens):
-                    self._error("Option '-" + key + "' requires a value")
+                    self._error(String("Option '-", key, "' requires a value"))
+                self._reject_option_as_value(matched, "-" + key, raw_tokens[i])
                 val = raw_tokens[i]
             self._store_scalar_value(matched, val, result)
         i += 1
@@ -2849,7 +3147,8 @@ struct Command(Copyable, Movable, Writable):
         """
         var i = start
         var first_char = String(key[byte=0:1])
-        var first_match = self._find_by_short(first_char)
+        var first_match_idx = self._find_index_by_short(first_char)
+        ref first_match = self.arguments[first_match_idx]
 
         if first_match._is_flag:
             # First char is a flag — treat entire string as merged
@@ -2857,17 +3156,19 @@ struct Command(Copyable, Movable, Writable):
             var j: Int = 0
             while j < key.byte_length():
                 var ch = String(key[byte = j : j + 1])
-                var m = self._find_by_short(ch)
+                var m_idx = self._find_index_by_short(ch)
+                ref m = self.arguments[m_idx]
                 # Emit deprecation warning if applicable.
                 if m._deprecated_msg:
                     self._warn(
-                        "'-" + ch + "' is deprecated: " + m._deprecated_msg
+                        String("'-", ch, "' is deprecated: ", m._deprecated_msg)
                     )
                 if m._is_count:
                     Self._increment_count(m.name, result)
                     j += 1
                 elif m._is_flag:
                     result._flags[m.name] = True
+                    result._mark_provided(m.name)
                     j += 1
                 elif m._number_of_values > 0:
                     # nargs in merged flags: rest of string is
@@ -2887,8 +3188,13 @@ struct Command(Copyable, Movable, Writable):
                             i += 1
                             if i >= len(raw_tokens):
                                 self._error(
-                                    "Option '-" + ch + "' requires a value"
+                                    String(
+                                        "Option '-", ch, "' requires a value"
+                                    )
                                 )
+                            self._reject_option_as_value(
+                                m, "-" + ch, raw_tokens[i]
+                            )
                             val = raw_tokens[i]
                     self._store_scalar_value(m, val, result)
                     j = key.byte_length()  # break
@@ -2898,10 +3204,12 @@ struct Command(Copyable, Movable, Writable):
             # Emit deprecation warning if applicable.
             if first_match._deprecated_msg:
                 self._warn(
-                    "'-"
-                    + first_char
-                    + "' is deprecated: "
-                    + first_match._deprecated_msg
+                    String(
+                        "'-",
+                        first_char,
+                        "' is deprecated: ",
+                        first_match._deprecated_msg,
+                    )
                 )
             if first_match._number_of_values > 0:
                 # nargs: consume N values from argv (ignore attached).
@@ -2966,9 +3274,34 @@ struct Command(Copyable, Movable, Writable):
             # are recognised wherever the user places them on the line.
             var child_copy = self.subcommands[sub_idx].copy()
             # Set full command path so child help/errors show "app sub".
-            child_copy.name = self.name + " " + canon
+            child_copy.name = String(self.name, " ", canon)
             for _pi in range(len(self.arguments)):
-                if self.arguments[_pi]._is_persistent:
+                if not self.arguments[_pi]._is_persistent:
+                    continue
+                # Skip injection when the child declares the same argument
+                # itself: appending here bypasses `add_argument`, so a
+                # duplicate would survive as far as help output and prefix
+                # matching.  Registration-time checks in `add_argument` and
+                # `add_subcommand` normally prevent this; paths that copy
+                # commands around (e.g. `add_parent`) can still reach it.
+                var already_owned = False
+                for _ci in range(len(child_copy.arguments)):
+                    ref ca = child_copy.arguments[_ci]
+                    if (
+                        ca.name == self.arguments[_pi].name
+                        or (
+                            ca._long_name
+                            and ca._long_name == self.arguments[_pi]._long_name
+                        )
+                        or (
+                            ca._short_name
+                            and ca._short_name
+                            == self.arguments[_pi]._short_name
+                        )
+                    ):
+                        already_owned = True
+                        break
+                if not already_owned:
                     child_copy.arguments.append(self.arguments[_pi].copy())
             var child_result = child_copy.parse_arguments(child_argv)
             # Bubble up persistent values from child to root result so
@@ -2996,6 +3329,12 @@ struct Command(Copyable, Movable, Writable):
                     child_result._values[_pn] = result._values[_pn]
                 if _pn in result._counts and _pn not in child_result._counts:
                     child_result._counts[_pn] = result._counts[_pn]
+                # Keep provenance in sync in both directions, so that group
+                # constraints on either side see the same picture.
+                if child_result.was_provided(_pn):
+                    result._mark_provided(_pn)
+                if result.was_provided(_pn):
+                    child_result._mark_provided(_pn)
             result.subcommand = canon
             result._subcommand_results.append(child_result^)
             # All remaining tokens were consumed by the child.
@@ -3028,7 +3367,7 @@ struct Command(Copyable, Movable, Writable):
                 #     tip: a similar subcommand exists: 'bar'
                 #
                 #   usage: prog <COMMAND> [OPTIONS]
-                var err_msg = "unrecognized subcommand '" + token + "'"
+                var err_msg = String("unrecognized subcommand '", token, "'")
                 if Self._no_color_env():
                     print(
                         "error: " + err_msg,
@@ -3150,7 +3489,7 @@ struct Command(Copyable, Movable, Writable):
             return
 
         for j in range(len(self.arguments)):
-            var a = self.arguments[j].copy()
+            ref a = self.arguments[j]
             if not a._prompt:
                 continue
             if result.has(a.name):
@@ -3176,7 +3515,7 @@ struct Command(Copyable, Movable, Writable):
 
             # Show default if available.
             if a._has_default:
-                msg += " (" + a._default_value + ")"
+                msg += String(" (", a._default_value, ")")
 
             # Flags get a y/n hint.
             if a._is_flag:
@@ -3221,6 +3560,9 @@ struct Command(Copyable, Movable, Writable):
             if value.byte_length() == 0:
                 # Empty input — fall through to _apply_defaults.
                 continue
+            # An answer typed at a prompt is user input, just like a token on
+            # the command line.
+            result._mark_provided(a.name)
             if a._is_flag:
                 var lower = value.lower()
                 if (
@@ -3239,18 +3581,22 @@ struct Command(Copyable, Movable, Writable):
                     result._flags[a.name] = False
                 else:
                     self._warn(
-                        "Invalid input for flag '"
-                        + a.name
-                        + "': expected y/n, got '"
-                        + value
-                        + "'"
+                        String(
+                            "Invalid input for flag '",
+                            a.name,
+                            "': expected y/n, got '",
+                            value,
+                            "'",
+                        )
                     )
             elif a._is_count:
                 try:
                     result._counts[a.name] = Int(atol(value))
                 except:
                     self._warn(
-                        "Invalid count for '" + a.name + "': '" + value + "'"
+                        String(
+                            "Invalid count for '", a.name, "': '", value, "'"
+                        )
                     )
             elif a._is_positional:
                 # Fill the correct positional slot.
@@ -3274,21 +3620,30 @@ struct Command(Copyable, Movable, Writable):
     # Defaults & validation helpers (extracted for subcommand reuse)
     # ===------------------------------------------------------------------=== #
 
-    def _apply_defaults(self, mut result: ParseResult):
+    def _apply_defaults(self, mut result: ParseResult) raises:
         """Fills in default values for arguments not provided by the user.
 
-        For positional arguments, defaults are placed into the correct slot.
-        For named arguments, the default is stored in ``result._values``.
+        The default is written into the same storage that the argument's own
+        accessor reads from — ``_flags`` for a flag, ``_counts`` for a
+        counter, ``_lists`` / ``_maps`` for a collecting option, the matching
+        slot for a positional, and ``_values`` for a plain option.  Storing
+        every default in ``_values`` would leave ``get_flag()`` and
+        ``get_list()`` blind to it.  ``add_argument()`` has already checked
+        that the default text makes sense for the argument kind.
 
         Args:
             result: The parse result to mutate in-place.
+
+        Raises:
+            Error if a default value cannot be stored (e.g. a malformed
+            ``key=value`` default on a map argument).
 
         Notes:
 
         This method is made standalone so that subcommands can reuse it.
         """
         for j in range(len(self.arguments)):
-            var a = self.arguments[j].copy()
+            ref a = self.arguments[j]
             if a._has_default and not result.has(a.name):
                 if a._is_positional:
                     # Fill positional to the right slot.
@@ -3298,6 +3653,16 @@ struct Command(Copyable, Movable, Writable):
                                 result._positionals.append("")
                             if not result._positionals[k]:
                                 result._positionals[k] = a._default_value
+                elif a._is_count:
+                    result._counts[a.name] = Int(atol(a._default_value))
+                elif a._is_flag:
+                    result._flags[a.name] = _parse_bool_literal(
+                        a._default_value
+                    )
+                elif a._is_map:
+                    self._store_map_value(a, a._default_value, result)
+                elif a._is_append or a._number_of_values > 0:
+                    self._store_append_value(a, a._default_value, result)
                 else:
                     result._values[a.name] = a._default_value
 
@@ -3341,11 +3706,18 @@ struct Command(Copyable, Movable, Writable):
                 var trigger = self._implications[i][0]
                 var implied = self._implications[i][1]
                 var kind = self._implications[i][2]  # "flag" or "count"
-                if result.has(trigger) and not result.has(implied):
+                # `was_provided`, not `has`: a value that only came from
+                # `.default()` is not the user asking for the trigger, and
+                # firing on it would mark the implied argument as supplied
+                # and break every group constraint that reads it.
+                if result.was_provided(trigger) and not result.has(implied):
                     if kind == "count":
                         result._counts[implied] = 1
                     else:
                         result._flags[implied] = True
+                    # An implied argument counts as supplied: the user asked
+                    # for it indirectly, by way of the trigger.
+                    result._mark_provided(implied)
                     changed = True
 
     def _validate(self, mut result: ParseResult) raises:
@@ -3367,12 +3739,19 @@ struct Command(Copyable, Movable, Writable):
         Raises:
             Error if any validation check fails.
         """
-        # Validate required arguments.
+        # Validate required arguments.  A declared default still satisfies
+        # the requirement (as in clap); what no longer satisfies it is an
+        # empty positional slot padded by `_apply_defaults` on behalf of a
+        # later positional that does have one.
         for j in range(len(self.arguments)):
-            var a = self.arguments[j].copy()
-            if a._is_required and not result.has(a.name):
+            ref a = self.arguments[j]
+            if (
+                a._is_required
+                and not a._has_default
+                and not result.was_provided(a.name)
+            ):
                 self._error_with_usage(
-                    "Required argument '" + a.name + "' was not provided"
+                    String("Required argument '", a.name, "' was not provided")
                 )
 
         # Validate positional argument count — too many arguments is an error.
@@ -3390,10 +3769,12 @@ struct Command(Copyable, Movable, Writable):
             and not has_remainder
         ):
             self._error_with_usage(
-                "Too many positional arguments: expected "
-                + String(expected_count)
-                + ", got "
-                + String(len(result._positionals))
+                String(
+                    "Too many positional arguments: expected ",
+                    String(expected_count),
+                    ", got ",
+                    String(len(result._positionals)),
+                )
             )
 
         # Validate mutually exclusive groups.
@@ -3401,7 +3782,7 @@ struct Command(Copyable, Movable, Writable):
             var found = List[String]()
             for n in range(len(self._exclusive_groups[g])):
                 var argument_name = self._exclusive_groups[g][n]
-                if result.has(argument_name):
+                if result.was_provided(argument_name):
                     found.append(argument_name)
             if len(found) > 1:
                 var names_str = String("")
@@ -3417,7 +3798,7 @@ struct Command(Copyable, Movable, Writable):
             var missing = List[String]()
             for n in range(len(self._required_groups[g])):
                 var argument_name = self._required_groups[g][n]
-                if result.has(argument_name):
+                if result.was_provided(argument_name):
                     provided.append(argument_name)
                 else:
                     missing.append(argument_name)
@@ -3433,11 +3814,13 @@ struct Command(Copyable, Movable, Writable):
                         provided_str += ", "
                     provided_str += self._display_name(provided[p])
                 self._error(
-                    "Arguments required together: "
-                    + missing_str
-                    + " required when "
-                    + provided_str
-                    + " is provided"
+                    String(
+                        "Arguments required together: ",
+                        missing_str,
+                        " required when ",
+                        provided_str,
+                        " is provided",
+                    )
                 )
 
         # Validate one-required groups.
@@ -3445,7 +3828,7 @@ struct Command(Copyable, Movable, Writable):
             var found_any = False
             for n in range(len(self._one_required_groups[g])):
                 var argument_name = self._one_required_groups[g][n]
-                if result.has(argument_name):
+                if result.was_provided(argument_name):
                     found_any = True
                     break
             if not found_any:
@@ -3465,18 +3848,22 @@ struct Command(Copyable, Movable, Writable):
         for g in range(len(self._conditional_reqs)):
             var target = self._conditional_reqs[g][0]
             var condition = self._conditional_reqs[g][1]
-            if result.has(condition) and not result.has(target):
+            if result.was_provided(condition) and not result.was_provided(
+                target
+            ):
                 self._error(
-                    "Argument "
-                    + self._display_name(target)
-                    + " is required when "
-                    + self._display_name(condition)
-                    + " is provided"
+                    String(
+                        "Argument ",
+                        self._display_name(target),
+                        " is required when ",
+                        self._display_name(condition),
+                        " is provided",
+                    )
                 )
 
         # Validate count ceilings — clamp and warn.
         for j in range(len(self.arguments)):
-            var a = self.arguments[j].copy()
+            ref a = self.arguments[j]
             if a._is_count and a._has_count_max:
                 var cur: Int
                 try:
@@ -3485,19 +3872,21 @@ struct Command(Copyable, Movable, Writable):
                     continue
                 if cur > a._count_max:
                     self._warn(
-                        self._display_name(a.name)
-                        + " count "
-                        + String(cur)
-                        + " exceeds maximum "
-                        + String(a._count_max)
-                        + ", capped to "
-                        + String(a._count_max)
+                        String(
+                            self._display_name(a.name),
+                            " count ",
+                            String(cur),
+                            " exceeds maximum ",
+                            String(a._count_max),
+                            ", capped to ",
+                            String(a._count_max),
+                        )
                     )
                     result._counts[a.name] = a._count_max
 
         # Validate numeric range constraints.
         for j in range(len(self.arguments)):
-            var a = self.arguments[j].copy()
+            ref a = self.arguments[j]
             if a._has_range and result.has(a.name):
                 var display = self._display_name(a.name)
                 # Get the raw string value(s) for this argument.
@@ -3511,11 +3900,13 @@ struct Command(Copyable, Movable, Writable):
                             v = atol(lst[k])
                         except:
                             self._error(
-                                "Expected an integer for "
-                                + self._display_name(a.name)
-                                + ", got '"
-                                + lst[k]
-                                + "'"
+                                String(
+                                    "Expected an integer for ",
+                                    self._display_name(a.name),
+                                    ", got '",
+                                    lst[k],
+                                    "'",
+                                )
                             )
                         if v < a._range_min or v > a._range_max:
                             if a._is_clamp:
@@ -3525,28 +3916,32 @@ struct Command(Copyable, Movable, Writable):
                                 elif v > a._range_max:
                                     clamped = a._range_max
                                 self._warn(
-                                    display
-                                    + " value "
-                                    + String(v)
-                                    + " is out of range ["
-                                    + String(a._range_min)
-                                    + ", "
-                                    + String(a._range_max)
-                                    + "], clamped to "
-                                    + String(clamped)
+                                    String(
+                                        display,
+                                        " value ",
+                                        String(v),
+                                        " is out of range [",
+                                        String(a._range_min),
+                                        ", ",
+                                        String(a._range_max),
+                                        "], clamped to ",
+                                        String(clamped),
+                                    )
                                 )
                                 result._lists[a.name][k] = String(clamped)
                             else:
                                 self._error(
-                                    "Value "
-                                    + String(v)
-                                    + " for "
-                                    + display
-                                    + " is out of range ["
-                                    + String(a._range_min)
-                                    + ", "
-                                    + String(a._range_max)
-                                    + "]"
+                                    String(
+                                        "Value ",
+                                        String(v),
+                                        " for ",
+                                        display,
+                                        " is out of range [",
+                                        String(a._range_min),
+                                        ", ",
+                                        String(a._range_max),
+                                        "]",
+                                    )
                                 )
                 else:
                     var raw: String
@@ -3561,11 +3956,13 @@ struct Command(Copyable, Movable, Writable):
                         v = atol(raw)
                     except:
                         self._error(
-                            "Expected an integer for "
-                            + self._display_name(a.name)
-                            + ", got '"
-                            + raw
-                            + "'"
+                            String(
+                                "Expected an integer for ",
+                                self._display_name(a.name),
+                                ", got '",
+                                raw,
+                                "'",
+                            )
                         )
                     if v < a._range_min or v > a._range_max:
                         if a._is_clamp:
@@ -3575,15 +3972,17 @@ struct Command(Copyable, Movable, Writable):
                             elif v > a._range_max:
                                 clamped = a._range_max
                             self._warn(
-                                display
-                                + " value "
-                                + String(v)
-                                + " is out of range ["
-                                + String(a._range_min)
-                                + ", "
-                                + String(a._range_max)
-                                + "], clamped to "
-                                + String(clamped)
+                                String(
+                                    display,
+                                    " value ",
+                                    String(v),
+                                    " is out of range [",
+                                    String(a._range_min),
+                                    ", ",
+                                    String(a._range_max),
+                                    "], clamped to ",
+                                    String(clamped),
+                                )
                             )
                             result._values[a.name] = String(clamped)
                             if a._is_positional:
@@ -3595,15 +3994,17 @@ struct Command(Copyable, Movable, Writable):
                                         break
                         else:
                             self._error(
-                                "Value "
-                                + String(v)
-                                + " for "
-                                + display
-                                + " is out of range ["
-                                + String(a._range_min)
-                                + ", "
-                                + String(a._range_max)
-                                + "]"
+                                String(
+                                    "Value ",
+                                    String(v),
+                                    " for ",
+                                    display,
+                                    " is out of range [",
+                                    String(a._range_min),
+                                    ", ",
+                                    String(a._range_max),
+                                    "]",
+                                )
                             )
 
     # ===------------------------------------------------------------------=== #
@@ -3630,6 +4031,10 @@ struct Command(Copyable, Movable, Writable):
             if has_eq:
                 var key_part = String(key[byte=:eq])
                 key = key_part^
+            # An empty name is never a known option — see the matching guard
+            # in `_parse_long_option`.
+            if key.byte_length() == 0:
+                return False
             # Recognise the `--no-<flag>` negation form for negatable long
             # options. Without this, `allow_hyphen_values` could swallow
             # `--no-foo` as a positional even though `foo` is a known
@@ -3674,7 +4079,7 @@ struct Command(Copyable, Movable, Writable):
             return False
         return False
 
-    def _find_by_long(self, name: String) raises -> Argument:
+    def _find_index_by_long(self, name: String) raises -> Int:
         """Finds an argument definition by its long name, alias, or unambiguous prefix.
 
         Resolution order:
@@ -3683,11 +4088,16 @@ struct Command(Copyable, Movable, Writable):
         3. Prefix match on long_name.
         4. Prefix match on aliases.
 
+        Returns an index rather than the ``Argument`` itself.  This runs once
+        per option token, and handing back a copy meant deep-copying every
+        field of the definition — a dozen heap allocations — only to read two
+        or three of them.  Callers bind the result with ``ref``.
+
         Args:
             name: The long option name (without '--'), or an unambiguous prefix.
 
         Returns:
-            The matching Argument.
+            The index into ``self.arguments`` of the matching argument.
 
         Raises:
             Error if no argument matches or the prefix is ambiguous.
@@ -3695,13 +4105,13 @@ struct Command(Copyable, Movable, Writable):
         # 1. Exact match on long_name.
         for i in range(len(self.arguments)):
             if self.arguments[i]._long_name == name:
-                return self.arguments[i].copy()
+                return i
 
         # 2. Exact match on aliases.
         for i in range(len(self.arguments)):
             for j in range(len(self.arguments[i]._alias_names)):
                 if self.arguments[i]._alias_names[j] == name:
-                    return self.arguments[i].copy()
+                    return i
 
         # 3. Prefix match on long_name.
         var candidates = List[String]()
@@ -3728,16 +4138,16 @@ struct Command(Copyable, Movable, Writable):
                         candidate_idx = i
 
         if len(candidates) == 1:
-            return self.arguments[candidate_idx].copy()
+            return candidate_idx
 
         if len(candidates) > 1:
             var opts = String("")
             for j in range(len(candidates)):
                 if j > 0:
                     opts += ", "
-                opts += "'--" + candidates[j] + "'"
+                opts += String("'--", candidates[j], "'")
             self._error(
-                "Ambiguous option '--" + name + "' could match: " + opts
+                String("Ambiguous option '--", name, "' could match: ", opts)
             )
 
         # Collect all known long names + aliases for typo suggestion.
@@ -3768,13 +4178,13 @@ struct Command(Copyable, Movable, Writable):
             name, all_longs
         ) if not cjk_suggestion else cjk_suggestion
 
-        var err_msg = "Unknown option '--" + name + "'"
+        var err_msg = String("Unknown option '--", name, "'")
         if suggestion:
-            var tip_detail = (
-                "a similar option exists: '--"
-                + suggestion
-                + "'"
-                + (" (detected CJK punctuation)" if cjk_suggestion else "")
+            var tip_detail = String(
+                "a similar option exists: '--",
+                suggestion,
+                "'",
+                (" (detected CJK punctuation)" if cjk_suggestion else ""),
             )
             if Self._no_color_env():
                 print(
@@ -3810,26 +4220,29 @@ struct Command(Copyable, Movable, Writable):
             "unreachable"
         )  # _error() always raises; satisfies Mojo's return checker
 
-    def _find_by_short(self, name: String) raises -> Argument:
+    def _find_index_by_short(self, name: String) raises -> Int:
         """Finds an argument definition by its short name.
+
+        Returns an index rather than the ``Argument`` itself, for the same
+        reason as ``_find_index_by_long``.
 
         Args:
             name: The short option name (without '-').
 
         Returns:
-            The matching Argument.
+            The index into ``self.arguments`` of the matching argument.
 
         Raises:
             Error if no argument matches.
         """
         for i in range(len(self.arguments)):
             if self.arguments[i]._short_name == name:
-                return self.arguments[i].copy()
+                return i
         # Short options are always a single character; any two single-character
         # inputs have Levenshtein distance ≤ 1, so the threshold would always
         # fire and produce meaningless suggestions (e.g. "-z" → "Did you mean
         # '-v'?"). Suggestions are therefore disabled for short options.
-        self._error("Unknown option '-" + name + "'")
+        self._error(String("Unknown option '-", name, "'"))
         raise Error(
             "unreachable"
         )  # _error() always raises; satisfies Mojo's return checker
@@ -3896,15 +4309,17 @@ struct Command(Copyable, Movable, Writable):
         for i in range(len(argument._choice_values)):
             if i > 0:
                 allowed += ", "
-            allowed += "'" + argument._choice_values[i] + "'"
+            allowed += String("'", argument._choice_values[i], "'")
         self._error(
-            "Invalid value '"
-            + value
-            + "' for argument '"
-            + argument.name
-            + "' (choose from "
-            + allowed
-            + ")"
+            String(
+                "Invalid value '",
+                value,
+                "' for argument '",
+                argument.name,
+                "' (choose from ",
+                allowed,
+                ")",
+            )
         )
 
     def _store_scalar_value(
@@ -3920,6 +4335,7 @@ struct Command(Copyable, Movable, Writable):
           (with delimiter splitting handled there);
         - scalar arguments validate choices and overwrite `_values`.
         """
+        result._mark_provided(argument.name)
         if argument._is_map:
             self._store_map_value(argument, value, result)
         elif argument._is_append:
@@ -3937,6 +4353,7 @@ struct Command(Copyable, Movable, Writable):
         except:
             pass
         result._counts[name] = cur + 1
+        result._mark_provided(name)
 
     def _consume_nargs(
         self,
@@ -3961,15 +4378,52 @@ struct Command(Copyable, Movable, Writable):
             i += 1
             if i >= len(raw_tokens):
                 self._error(
-                    "Option '"
-                    + display
-                    + "' requires "
-                    + String(argument._number_of_values)
-                    + " values"
+                    String(
+                        "Option '",
+                        display,
+                        "' requires ",
+                        String(argument._number_of_values),
+                        " values",
+                    )
                 )
+            self._reject_option_as_value(argument, display, raw_tokens[i])
             self._validate_choices(argument, raw_tokens[i])
             result._lists[argument.name].append(raw_tokens[i])
+        result._mark_provided(argument.name)
         return i
+
+    def _reject_option_as_value(
+        self, argument: Argument, display: String, token: String
+    ) raises:
+        """Errors out when *token* is an option rather than a value.
+
+        Called before an option consumes the next token on the command line.
+        Only *registered* options (and the `--` end-of-options marker) are
+        refused, so a value that merely starts with a hyphen — a negative
+        number, an unregistered `-foo` — still goes through.  Arguments
+        declared with ``.allow_hyphen_values()`` opt out of the check
+        entirely.
+
+        Args:
+            argument: The argument that is about to consume the token.
+            display: The user-facing spelling of the option (`--key` / `-k`).
+            token: The token that would be consumed as the value.
+
+        Raises:
+            Error if the token is a registered option or the `--` marker.
+        """
+        if argument._allow_hyphen_values:
+            return
+        if token == "--" or self._is_known_option(token):
+            self._error(
+                String(
+                    "Option '",
+                    display,
+                    "' requires a value, but found the option '",
+                    token,
+                    "'",
+                )
+            )
 
     def _find_remainder_slot(self) -> Int:
         """Returns the positional-slot index of the remainder argument
@@ -4052,11 +4506,13 @@ struct Command(Copyable, Movable, Writable):
                     var eq = piece.find("=")
                     if eq < 0:
                         self._error(
-                            "Invalid key=value format '"
-                            + piece
-                            + "' for argument '"
-                            + argument.name
-                            + "'"
+                            String(
+                                "Invalid key=value format '",
+                                piece,
+                                "' for argument '",
+                                argument.name,
+                                "'",
+                            )
                         )
                     var k = String(piece[byte=:eq])
                     var v = String(piece[byte = eq + 1 :])
@@ -4066,11 +4522,13 @@ struct Command(Copyable, Movable, Writable):
             var eq = value.find("=")
             if eq < 0:
                 self._error(
-                    "Invalid key=value format '"
-                    + value
-                    + "' for argument '"
-                    + argument.name
-                    + "'"
+                    String(
+                        "Invalid key=value format '",
+                        value,
+                        "' for argument '",
+                        argument.name,
+                        "'",
+                    )
                 )
             var k = String(value[byte=:eq])
             var v = String(value[byte = eq + 1 :])
@@ -4173,10 +4631,10 @@ struct Command(Copyable, Movable, Writable):
 
         # Usage line.
         if self._custom_usage:
-            s += header_color + "usage:" + reset_code + " "
+            s += String(header_color, "usage:", reset_code, " ")
             s += self._custom_usage + "\n\n"
             return s
-        s += header_color + "usage:" + reset_code + " "
+        s += String(header_color, "usage:", reset_code, " ")
         s += program_color + self.name + reset_code
 
         # Collect usage tokens (plain and coloured) for wrapping.
@@ -4316,7 +4774,7 @@ struct Command(Copyable, Movable, Writable):
                 pos_colors.append(colored)
                 pos_helps.append(self.arguments[i].help_text)
 
-        var s = header_color + "arguments:" + reset_code + "\n"
+        var s = String(header_color, "arguments:", reset_code, "\n")
         var pos_indices = List[Int]()
         for k in range(len(pos_plains)):
             pos_indices.append(k)
@@ -4373,66 +4831,55 @@ struct Command(Copyable, Movable, Writable):
         var opt_groups = List[String]()
 
         for i in range(len(self.arguments)):
-            if (
-                not self.arguments[i]._is_positional
-                and not self.arguments[i]._is_hidden
-            ):
+            ref a = self.arguments[i]
+            if not a._is_positional and not a._is_hidden:
                 var plain = String("  ")
                 var colored = String("  ")
-                if self.arguments[i]._short_name:
-                    plain += "-" + self.arguments[i]._short_name
-                    colored += (
-                        short_option_color
-                        + "-"
-                        + self.arguments[i]._short_name
-                        + reset_code
+                if a._short_name:
+                    plain += "-" + a._short_name
+                    colored += String(
+                        short_option_color,
+                        "-",
+                        a._short_name,
+                        reset_code,
                     )
-                    if self.arguments[i]._long_name:
+                    if a._long_name:
                         plain += ", "
                         colored += ", "
                 else:
                     plain += "    "
                     colored += "    "
-                if self.arguments[i]._long_name:
-                    var long_part = String("--") + self.arguments[i]._long_name
+                if a._long_name:
+                    var long_part = String("--") + a._long_name
                     plain += long_part
                     colored += long_option_color + long_part + reset_code
-                    if self.arguments[i]._is_negatable:
-                        var neg_part = (
-                            String(" / --no-") + self.arguments[i]._long_name
-                        )
+                    if a._is_negatable:
+                        var neg_part = String(" / --no-") + a._long_name
                         plain += neg_part
-                        colored += (
-                            " / "
-                            + long_option_color
-                            + "--no-"
-                            + self.arguments[i]._long_name
-                            + reset_code
+                        colored += String(
+                            " / ",
+                            long_option_color,
+                            "--no-",
+                            a._long_name,
+                            reset_code,
                         )
                     # Show aliases.
-                    for j in range(len(self.arguments[i]._alias_names)):
-                        var alias_part = (
-                            String(", --") + self.arguments[i]._alias_names[j]
-                        )
+                    for j in range(len(a._alias_names)):
+                        var alias_part = String(", --") + a._alias_names[j]
                         plain += alias_part
-                        colored += (
-                            ", "
-                            + long_option_color
-                            + "--"
-                            + self.arguments[i]._alias_names[j]
-                            + reset_code
+                        colored += String(
+                            ", ",
+                            long_option_color,
+                            "--",
+                            a._alias_names[j],
+                            reset_code,
                         )
 
                 # Show value_name or choices for value-taking options.
-                if (
-                    not self.arguments[i]._is_flag
-                    and not self.arguments[i]._is_count
-                ):
-                    var ncount = self.arguments[i]._number_of_values
+                if not a._is_flag and not a._is_count:
+                    var ncount = a._number_of_values
                     var repeat = ncount if ncount > 0 else 1
-                    var append_dots = (
-                        self.arguments[i]._is_append and ncount == 0
-                    )
+                    var append_dots = a._is_append and ncount == 0
                     # Determine separator and wrapping for require_equals/default_if_no_value.
                     var sep = String("=") if self.arguments[
                         i
@@ -4443,18 +4890,20 @@ struct Command(Copyable, Movable, Writable):
                     var close_bracket = String("]") if self.arguments[
                         i
                     ]._has_default_if_no_value else String("")
-                    if self.arguments[i]._value_name:
-                        var raw_mv = self.arguments[i]._value_name
+                    if a._value_name:
+                        var raw_mv = a._value_name
                         var mv: String
-                        if self.arguments[i]._value_name_wrapped:
-                            mv = "<" + raw_mv + ">"
+                        if a._value_name_wrapped:
+                            mv = String("<", raw_mv, ">")
                         else:
                             mv = raw_mv
                         var mv_plain = String("")
                         var mv_colored = String("")
                         for _r in range(repeat - 1):
                             mv_plain += " " + mv
-                            mv_colored += " " + value_color + mv + reset_code
+                            mv_colored += String(
+                                " ", value_color, mv, reset_code
+                            )
                         # Last (or only) occurrence — attach "..." if append.
                         var last = mv + ("..." if append_dots else "")
                         mv_plain += open_bracket + sep + last + close_bracket
@@ -4468,12 +4917,12 @@ struct Command(Copyable, Movable, Writable):
                         )
                         plain += mv_plain
                         colored += mv_colored
-                    elif len(self.arguments[i]._choice_values) > 0:
+                    elif len(a._choice_values) > 0:
                         var choices_str = String("{")
-                        for j in range(len(self.arguments[i]._choice_values)):
+                        for j in range(len(a._choice_values)):
                             if j > 0:
                                 choices_str += ","
-                            choices_str += self.arguments[i]._choice_values[j]
+                            choices_str += a._choice_values[j]
                         choices_str += "}"
                         var suffix = choices_str
                         if append_dots:
@@ -4490,15 +4939,17 @@ struct Command(Copyable, Movable, Writable):
                     else:
                         # Default placeholder: <key=value> for map, <name> otherwise.
                         var tag: String
-                        if self.arguments[i]._is_map:
+                        if a._is_map:
                             tag = "<key=value>"
                         else:
-                            tag = "<" + self.arguments[i].name + ">"
+                            tag = String("<", a.name, ">")
                         var ph_plain = String("")
                         var ph_colored = String("")
                         for _r in range(repeat - 1):
                             ph_plain += " " + tag
-                            ph_colored += " " + value_color + tag + reset_code
+                            ph_colored += String(
+                                " ", value_color, tag, reset_code
+                            )
                         # Last (or only) — attach "..." if append.
                         var last = tag + ("..." if append_dots else "")
                         ph_plain += open_bracket + sep + last + close_bracket
@@ -4515,18 +4966,14 @@ struct Command(Copyable, Movable, Writable):
 
                 opt_plains.append(plain)
                 opt_colors.append(colored)
-                opt_persistent.append(self.arguments[i]._is_persistent)
-                opt_groups.append(self.arguments[i]._group)
+                opt_persistent.append(a._is_persistent)
+                opt_groups.append(a._group)
                 # Append deprecation notice to help text if applicable.
-                var help = self.arguments[i].help_text
-                if self.arguments[i]._deprecated_msg:
+                var help = a.help_text
+                if a._deprecated_msg:
                     if help:
                         help += " "
-                    help += (
-                        "[deprecated: "
-                        + self.arguments[i]._deprecated_msg
-                        + "]"
-                    )
+                    help += String("[deprecated: ", a._deprecated_msg, "]")
                 opt_helps.append(help)
 
         # Built-in options (always shown under local ungrouped "options:" section).
@@ -4542,15 +4989,15 @@ struct Command(Copyable, Movable, Writable):
             + reset_code
         )  # Not show -? in help message as it requires quoting in some shells
         var version_plain = String("  -V, --version")
-        var version_colored = (
-            "  "
-            + short_option_color
-            + "-V"
-            + reset_code
-            + ", "
-            + long_option_color
-            + "--version"
-            + reset_code
+        var version_colored = String(
+            "  ",
+            short_option_color,
+            "-V",
+            reset_code,
+            ", ",
+            long_option_color,
+            "--version",
+            reset_code,
         )
         opt_plains.append(help_plain)
         opt_colors.append(help_colored)
@@ -4566,16 +5013,16 @@ struct Command(Copyable, Movable, Writable):
             var comp_plain = String(
                 "      --" + self._completions_name + " <SHELL>"
             )
-            var comp_colored = (
-                "      "
-                + long_option_color
-                + "--"
-                + self._completions_name
-                + reset_code
-                + " "
-                + value_color
-                + "<SHELL>"
-                + reset_code
+            var comp_colored = String(
+                "      ",
+                long_option_color,
+                "--",
+                self._completions_name,
+                reset_code,
+                " ",
+                value_color,
+                "<SHELL>",
+                reset_code,
             )
             opt_plains.append(comp_plain)
             opt_colors.append(comp_colored)
@@ -4616,7 +5063,7 @@ struct Command(Copyable, Movable, Writable):
         )
         var ug_ds = ug_layout[0]
         var ug_dw = ug_layout[1]
-        var s = header_color + "options:" + reset_code + "\n"
+        var s = String(header_color, "options:", reset_code, "\n")
         for ki in range(len(ungrouped_idx)):
             var k = ungrouped_idx[ki]
             s += (
@@ -4640,7 +5087,7 @@ struct Command(Copyable, Movable, Writable):
             var g_layout = _section_desc_layout(opt_plains, grp_idx, line_width)
             var g_ds = g_layout[0]
             var g_dw = g_layout[1]
-            s += "\n" + header_color + gname + ":" + reset_code + "\n"
+            s += String("\n", header_color, gname, ":", reset_code, "\n")
             for ki in range(len(grp_idx)):
                 var k = grp_idx[ki]
                 s += (
@@ -4663,7 +5110,7 @@ struct Command(Copyable, Movable, Writable):
             var gl_layout = _section_desc_layout(opt_plains, gl_idx, line_width)
             var gl_ds = gl_layout[0]
             var gl_dw = gl_layout[1]
-            s += "\n" + header_color + "global options:" + reset_code + "\n"
+            s += String("\n", header_color, "global options:", reset_code, "\n")
             for ki in range(len(gl_idx)):
                 var k = gl_idx[ki]
                 s += (
@@ -4747,7 +5194,7 @@ struct Command(Copyable, Movable, Writable):
         )
         var cmd_ds = cmd_layout[0]
         var cmd_dw = cmd_layout[1]
-        var s = "\n" + header_color + "commands:" + reset_code + "\n"
+        var s = String("\n", header_color, "commands:", reset_code, "\n")
         for k in range(len(cmd_plains)):
             s += (
                 _format_two_column_line(
@@ -4836,9 +5283,9 @@ struct Command(Copyable, Movable, Writable):
         if len(tip_lines) == 0:
             return ""
 
-        var s = "\n" + header_color + "tips:" + reset_code + "\n"
+        var s = String("\n", header_color, "tips:", reset_code, "\n")
         for _ti in range(len(tip_lines)):
-            s += "  " + tip_lines[_ti] + "\n"
+            s += String("  ", tip_lines[_ti], "\n")
         return s
 
     # ===------------------------------------------------------------------=== #
@@ -4902,7 +5349,7 @@ struct Command(Copyable, Movable, Writable):
         if lower == "bash":
             return self._completion_bash()
         raise Error(
-            "Unknown shell '" + shell + "'. Choose from: bash, zsh, fish"
+            String("Unknown shell '", shell, "'. Choose from: bash, zsh, fish")
         )
 
     def _completion_fish(self) -> String:
@@ -4922,20 +5369,22 @@ struct Command(Copyable, Movable, Writable):
         # Root-level options.
         s += self._fish_options_for(self.name, "")
         # Built-in options.
-        s += (
-            "complete -c "
-            + self.name
-            + " -s h -l help -d 'Show this help message'\n"
+        s += String(
+            "complete -c ",
+            self.name,
+            " -s h -l help -d 'Show this help message'\n",
         )
-        s += "complete -c " + self.name + " -s V -l version -d 'Show version'\n"
+        s += String(
+            "complete -c ", self.name, " -s V -l version -d 'Show version'\n"
+        )
         if self._completions_enabled and not self._completions_is_subcommand:
-            s += (
-                "complete -c "
-                + self.name
-                + " -l "
-                + self._completions_name
-                + " -r -a 'bash zsh fish'"
-                + " -d 'Generate shell completion script'\n"
+            s += String(
+                "complete -c ",
+                self.name,
+                " -l ",
+                self._completions_name,
+                " -r -a 'bash zsh fish'",
+                " -d 'Generate shell completion script'\n",
             )
 
         # Subcommands.
@@ -4971,33 +5420,37 @@ struct Command(Copyable, Movable, Writable):
                     continue
                 var sub = self.subcommands[i].copy()
                 # Register the subcommand itself.
-                s += (
-                    "complete -c "
-                    + self.name
-                    + " -n 'not "
-                    + no_sub_cond
-                    + "'"
-                    + " -f -a '"
-                    + sub.name
-                    + "'"
+                s += String(
+                    "complete -c ",
+                    self.name,
+                    " -n 'not ",
+                    no_sub_cond,
+                    "'",
+                    " -f -a '",
+                    sub.name,
+                    "'",
                 )
                 if sub.description:
-                    s += " -d '" + self._fish_escape(sub.description) + "'"
+                    s += String(
+                        " -d '", self._fish_escape(sub.description), "'"
+                    )
                 s += "\n"
                 # Register each alias as a completable name.
                 for _ai in range(len(sub._command_aliases)):
-                    s += (
-                        "complete -c "
-                        + self.name
-                        + " -n 'not "
-                        + no_sub_cond
-                        + "'"
-                        + " -f -a '"
-                        + sub._command_aliases[_ai]
-                        + "'"
+                    s += String(
+                        "complete -c ",
+                        self.name,
+                        " -n 'not ",
+                        no_sub_cond,
+                        "'",
+                        " -f -a '",
+                        sub._command_aliases[_ai],
+                        "'",
                     )
                     if sub.description:
-                        s += " -d '" + self._fish_escape(sub.description) + "'"
+                        s += String(
+                            " -d '", self._fish_escape(sub.description), "'"
+                        )
                     s += "\n"
 
                 # Subcommand-specific options.
@@ -5013,7 +5466,7 @@ struct Command(Copyable, Movable, Writable):
                     if argument._is_hidden or argument._is_positional:
                         continue
                     var line = "complete -c " + self.name
-                    line += " -n '" + sub_cond + "'"
+                    line += String(" -n '", sub_cond, "'")
                     if argument._short_name:
                         line += " -s " + argument._short_name
                     if argument._long_name:
@@ -5026,36 +5479,34 @@ struct Command(Copyable, Movable, Writable):
                             if choices:
                                 choices += " "
                             choices += argument._choice_values[k]
-                        line += " -a '" + choices + "'"
+                        line += String(" -a '", choices, "'")
                     if argument.help_text:
-                        line += (
-                            " -d '"
-                            + self._fish_escape(argument.help_text)
-                            + "'"
+                        line += String(
+                            " -d '", self._fish_escape(argument.help_text), "'"
                         )
                     s += line + "\n"
 
             # Completions subcommand entry.
             if _comp_is_sub:
                 var cname = self._completions_name
-                s += (
-                    "complete -c "
-                    + self.name
-                    + " -n 'not "
-                    + no_sub_cond
-                    + "'"
-                    + " -f -a '"
-                    + cname
-                    + "'"
-                    + " -d 'Generate shell completion script'\n"
+                s += String(
+                    "complete -c ",
+                    self.name,
+                    " -n 'not ",
+                    no_sub_cond,
+                    "'",
+                    " -f -a '",
+                    cname,
+                    "'",
+                    " -d 'Generate shell completion script'\n",
                 )
-                s += (
-                    "complete -c "
-                    + self.name
-                    + " -n '__fish_seen_subcommand_from "
-                    + cname
-                    + "'"
-                    + " -r -a 'bash zsh fish'\n"
+                s += String(
+                    "complete -c ",
+                    self.name,
+                    " -n '__fish_seen_subcommand_from ",
+                    cname,
+                    "'",
+                    " -r -a 'bash zsh fish'\n",
                 )
         return s
 
@@ -5077,14 +5528,14 @@ struct Command(Copyable, Movable, Writable):
         """
         var s = String("")
         for i in range(len(self.arguments)):
-            var argument = self.arguments[i].copy()
+            ref argument = self.arguments[i]
             if argument._is_hidden or argument._is_positional:
                 continue
             if persistent_only and not argument._is_persistent:
                 continue
             var line = "complete -c " + command_name
             if condition:
-                line += " -n '" + condition + "'"
+                line += String(" -n '", condition, "'")
             if argument._short_name:
                 line += " -s " + argument._short_name
             if argument._long_name:
@@ -5097,9 +5548,11 @@ struct Command(Copyable, Movable, Writable):
                     if choices:
                         choices += " "
                     choices += argument._choice_values[k]
-                line += " -a '" + choices + "'"
+                line += String(" -a '", choices, "'")
             if argument.help_text:
-                line += " -d '" + self._fish_escape(argument.help_text) + "'"
+                line += String(
+                    " -d '", self._fish_escape(argument.help_text), "'"
+                )
             s += line + "\n"
         return s
 
@@ -5127,7 +5580,7 @@ struct Command(Copyable, Movable, Writable):
             A complete Zsh completion script.
         """
         var s = String("#compdef " + self.name + "\n")
-        s += "# Zsh completions for " + self.name + "\n"
+        s += String("# Zsh completions for ", self.name, "\n")
         s += "# Generated by ArgMojo\n\n"
 
         # If there are subcommands, generate a dispatcher function.
@@ -5147,7 +5600,7 @@ struct Command(Copyable, Movable, Writable):
         else:
             s += self._zsh_simple()
 
-        s += "compdef _" + self.name + " " + self.name + "\n"
+        s += String("compdef _", self.name, " ", self.name, "\n")
         return s
 
     def _zsh_simple(self) -> String:
@@ -5160,20 +5613,20 @@ struct Command(Copyable, Movable, Writable):
         s += "  _arguments \\\n"
         # User-defined arguments.
         for i in range(len(self.arguments)):
-            var argument = self.arguments[i].copy()
+            ref argument = self.arguments[i]
             if argument._is_hidden:
                 continue
             if argument._is_positional:
                 continue
-            s += "    " + self._zsh_argument_spec(argument) + " \\\n"
+            s += String("    ", self._zsh_argument_spec(argument), " \\\n")
         # Built-in options.
         s += "    '(- *)'{-h,--help}'[Show this help message]' \\\n"
         if self._completions_enabled and not self._completions_is_subcommand:
             s += "    '(- *)'{-V,--version}'[Show version]' \\\n"
-            s += (
-                "    '--"
-                + self._completions_name
-                + "[Generate shell completion script]:shell:(bash zsh fish)'\n"
+            s += String(
+                "    '--",
+                self._completions_name,
+                "[Generate shell completion script]:shell:(bash zsh fish)'\n",
             )
         else:
             s += "    '(- *)'{-V,--version}'[Show version]'\n"
@@ -5199,33 +5652,37 @@ struct Command(Copyable, Movable, Writable):
             var desc = self._zsh_escape(
                 sub.description
             ) if sub.description else ""
-            s += "    '" + sub.name + ":" + desc + "'\n"
+            s += String("    '", sub.name, ":", desc, "'\n")
             # Add aliases as separate entries pointing to same description.
             for _ai in range(len(sub._command_aliases)):
-                s += "    '" + sub._command_aliases[_ai] + ":" + desc + "'\n"
+                s += String(
+                    "    '", sub._command_aliases[_ai], ":", desc, "'\n"
+                )
         if self._completions_enabled and self._completions_is_subcommand:
-            s += (
-                "    '"
-                + self._completions_name
-                + ":Generate shell completion script'\n"
+            s += String(
+                "    '",
+                self._completions_name,
+                ":Generate shell completion script'\n",
             )
         s += "  )\n\n"
 
         s += "  _arguments -C \\\n"
         # Root-level options.
         for i in range(len(self.arguments)):
-            var argument = self.arguments[i].copy()
+            ref argument = self.arguments[i]
             if argument._is_hidden or argument._is_positional:
                 continue
-            s += "    " + self._zsh_argument_spec(argument) + " \\\n"
+            s += String("    ", self._zsh_argument_spec(argument), " \\\n")
         s += "    '(- *)'{-h,--help}'[Show this help message]' \\\n"
         s += "    '(- *)'{-V,--version}'[Show version]' \\\n"
         if self._completions_enabled and not self._completions_is_subcommand:
-            s += (
-                "    '--"
-                + self._completions_name
-                + "[Generate shell completion"
-                " script]:shell:(bash zsh fish)' \\\n"
+            s += String(
+                "    '--",
+                self._completions_name,
+                (
+                    "[Generate shell completion"
+                    " script]:shell:(bash zsh fish)' \\\n"
+                ),
             )
         s += "    '1:command:->cmd' \\\n"
         s += "    '*::arg:->arguments'\n\n"
@@ -5247,7 +5704,7 @@ struct Command(Copyable, Movable, Writable):
             var zsh_pat = sub.name
             for _ai in range(len(sub._command_aliases)):
                 zsh_pat += "|" + sub._command_aliases[_ai]
-            s += "        " + zsh_pat + ")\n"
+            s += String("        ", zsh_pat, ")\n")
             s += "          _arguments \\\n"
             for j in range(len(sub.arguments)):
                 var argument = sub.arguments[j].copy()
@@ -5255,14 +5712,14 @@ struct Command(Copyable, Movable, Writable):
                     continue
                 if argument._is_positional:
                     continue
-                s += (
-                    "            " + self._zsh_argument_spec(argument) + " \\\n"
+                s += String(
+                    "            ", self._zsh_argument_spec(argument), " \\\n"
                 )
             s += "            '(- *)'{-h,--help}'[Show this help message]'\n"
             s += "          ;;\n"
 
         if self._completions_enabled and self._completions_is_subcommand:
-            s += "        " + self._completions_name + ")\n"
+            s += String("        ", self._completions_name, ")\n")
             s += (
                 "          _arguments \\\n"
                 "            '1:shell:(bash zsh fish)'\n"
@@ -5292,17 +5749,17 @@ struct Command(Copyable, Movable, Writable):
 
         if argument._short_name and argument._long_name:
             # Grouped short+long form.
-            spec += (
-                "'(-"
-                + argument._short_name
-                + " --"
-                + argument._long_name
-                + ")'"
-                + "{-"
-                + argument._short_name
-                + ",--"
-                + argument._long_name
-                + "}"
+            spec += String(
+                "'(-",
+                argument._short_name,
+                " --",
+                argument._long_name,
+                ")'",
+                "{-",
+                argument._short_name,
+                ",--",
+                argument._long_name,
+                "}",
             )
         elif argument._long_name:
             spec += "'--" + argument._long_name
@@ -5311,7 +5768,7 @@ struct Command(Copyable, Movable, Writable):
 
         if argument._short_name and argument._long_name:
             # Description + value spec.
-            spec += "'[" + desc + "]"
+            spec += String("'[", desc, "]")
             if not argument._is_flag and not argument._is_count:
                 if len(argument._choice_values) > 0:
                     var choices = String("")
@@ -5319,12 +5776,12 @@ struct Command(Copyable, Movable, Writable):
                         if choices:
                             choices += " "
                         choices += argument._choice_values[k]
-                    spec += ":value:(" + choices + ")"
+                    spec += String(":value:(", choices, ")")
                 else:
                     var mv = (
                         argument._value_name if argument._value_name else argument.name
                     )
-                    spec += ":" + mv + ":"
+                    spec += String(":", mv, ":")
             spec += "'"
         else:
             if not argument._is_flag and not argument._is_count:
@@ -5334,14 +5791,14 @@ struct Command(Copyable, Movable, Writable):
                         if choices:
                             choices += " "
                         choices += argument._choice_values[k]
-                    spec += "[" + desc + "]:value:(" + choices + ")'"
+                    spec += String("[", desc, "]:value:(", choices, ")'")
                 else:
                     var mv = (
                         argument._value_name if argument._value_name else argument.name
                     )
-                    spec += "[" + desc + "]:" + mv + ":'"
+                    spec += String("[", desc, "]:", mv, ":'")
             else:
-                spec += "[" + desc + "]'"
+                spec += String("[", desc, "]'")
 
         return spec
 
@@ -5375,7 +5832,7 @@ struct Command(Copyable, Movable, Writable):
         Returns:
             A complete Bash completion script.
         """
-        var fn_name = "_" + self.name + "_completion"
+        var fn_name = String("_", self.name, "_completion")
         var s = String("# Bash completions for " + self.name + "\n")
         s += "# Generated by ArgMojo\n\n"
         s += fn_name + "() {\n"
@@ -5400,7 +5857,7 @@ struct Command(Copyable, Movable, Writable):
             s += self._bash_simple()
 
         s += "}\n\n"
-        s += "complete -F " + fn_name + " " + self.name + "\n"
+        s += String("complete -F ", fn_name, " ", self.name, "\n")
         return s
 
     def _bash_simple(self) -> String:
@@ -5414,7 +5871,7 @@ struct Command(Copyable, Movable, Writable):
         if self._completions_enabled and not self._completions_is_subcommand:
             words += " --" + self._completions_name
         for i in range(len(self.arguments)):
-            var argument = self.arguments[i].copy()
+            ref argument = self.arguments[i]
             if argument._is_hidden or argument._is_positional:
                 continue
             if argument._long_name:
@@ -5460,7 +5917,7 @@ struct Command(Copyable, Movable, Writable):
         if self._completions_enabled and not self._completions_is_subcommand:
             root_words += " --" + self._completions_name
         for i in range(len(self.arguments)):
-            var argument = self.arguments[i].copy()
+            ref argument = self.arguments[i]
             if argument._is_hidden or argument._is_positional:
                 continue
             if argument._long_name:
@@ -5472,7 +5929,7 @@ struct Command(Copyable, Movable, Writable):
         s += "  local subcmd=''\n"
         s += "  for ((i=1; i<COMP_CWORD; i++)); do\n"
         s += "    case ${COMP_WORDS[i]} in\n"
-        s += "      " + sub_names.replace(" ", "|") + ")\n"
+        s += String("      ", sub_names.replace(" ", "|"), ")\n")
         s += "        subcmd=${COMP_WORDS[i]}\n"
         s += "        break\n"
         s += "        ;;\n"
@@ -5482,12 +5939,12 @@ struct Command(Copyable, Movable, Writable):
         s += "  if [[ -z $subcmd ]]; then\n"
         # Root-level $prev choices completion.
         s += self._bash_prev_cases_for_arguments(self.arguments, "    ")
-        s += (
-            '    COMPREPLY=($(compgen -W "'
-            + root_words
-            + " "
-            + sub_names
-            + '" -- "$cur"))\n'
+        s += String(
+            '    COMPREPLY=($(compgen -W "',
+            root_words,
+            " ",
+            sub_names,
+            '" -- "$cur"))\n',
         )
         s += "    return\n"
         s += "  fi\n\n"
@@ -5513,7 +5970,7 @@ struct Command(Copyable, Movable, Writable):
             var bash_pat = sub.name
             for _ai in range(len(sub._command_aliases)):
                 bash_pat += "|" + sub._command_aliases[_ai]
-            s += "    " + bash_pat + ")\n"
+            s += String("    ", bash_pat, ")\n")
             # Subcommand-level $prev choices completion.
             s += self._bash_prev_cases_for_arguments(sub.arguments, "      ")
             s += (
@@ -5523,7 +5980,7 @@ struct Command(Copyable, Movable, Writable):
             )
             s += "      ;;\n"
         if self._completions_enabled and self._completions_is_subcommand:
-            s += "    " + self._completions_name + ")\n"
+            s += String("    ", self._completions_name, ")\n")
             s += '      COMPREPLY=($(compgen -W "bash zsh fish" -- "$cur"))\n'
             s += "      ;;\n"
         s += "  esac\n"
@@ -5556,12 +6013,12 @@ struct Command(Copyable, Movable, Writable):
 
         var s = String("  case $prev in\n")
         if self._completions_enabled and not self._completions_is_subcommand:
-            s += "    --" + self._completions_name + ")\n"
+            s += String("    --", self._completions_name, ")\n")
             s += '      COMPREPLY=($(compgen -W "bash zsh fish" -- "$cur"))\n'
             s += "      return\n"
             s += "      ;;\n"
         for i in range(len(self.arguments)):
-            var argument = self.arguments[i].copy()
+            ref argument = self.arguments[i]
             if (
                 argument._is_hidden
                 or argument._is_positional
@@ -5580,7 +6037,7 @@ struct Command(Copyable, Movable, Writable):
                 if choices:
                     choices += " "
                 choices += argument._choice_values[k]
-            s += "    " + pattern + ")\n"
+            s += String("    ", pattern, ")\n")
             s += '      COMPREPLY=($(compgen -W "' + choices + '" -- "$cur"))\n'
             s += "      return\n"
             s += "      ;;\n"
@@ -5635,7 +6092,7 @@ struct Command(Copyable, Movable, Writable):
                 if choices:
                     choices += " "
                 choices += argument._choice_values[k]
-            s += indent + "  " + pattern + ")\n"
+            s += String(indent, "  ", pattern, ")\n")
             s += (
                 indent
                 + '    COMPREPLY=($(compgen -W "'

--- a/src/argmojo/parse_result.mojo
+++ b/src/argmojo/parse_result.mojo
@@ -1,5 +1,7 @@
 """Stores parsed argument values."""
 
+from std.collections import Set
+
 
 struct ParseResult(Copyable, Movable, Writable):
     """Stores the results of parsing command-line arguments.
@@ -34,6 +36,16 @@ struct ParseResult(Copyable, Movable, Writable):
     var _unknown_arguments: List[String]
     """Unrecognised arguments collected by ``parse_known_arguments()``.
     Empty when using the standard ``parse_arguments()`` method."""
+    var _provided: Set[String]
+    """Names of the arguments that the user actually supplied on the command
+    line (or answered at an interactive prompt).
+
+    This is what separates "the user asked for it" from "a default filled it
+    in".  ``has()`` cannot make that distinction, because defaults are written
+    into the very same storage as parsed values.  Group constraints
+    (mutually-exclusive, required-together, one-required, conditional) must
+    only look at what the user really typed, so they consult
+    ``was_provided()`` instead."""
 
     def __init__(out self):
         """Creates an empty ParseResult."""
@@ -47,6 +59,7 @@ struct ParseResult(Copyable, Movable, Writable):
         self.subcommand = ""
         self._subcommand_results = List[ParseResult]()
         self._unknown_arguments = List[String]()
+        self._provided = Set[String]()
 
     def __init__(out self, *, copy: Self):
         """Creates a deep copy of a ParseResult.
@@ -68,6 +81,7 @@ struct ParseResult(Copyable, Movable, Writable):
         self.subcommand = copy.subcommand
         self._subcommand_results = copy._subcommand_results.copy()
         self._unknown_arguments = copy._unknown_arguments.copy()
+        self._provided = copy._provided.copy()
 
     def __deinit__(deinit self):
         """Destroys the ParseResult, releasing all owned fields.
@@ -97,6 +111,7 @@ struct ParseResult(Copyable, Movable, Writable):
         self.subcommand = move.subcommand^
         self._subcommand_results = move._subcommand_results^
         self._unknown_arguments = move._unknown_arguments^
+        self._provided = move._provided^
 
     def get_flag(self, name: String) -> Bool:
         """Gets a boolean flag value. Returns False if not set.
@@ -152,6 +167,21 @@ struct ParseResult(Copyable, Movable, Writable):
         """
         var s = self.get_string(name)
         return Int(atol(s))
+
+    def get_float(self, name: String) raises -> Float64:
+        """Gets a floating-point argument value.
+
+        Args:
+            name: The argument name.
+
+        Returns:
+            The floating-point value of the argument.
+
+        Raises:
+            Error if the argument was not provided or is not a valid number.
+        """
+        var s = self.get_string(name)
+        return Float64(atof(s))
 
     def get_count(self, name: String) -> Int:
         """Gets the count for a counter-type argument. Returns 0 if not set.
@@ -236,6 +266,45 @@ struct ParseResult(Copyable, Movable, Writable):
             if self._positional_names[i] == name:
                 return i < len(self._positionals)
         return False
+
+    def was_provided(self, name: String) -> Bool:
+        """Checks whether the user actually supplied an argument.
+
+        Unlike ``has()``, this returns False for an argument whose value
+        only comes from ``.default()``.  It returns True when the argument
+        was given on the command line, answered at an interactive prompt,
+        or set through an ``implies()`` rule.
+
+        Args:
+            name: The argument name.
+
+        Returns:
+            True if the user supplied the argument, False if the value is a
+            default or the argument is absent.
+
+        Examples:
+
+        ```mojo
+        from argmojo import Command, Argument
+        var command = Command("myapp", "A sample application")
+        command.add_argument(
+            Argument("format", help="...").long["format"]().default["json"]()
+        )
+        var arguments: List[String] = ["myapp"]
+        var result = command.parse_arguments(arguments)
+        # result.has("format")          → True  (the default is in place)
+        # result.was_provided("format") → False (the user typed nothing)
+        ```
+        """
+        return name in self._provided
+
+    def _mark_provided(mut self, name: String):
+        """Records that *name* was supplied by the user.
+
+        Args:
+            name: The argument name.
+        """
+        self._provided.add(name)
 
     def has_subcommand_result(self) -> Bool:
         """Checks whether a subcommand result is present.

--- a/src/argmojo/utils.mojo
+++ b/src/argmojo/utils.mojo
@@ -420,6 +420,32 @@ def _format_two_column_line(
     return line
 
 
+# ── ASCII byte constants ────────────────────────────────────────────────────
+# Used by the byte-scanning helpers below.  Writing the byte value directly
+# avoids the one-byte `String` slices that the character-oriented versions of
+# these functions used to build, which are what made them expensive to
+# compile (see the note in `_looks_like_number`).
+comptime _BYTE_ZERO: UInt8 = 0x30  # '0'
+comptime _BYTE_NINE: UInt8 = 0x39  # '9'
+comptime _BYTE_MINUS: UInt8 = 0x2D  # '-'
+comptime _BYTE_PLUS: UInt8 = 0x2B  # '+'
+comptime _BYTE_DOT: UInt8 = 0x2E  # '.'
+comptime _BYTE_LOWER_E: UInt8 = 0x65  # 'e'
+comptime _BYTE_UPPER_E: UInt8 = 0x45  # 'E'
+
+
+def _is_digit_byte(b: UInt8) -> Bool:
+    """Returns True if byte *b* is an ASCII digit.
+
+    Args:
+        b: The byte to test.
+
+    Returns:
+        True when the byte is in the range ``'0'`` to ``'9'``.
+    """
+    return b >= _BYTE_ZERO and b <= _BYTE_NINE
+
+
 def _looks_like_number(token: String) -> Bool:
     """Returns True if *token* is a negative-number literal.
 
@@ -427,50 +453,75 @@ def _looks_like_number(token: String) -> Bool:
     ``-N.NEX``, ``-.NE+X``, and the corresponding ``-Ne+X``, ``-Ne-X``,
     ``-NE+X``, ``-NE-X`` variants.
     """
-    if token.byte_length() < 2 or not token.startswith("-"):
+    # [Mojo Miji]
+    # This walks raw bytes rather than one-byte string slices.  Every
+    # `token[byte=j:j+1] >= "0"` writes out a whole string comparison that
+    # the compiler then inlines; there are ~30 of them here, and they cost
+    # more compile time than the rest of the parser put together.  Comparing
+    # `UInt8` against a byte constant is a single machine instruction, and it
+    # is equally correct: all the characters matched below are ASCII, and a
+    # UTF-8 continuation byte is always >= 0x80 so it can never be mistaken
+    # for one of them.
+    var bytes = token.as_bytes()
+    var n = len(bytes)
+    if n < 2 or bytes[0] != _BYTE_MINUS:
         return False
     var j = 1
     # Optional leading '.' after minus (e.g. -.5).
-    if token[byte = j : j + 1] == ".":
+    if bytes[j] == _BYTE_DOT:
         j += 1
-        if j >= token.byte_length() or not (
-            token[byte = j : j + 1] >= "0" and token[byte = j : j + 1] <= "9"
-        ):
+        if j >= n or not _is_digit_byte(bytes[j]):
             return False
-    elif not (
-        token[byte = j : j + 1] >= "0" and token[byte = j : j + 1] <= "9"
-    ):
+    elif not _is_digit_byte(bytes[j]):
         return False
     # Integer digits.
-    while j < token.byte_length() and (
-        token[byte = j : j + 1] >= "0" and token[byte = j : j + 1] <= "9"
-    ):
+    while j < n and _is_digit_byte(bytes[j]):
         j += 1
     # Optional fractional part.
-    if j < token.byte_length() and token[byte = j : j + 1] == ".":
+    if j < n and bytes[j] == _BYTE_DOT:
         j += 1
-        while j < token.byte_length() and (
-            token[byte = j : j + 1] >= "0" and token[byte = j : j + 1] <= "9"
-        ):
+        while j < n and _is_digit_byte(bytes[j]):
             j += 1
     # Optional exponent.
-    if j < token.byte_length() and (
-        token[byte = j : j + 1] == "e" or token[byte = j : j + 1] == "E"
-    ):
+    if j < n and (bytes[j] == _BYTE_LOWER_E or bytes[j] == _BYTE_UPPER_E):
         j += 1
-        if j < token.byte_length() and (
-            token[byte = j : j + 1] == "+" or token[byte = j : j + 1] == "-"
-        ):
+        if j < n and (bytes[j] == _BYTE_PLUS or bytes[j] == _BYTE_MINUS):
             j += 1
-        if j >= token.byte_length() or not (
-            token[byte = j : j + 1] >= "0" and token[byte = j : j + 1] <= "9"
-        ):
+        if j >= n or not _is_digit_byte(bytes[j]):
             return False
-        while j < token.byte_length() and (
-            token[byte = j : j + 1] >= "0" and token[byte = j : j + 1] <= "9"
-        ):
+        while j < n and _is_digit_byte(bytes[j]):
             j += 1
-    return j == token.byte_length()
+    return j == n
+
+
+def _is_bool_literal(text: String) -> Bool:
+    """Returns True if *text* spells out a boolean value.
+
+    Accepted (case-insensitive): ``true``/``false``, ``1``/``0``,
+    ``yes``/``no``, ``on``/``off``.  Used to validate the default value of a
+    flag argument at registration time.
+    """
+    var lower = text.lower()
+    return (
+        lower == "true"
+        or lower == "false"
+        or lower == "1"
+        or lower == "0"
+        or lower == "yes"
+        or lower == "no"
+        or lower == "on"
+        or lower == "off"
+    )
+
+
+def _parse_bool_literal(text: String) -> Bool:
+    """Returns the boolean meaning of *text*.
+
+    Only the true-ish spellings are listed; everything else is False.  Call
+    ``_is_bool_literal`` first if the input has not been validated yet.
+    """
+    var lower = text.lower()
+    return lower == "true" or lower == "1" or lower == "yes" or lower == "on"
 
 
 def _is_ascii_digit(ch: String) -> Bool:
@@ -531,8 +582,13 @@ def _levenshtein(a: String, b: String) -> Int:
     The classic dynamic-programming algorithm, O(m*n) time and O(min(m,n))
     space (only the previous row is kept).
     """
-    var m = a.byte_length()
-    var n = b.byte_length()
+    # Compare raw bytes: the inner loop runs m*n times, and a one-byte
+    # string slice there expands into a full string comparison both at
+    # runtime and in the emitted code.
+    var ab = a.as_bytes()
+    var bb = b.as_bytes()
+    var m = len(ab)
+    var n = len(bb)
     if m == 0:
         return n
     if n == 0:
@@ -550,7 +606,7 @@ def _levenshtein(a: String, b: String) -> Int:
     for i in range(1, m + 1):
         curr[0] = i
         for j in range(1, n + 1):
-            var cost = 0 if a[byte = i - 1 : i] == b[byte = j - 1 : j] else 1
+            var cost = 0 if ab[i - 1] == bb[j - 1] else 1
             var ins = prev[j] + 1
             var dele = curr[j - 1] + 1
             var sub = prev[j - 1] + cost
@@ -826,12 +882,17 @@ def _read_password_asterisk(msg: String) raises -> String:
     - ``"password input EOF"`` for Ctrl-D / EOF
     - ``"password input read error"`` for a read(2) failure
 
-    Note: passwords are assumed to be ASCII (the overwhelmingly common
-    case).  Non-ASCII / UTF-8 multi-byte input will produce one ``*``
-    per byte rather than per character, and backspace operates on bytes.
-    The plain ``.password()`` mode (using ``input()``) handles UTF-8
-    correctly and should be preferred when Unicode passphrases are
-    expected.
+    Multi-byte UTF-8 passphrases are read correctly: the bytes are
+    collected as typed and decoded once at the end.  Only the *echo* is
+    per-byte — a two-byte character prints two ``*`` and needs two
+    backspaces to erase.  The plain ``.password()`` mode (using
+    ``input()``) echoes nothing at all and has no such quirk, so prefer
+    it when Unicode passphrases are common.
+
+    The collected bytes are overwritten with zeros before this function
+    returns, so the plaintext does not linger in the freed buffer.  The
+    returned ``String`` is of course still plaintext and is the caller's
+    responsibility.
     """
     from std.sys import stderr
 
@@ -928,7 +989,26 @@ def _read_password_asterisk(msg: String) raises -> String:
     if cancelled:
         raise cancel_reason
 
+    # Decode the collected bytes as UTF-8 in one step.  Going byte by byte
+    # through `chr()` would treat each byte as a code point and re-encode
+    # it, turning a typed "é" (0xC3 0xA9) into "Ã©" (0xC3 0x83 0xC2 0xA9).
+    # `from_utf8` validates; a terminal in a UTF-8 locale always satisfies
+    # it, but a raw byte sequence that does not is reported rather than
+    # silently mangled.
     var result = String()
+    var decode_failed = False
+    try:
+        result = String(from_utf8=Span(password))
+    except:
+        decode_failed = True
+
+    # Wipe the plaintext bytes before the buffer is freed — on the error
+    # path too, which is why this is not simply written after the decode.
     for i in range(len(password)):
-        result += chr(Int(password[i]))
+        password[i] = 0
+    one[0] = 0
+
+    if decode_failed:
+        raise Error("password input is not valid UTF-8")
+
     return result^

--- a/tests/check_schema_errors.sh
+++ b/tests/check_schema_errors.sh
@@ -113,6 +113,42 @@ def main() raises:
     _ = Bad.to_command()
 ' "range_min must be <= range_max"
 
+# 7. Range min > max (Positional)
+check_compile_error "positional_range_inverted" '
+from argmojo import Parsable, Positional
+struct Bad(Parsable):
+    var level: Positional[Int, has_range=True, range_min=100, range_max=10]
+    @staticmethod
+    def description() -> String:
+        return String("bad")
+def main() raises:
+    _ = Bad.to_command()
+' "range_min must be <= range_max"
+
+# 8. Range validation is integer-only, so Float64 + has_range is refused.
+check_compile_error "option_float_range" '
+from argmojo import Parsable, Option
+struct Bad(Parsable):
+    var ratio: Option[Float64, has_range=True, range_min=0, range_max=10]
+    @staticmethod
+    def description() -> String:
+        return String("bad")
+def main() raises:
+    _ = Bad.to_command()
+' "range validation is integer-only"
+
+# 9. Same, for Positional.
+check_compile_error "positional_float_range" '
+from argmojo import Parsable, Positional
+struct Bad(Parsable):
+    var scale: Positional[Float64, has_range=True, range_min=0, range_max=10]
+    @staticmethod
+    def description() -> String:
+        return String("bad")
+def main() raises:
+    _ = Bad.to_command()
+' "range validation is integer-only"
+
 echo
 echo "=== Results: $PASS passed, $FAIL failed ==="
 [ "$FAIL" -eq 0 ]

--- a/tests/test_declarative.mojo
+++ b/tests/test_declarative.mojo
@@ -308,5 +308,76 @@ def test_positional_allow_hyphen() raises:
 # =======================================================================
 
 
+# =======================================================================
+# Float64 values, wrapper parameter parity, and ergonomic unwrapping
+# =======================================================================
+
+
+struct Metrics(Parsable):
+    var ratio: Option[
+        Float64, long="ratio", short="r", help="A ratio", default="1.5"
+    ]
+    var verbose: Count[short="v", help="Verbosity", max=3, alias_name="loud"]
+    var quiet: Flag[short="q", help="Quiet", alias_name="silent"]
+    var scale: Positional[Float64, help="Scale factor", default="2.25"]
+    var legacy: Positional[
+        String,
+        help="Legacy slot",
+        default="x",
+        hidden=True,
+        deprecated="use --ratio instead",
+    ]
+
+    @staticmethod
+    def description() -> String:
+        return String("Metrics tool.")
+
+
+def test_float_option_and_positional() raises:
+    """Option[Float64] and Positional[Float64] round-trip through parsing."""
+    var args: List[String] = ["metrics", "--ratio", "0.25", "3.5"]
+    var parsed = Metrics.parse_arguments(args)
+    assert_equal(parsed.ratio.value, 0.25)
+    assert_equal(parsed.scale.value, 3.5)
+
+
+def test_float_defaults_are_applied() raises:
+    """A Float64 default reaches the field when nothing is supplied."""
+    var args: List[String] = ["metrics"]
+    var parsed = Metrics.parse_arguments(args)
+    assert_equal(parsed.ratio.value, 1.5)
+    assert_equal(parsed.scale.value, 2.25)
+
+
+def test_count_is_intable() raises:
+    """Count provides __int__, mirroring Flag.__bool__."""
+    var args: List[String] = ["metrics", "-vv"]
+    var parsed = Metrics.parse_arguments(args)
+    assert_equal(Int(parsed.verbose), 2)
+
+
+def test_count_and_flag_accept_aliases() raises:
+    """alias_name works on Count and Flag, not only on Option."""
+    var args: List[String] = ["metrics", "--loud", "--silent"]
+    var parsed = Metrics.parse_arguments(args)
+    assert_equal(Int(parsed.verbose), 1)
+    assert_true(parsed.quiet.value, msg="--silent is an alias of --quiet")
+
+
+def test_positional_hidden_and_deprecated() raises:
+    """Positional now honours hidden and deprecated, like Option does."""
+    var command = Metrics.to_command()
+    var help = command._generate_help(color=False)
+    assert_true(help.find("Legacy slot") < 0, msg="hidden positional")
+    for i in range(len(command.arguments)):
+        if command.arguments[i].name == "legacy":
+            assert_true(
+                command.arguments[i]._is_hidden, msg="hidden flag is set"
+            )
+            assert_equal(
+                command.arguments[i]._deprecated_msg, "use --ratio instead"
+            )
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_groups.mojo
+++ b/tests/test_groups.mojo
@@ -1845,5 +1845,221 @@ def test_implies_rejects_value_taking_implied() raises:
 # ═══════════════════════════════════════════════════════════════════════════════
 
 
+# ── Defaults must not be mistaken for user input ─────────────────────────────
+
+
+def test_exclusive_group_ignores_default() raises:
+    """A default value does not trigger a mutually-exclusive conflict."""
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("json", help="JSON").long["json"]().flag())
+    command.add_argument(
+        Argument("format", help="Format").long["format"]().default["text"]()
+    )
+    command.mutually_exclusive(["json", "format"])
+
+    var args: List[String] = ["test", "--json"]
+    var result = command.parse_arguments(args)
+    assert_true(result.get_flag("json"), msg="--json should be set")
+    assert_equal(result.get_string("format"), "text")
+    assert_false(
+        result.was_provided("format"),
+        msg="a defaulted argument was not provided by the user",
+    )
+
+
+def test_exclusive_group_still_catches_two_real_arguments() raises:
+    """Two arguments actually typed by the user still conflict."""
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("json", help="JSON").long["json"]().flag())
+    command.add_argument(
+        Argument("format", help="Format").long["format"]().default["text"]()
+    )
+    command.mutually_exclusive(["json", "format"])
+
+    var args: List[String] = ["test", "--json", "--format", "yaml"]
+    var raised = False
+    try:
+        _ = command.parse_arguments(args)
+    except:
+        raised = True
+    assert_true(raised, msg="two user-supplied arguments must conflict")
+
+
+def test_required_together_ignores_default() raises:
+    """A default does not make a required-together group half-provided."""
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("user", help="User").long["user"]())
+    command.add_argument(
+        Argument("pass", help="Password").long["pass"]().default["secret"]()
+    )
+    command.required_together(["user", "pass"])
+
+    var args: List[String] = ["test"]
+    var result = command.parse_arguments(args)
+    assert_equal(result.get_string("pass"), "secret")
+
+
+def test_required_together_still_catches_partial_input() raises:
+    """Supplying only one member of the group is still an error."""
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("user", help="User").long["user"]())
+    command.add_argument(
+        Argument("pass", help="Password").long["pass"]().default["secret"]()
+    )
+    command.required_together(["user", "pass"])
+
+    var args: List[String] = ["test", "--user", "zhu"]
+    var raised = False
+    try:
+        _ = command.parse_arguments(args)
+    except:
+        raised = True
+    assert_true(raised, msg="--user without --pass must raise")
+
+
+def test_one_required_not_satisfied_by_default() raises:
+    """A default value cannot satisfy a one-required group."""
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("json", help="JSON").long["json"]().flag())
+    command.add_argument(
+        Argument("format", help="Format").long["format"]().default["text"]()
+    )
+    command.one_required(["json", "format"])
+
+    var args: List[String] = ["test"]
+    var raised = False
+    try:
+        _ = command.parse_arguments(args)
+    except:
+        raised = True
+    assert_true(
+        raised, msg="a default must not satisfy one_required on its own"
+    )
+
+
+def test_conditional_requirement_ignores_default() raises:
+    """A defaulted condition does not make the target required."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("mode", help="Mode").long["mode"]().default["fast"]()
+    )
+    command.add_argument(Argument("key", help="Key").long["key"]())
+    command.required_if("key", "mode")
+
+    var args: List[String] = ["test"]
+    var result = command.parse_arguments(args)
+    assert_equal(result.get_string("mode"), "fast")
+
+
+def test_conditional_requirement_fires_on_real_input() raises:
+    """Typing the condition still makes the target required."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("mode", help="Mode").long["mode"]().default["fast"]()
+    )
+    command.add_argument(Argument("key", help="Key").long["key"]())
+    command.required_if("key", "mode")
+
+    var args: List[String] = ["test", "--mode", "slow"]
+    var raised = False
+    try:
+        _ = command.parse_arguments(args)
+    except:
+        raised = True
+    assert_true(raised, msg="--mode given by the user must require --key")
+
+
+def test_was_provided_reports_user_input() raises:
+    """was_provided() separates typed values from defaults."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("format", help="Format").long["format"]().default["json"]()
+    )
+    command.add_argument(Argument("out", help="Out").long["out"]())
+
+    var args: List[String] = ["test", "--out", "file.txt"]
+    var result = command.parse_arguments(args)
+    assert_true(result.was_provided("out"), msg="--out was typed")
+    assert_false(result.was_provided("format"), msg="--format is a default")
+    assert_true(result.has("format"), msg="has() still sees the default")
+    assert_false(result.was_provided("missing"), msg="unknown name is False")
+
+
+def test_implied_argument_counts_as_provided() raises:
+    """An implies() rule marks the implied argument as provided."""
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("debug", help="Debug").long["debug"]().flag())
+    command.add_argument(
+        Argument("verbose", help="Verbose").long["verbose"]().flag()
+    )
+    command.implies("debug", "verbose")
+
+    var args: List[String] = ["test", "--debug"]
+    var result = command.parse_arguments(args)
+    assert_true(result.get_flag("verbose"), msg="verbose is implied")
+    assert_true(
+        result.was_provided("verbose"),
+        msg="an implied argument counts as user intent",
+    )
+
+
+def test_default_on_trigger_does_not_fire_implication() raises:
+    """A default on the trigger must not fire an implies() rule."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("mode", help="Mode").long["mode"]().default["fast"]()
+    )
+    command.add_argument(
+        Argument("parallel", help="Parallel").long["parallel"]().flag()
+    )
+    command.implies("mode", "parallel")
+
+    var args: List[String] = ["test"]
+    var result = command.parse_arguments(args)
+    assert_false(
+        result.get_flag("parallel"),
+        msg="a default trigger must not imply --parallel",
+    )
+    assert_false(
+        result.was_provided("parallel"), msg="and must not mark it provided"
+    )
+
+
+def test_default_trigger_does_not_break_exclusive_group() raises:
+    """The implication path must not resurrect a false exclusive error."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("mode", help="Mode").long["mode"]().default["fast"]()
+    )
+    command.add_argument(
+        Argument("parallel", help="Parallel").long["parallel"]().flag()
+    )
+    command.add_argument(Argument("quiet", help="Quiet").long["quiet"]().flag())
+    command.implies("mode", "parallel")
+    var group: List[String] = ["parallel", "quiet"]
+    command.mutually_exclusive(group^)
+
+    var args: List[String] = ["test", "--quiet"]
+    var result = command.parse_arguments(args)
+    assert_true(result.get_flag("quiet"), msg="--quiet parses cleanly")
+    assert_false(result.get_flag("parallel"), msg="--parallel stays unset")
+
+
+def test_typed_trigger_still_fires_implication() raises:
+    """A trigger the user typed must still imply, even with a default set."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("mode", help="Mode").long["mode"]().default["fast"]()
+    )
+    command.add_argument(
+        Argument("parallel", help="Parallel").long["parallel"]().flag()
+    )
+    command.implies("mode", "parallel")
+
+    var args: List[String] = ["test", "--mode", "slow"]
+    var result = command.parse_arguments(args)
+    assert_true(result.get_flag("parallel"), msg="a typed --mode still implies")
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_groups.mojo
+++ b/tests/test_groups.mojo
@@ -1970,7 +1970,7 @@ def test_conditional_requirement_fires_on_real_input() raises:
 
 
 def test_was_provided_reports_user_input() raises:
-    """was_provided() separates typed values from defaults."""
+    """Tests that was_provided() separates typed values from defaults."""
     var command = Command("test", "Test app")
     command.add_argument(
         Argument("format", help="Format").long["format"]().default["json"]()
@@ -2059,6 +2059,96 @@ def test_typed_trigger_still_fires_implication() raises:
     var args: List[String] = ["test", "--mode", "slow"]
     var result = command.parse_arguments(args)
     assert_true(result.get_flag("parallel"), msg="a typed --mode still implies")
+
+
+def test_parse_known_default_trigger_does_not_fire_implication() raises:
+    """Test that parse_known_arguments() must not imply from a default either.
+    """
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("mode", help="Mode").long["mode"]().default["fast"]()
+    )
+    command.add_argument(
+        Argument("parallel", help="Parallel").long["parallel"]().flag()
+    )
+    command.implies("mode", "parallel")
+
+    var args: List[String] = ["test", "--unknown"]
+    var result = command.parse_known_arguments(args)
+    assert_equal(
+        result.get_string("mode"), "fast", msg="the default still applies"
+    )
+    assert_false(
+        result.get_flag("parallel"),
+        msg="a default trigger must not imply --parallel",
+    )
+    assert_false(
+        result.was_provided("parallel"), msg="and must not mark it provided"
+    )
+
+
+def test_parse_known_implication_outranks_a_default_on_the_implied_arg() raises:
+    """Implications must run before defaults in parse_known_arguments().
+
+    An implication only fires while the implied argument is still unset, so
+    filling defaults first would let a `.default()` on --parallel swallow the
+    rule and leave the flag false even though the user typed the trigger.
+    """
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("mode", help="Mode").long["mode"]())
+    command.add_argument(
+        Argument("parallel", help="Parallel")
+        .long["parallel"]()
+        .flag()
+        .default["false"]()
+    )
+    command.implies("mode", "parallel")
+
+    var args: List[String] = ["test", "--mode", "slow", "--unknown"]
+    var result = command.parse_known_arguments(args)
+    assert_true(
+        result.get_flag("parallel"),
+        msg="the implication must beat the default on --parallel",
+    )
+    assert_true(
+        result.was_provided("parallel"),
+        msg="an implied argument counts as user intent",
+    )
+
+
+def test_both_entry_points_agree_on_an_implied_default_argument() raises:
+    """Tests that parse_arguments() and parse_known_arguments() must not
+    disagree.
+
+    Same command line, same implication, same `.default()` on the implied
+    argument: both entry points have to answer identically, which is what
+    the shared implications-before-defaults order guarantees.
+    """
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("mode", help="Mode").long["mode"]())
+    command.add_argument(
+        Argument("parallel", help="Parallel")
+        .long["parallel"]()
+        .flag()
+        .default["false"]()
+    )
+    command.implies("mode", "parallel")
+
+    var full_args: List[String] = ["test", "--mode", "slow"]
+    var known_args: List[String] = ["test", "--mode", "slow"]
+    var full = command.parse_arguments(full_args)
+    var known = command.parse_known_arguments(known_args)
+
+    assert_equal(
+        full.get_flag("parallel"),
+        known.get_flag("parallel"),
+        msg="both entry points set the implied --parallel the same way",
+    )
+    assert_equal(
+        full.was_provided("parallel"),
+        known.was_provided("parallel"),
+        msg="both entry points mark it provided the same way",
+    )
 
 
 def main() raises:

--- a/tests/test_interactive.mojo
+++ b/tests/test_interactive.mojo
@@ -971,5 +971,140 @@ def test_confirmation_with_parent_args() raises:
 # ── Test runner ──────────────────────────────────────────────────────────────
 
 
+# ── Prompting runs before defaults are applied ───────────────────────────────
+
+
+def test_prompt_arg_with_default_is_not_marked_provided() raises:
+    """A default that fills a prompt argument is not counted as user input.
+
+    Prompting runs before ``_apply_defaults`` so that an argument carrying
+    both ``.prompt()`` and ``.default()`` is actually offered to the user;
+    the default is what an empty answer (or a non-interactive stdin) falls
+    back to.  Under the test runner stdin is not interactive, so the default
+    path is the one exercised here.
+    """
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("level", help="Log level")
+        .long["level"]()
+        .default["info"]()
+        .prompt()
+    )
+
+    var args: List[String] = ["test"]
+    var result = command.parse_arguments(args)
+    assert_equal(result.get_string("level"), "info")
+    assert_false(
+        result.was_provided("level"),
+        msg="a default is not user input, even on a prompt argument",
+    )
+
+
+def test_prompt_arg_value_from_cli_is_marked_provided() raises:
+    """A value given on the command line skips the prompt and counts as
+    provided."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("level", help="Log level")
+        .long["level"]()
+        .default["info"]()
+        .prompt()
+    )
+
+    var args: List[String] = ["test", "--level", "debug"]
+    var result = command.parse_arguments(args)
+    assert_equal(result.get_string("level"), "debug")
+    assert_true(result.was_provided("level"), msg="--level was typed")
+
+
+def test_prompt_default_does_not_satisfy_a_group() raises:
+    """A prompt argument left to its default cannot satisfy a one-required
+    group."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("level", help="Log level")
+        .long["level"]()
+        .default["info"]()
+        .prompt()
+    )
+    command.add_argument(Argument("quiet", help="Quiet").long["quiet"]().flag())
+    command.one_required(["level", "quiet"])
+
+    var args: List[String] = ["test"]
+    var raised = False
+    try:
+        _ = command.parse_arguments(args)
+    except:
+        raised = True
+    assert_true(raised, msg="neither member was supplied by the user")
+
+
+def test_confirmation_rejects_user_argument_named_yes() raises:
+    """A user argument named 'yes' cannot silently auto-confirm.
+
+    ``_confirm`` reads the flag by the hard-coded name "yes", so an
+    unrelated argument of that name would skip the prompt.  Every
+    registration order is blocked, so the situation is unreachable.
+    """
+    # Order 1: user argument first, then confirmation_option().
+    var first = Command("test", "Test app")
+    first.add_argument(Argument("yes", help="Answer").positional())
+    var raised_first = False
+    try:
+        first.confirmation_option()
+    except:
+        raised_first = True
+    assert_true(raised_first, msg="an existing 'yes' must block the option")
+
+    # Order 2: confirmation_option() first, then the user argument.
+    var second = Command("test", "Test app")
+    second.confirmation_option()
+    var raised_second = False
+    try:
+        second.add_argument(Argument("yes", help="Answer").positional())
+    except:
+        raised_second = True
+    assert_true(raised_second, msg="the option must block a later 'yes'")
+
+    # Order 3: name collision only — the long name differs.
+    var third = Command("test", "Test app")
+    third.add_argument(Argument("yes", help="Answer").long["confirm"]().flag())
+    var raised_third = False
+    try:
+        third.confirmation_option()
+    except:
+        raised_third = True
+    assert_true(raised_third, msg="the bare name collides even via --confirm")
+
+
+def test_confirmation_rejects_persistent_yes_from_parent() raises:
+    """A persistent --yes on the parent cannot shadow a child's own flag."""
+    for order in range(2):
+        var parent = Command("app", "Parent")
+        var child = Command("drop", "Drop it")
+        child.confirmation_option()
+        var raised = False
+        try:
+            if order == 0:
+                parent.add_subcommand(child.copy())
+                parent.add_argument(
+                    Argument("yes", help="Global yes")
+                    .long["yes"]()
+                    .flag()
+                    .persistent()
+                )
+            else:
+                parent.add_argument(
+                    Argument("yes", help="Global yes")
+                    .long["yes"]()
+                    .flag()
+                    .persistent()
+                )
+                parent.add_subcommand(child.copy())
+        except:
+            raised = True
+        assert_true(raised, msg="persistent --yes must conflict either way")
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_options.mojo
+++ b/tests/test_options.mojo
@@ -2746,5 +2746,80 @@ def test_malformed_map_default_raises() raises:
     assert_true(raised, msg="malformed map default must raise")
 
 
+# ── get_float ────────────────────────────────────────────────────────────────
+
+
+def test_get_float_reads_a_decimal_value() raises:
+    """Tests that get_float() parses a decimal value as Float64."""
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("ratio", help="Ratio").long["ratio"]())
+
+    var args: List[String] = ["test", "--ratio", "2.5"]
+    var result = command.parse_arguments(args)
+    assert_equal(result.get_float("ratio"), 2.5, msg="2.5 round-trips")
+
+
+def test_get_float_reads_a_negative_value() raises:
+    """A negative decimal survives the hyphen check and parses."""
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("offset", help="Offset").long["offset"]())
+
+    var args: List[String] = ["test", "--offset", "-1.75"]
+    var result = command.parse_arguments(args)
+    assert_equal(result.get_float("offset"), -1.75, msg="-1.75 round-trips")
+
+
+def test_get_float_reads_an_integer_literal() raises:
+    """A value written without a decimal point still reads as Float64."""
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("ratio", help="Ratio").long["ratio"]())
+
+    var args: List[String] = ["test", "--ratio", "3"]
+    var result = command.parse_arguments(args)
+    assert_equal(result.get_float("ratio"), 3.0, msg="3 reads as 3.0")
+
+
+def test_get_float_reads_a_default() raises:
+    """A default value is readable through get_float()."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("ratio", help="Ratio").long["ratio"]().default["1.5"]()
+    )
+
+    var args: List[String] = ["test"]
+    var result = command.parse_arguments(args)
+    assert_equal(result.get_float("ratio"), 1.5, msg="the default is readable")
+
+
+def test_get_float_raises_on_a_non_numeric_value() raises:
+    """A value that is not a number must raise rather than return garbage."""
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("ratio", help="Ratio").long["ratio"]())
+
+    var args: List[String] = ["test", "--ratio", "abc"]
+    var result = command.parse_arguments(args)
+    var raised = False
+    try:
+        _ = result.get_float("ratio")
+    except:
+        raised = True
+    assert_true(raised, msg="a non-numeric value must raise")
+
+
+def test_get_float_raises_on_a_missing_argument() raises:
+    """Reading an argument that was never provided must raise."""
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("ratio", help="Ratio").long["ratio"]())
+
+    var args: List[String] = ["test"]
+    var result = command.parse_arguments(args)
+    var raised = False
+    try:
+        _ = result.get_float("ratio")
+    except:
+        raised = True
+    assert_true(raised, msg="a missing argument must raise")
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_options.mojo
+++ b/tests/test_options.mojo
@@ -1251,6 +1251,46 @@ def test_remainder_only() raises:
     assert_equal(rest[2], "file.txt")
 
 
+def test_remainder_first_slot_swallows_help() raises:
+    """A remainder in slot 0 captures --help instead of printing help.
+
+    This is deliberate — a wrapper command must forward its tail
+    untouched — and the test exists so the behaviour cannot change by
+    accident.  If help were printed instead, the process would exit(0)
+    and this test would never reach its assertions.
+    """
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("rest", help="All arguments").remainder())
+
+    var args: List[String] = ["test", "--help", "--version", "-h"]
+    var result = command.parse_arguments(args)
+    var rest = result.get_list("rest")
+    assert_equal(len(rest), 3)
+    assert_equal(rest[0], "--help")
+    assert_equal(rest[1], "--version")
+    assert_equal(rest[2], "-h")
+
+
+def test_remainder_mode_starts_only_once_earlier_slots_fill() raises:
+    """A positional ahead of the remainder delays when swallowing begins.
+
+    Remainder mode turns on only after slot 0 is filled, so a --help
+    typed *before* any positional still reaches the help branch (not
+    asserted here, since that branch exits the process).
+    """
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("cmd", help="Command").positional())
+    command.add_argument(Argument("rest", help="Rest").remainder())
+
+    # --help lands in the first positional slot, before remainder mode
+    # starts, so it is *not* collected as a remainder value.
+    var args: List[String] = ["test", "run", "--help"]
+    var result = command.parse_arguments(args)
+    var rest = result.get_list("rest")
+    assert_equal(len(rest), 1)
+    assert_equal(rest[0], "--help")
+
+
 def test_remainder_with_options_before() raises:
     """Tests that options before the remainder positional slot are parsed normally.
     """
@@ -2491,6 +2531,219 @@ def test_delimiter_fullwidth_mixed() raises:
     assert_equal(tags[0], "a")
     assert_equal(tags[1], "b")
     assert_equal(tags[2], "c")
+
+
+# ── Defaults reach the accessor that belongs to the argument kind ────────────
+
+
+def test_flag_default_true_is_visible_to_get_flag() raises:
+    """A flag default lands in the flag store, not in the value store."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("color", help="Colour")
+        .long["color"]()
+        .flag()
+        .negatable()
+        .default["true"]()
+    )
+
+    var args: List[String] = ["test"]
+    var result = command.parse_arguments(args)
+    assert_true(result.get_flag("color"), msg="default true must be visible")
+    assert_false(result.was_provided("color"), msg="the user typed nothing")
+
+
+def test_flag_default_true_can_be_negated() raises:
+    """``--no-color`` still wins over a default of true."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("color", help="Colour")
+        .long["color"]()
+        .flag()
+        .negatable()
+        .default["true"]()
+    )
+
+    var args: List[String] = ["test", "--no-color"]
+    var result = command.parse_arguments(args)
+    assert_false(result.get_flag("color"), msg="--no-color must win")
+    assert_true(result.was_provided("color"), msg="--no-color is user input")
+
+
+def test_flag_default_false_spellings() raises:
+    """The false-ish spellings are accepted and mean False."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("color", help="Colour").long["color"]().flag().default["off"]()
+    )
+
+    var args: List[String] = ["test"]
+    var result = command.parse_arguments(args)
+    assert_false(result.get_flag("color"), msg="'off' means False")
+
+
+def test_count_default_is_visible_to_get_count() raises:
+    """A count default lands in the count store."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("verbose", help="Verbosity")
+        .long["verbose"]()
+        .short["v"]()
+        .count()
+        .default["2"]()
+    )
+
+    var args: List[String] = ["test"]
+    var result = command.parse_arguments(args)
+    assert_equal(result.get_count("verbose"), 2)
+
+
+def test_count_default_overridden_by_input() raises:
+    """Typing the flag replaces the default instead of adding to it."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("verbose", help="Verbosity")
+        .long["verbose"]()
+        .short["v"]()
+        .count()
+        .default["2"]()
+    )
+
+    var args: List[String] = ["test", "-vvv"]
+    var result = command.parse_arguments(args)
+    assert_equal(result.get_count("verbose"), 3)
+
+
+def test_append_default_is_visible_to_get_list() raises:
+    """An append default lands in the list store."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("tag", help="Tag").long["tag"]().append().default["x"]()
+    )
+
+    var args: List[String] = ["test"]
+    var result = command.parse_arguments(args)
+    var tags = result.get_list("tag")
+    assert_equal(len(tags), 1)
+    assert_equal(tags[0], "x")
+
+
+def test_map_default_is_visible_to_get_map() raises:
+    """A map default lands in the map store."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("def", help="Define")
+        .long["define"]()
+        .map_option()
+        .default["A=1"]()
+    )
+
+    var args: List[String] = ["test"]
+    var result = command.parse_arguments(args)
+    var m = result.get_map("def")
+    assert_equal(len(m), 1)
+    assert_equal(m["A"], "1")
+
+
+# ── Registration-time checks on default values ───────────────────────────────
+
+
+def test_default_outside_choices_raises_at_registration() raises:
+    """A default that is not one of the choices is caught when registering."""
+    var command = Command("test", "Test app")
+    var raised = False
+    try:
+        command.add_argument(
+            Argument("format", help="Format")
+            .long["format"]()
+            .choice["json"]()
+            .choice["yaml"]()
+            .default["xml"]()
+        )
+    except:
+        raised = True
+    assert_true(raised, msg="default outside choices must raise")
+
+
+def test_default_inside_choices_is_accepted() raises:
+    """A default that is one of the choices registers and applies normally."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("format", help="Format")
+        .long["format"]()
+        .choice["json"]()
+        .choice["yaml"]()
+        .default["yaml"]()
+    )
+
+    var args: List[String] = ["test"]
+    var result = command.parse_arguments(args)
+    assert_equal(result.get_string("format"), "yaml")
+
+
+def test_default_if_no_value_outside_choices_raises() raises:
+    """default_if_no_value must honour the declared choices too."""
+    var command = Command("test", "Test app")
+    var raised = False
+    try:
+        command.add_argument(
+            Argument("compress", help="Compress")
+            .long["compress"]()
+            .choice["gzip"]()
+            .choice["xz"]()
+            .default_if_no_value["bzip2"]()
+        )
+    except:
+        raised = True
+    assert_true(raised, msg="default_if_no_value outside choices must raise")
+
+
+def test_non_boolean_flag_default_raises() raises:
+    """A flag default has to spell out a boolean."""
+    var command = Command("test", "Test app")
+    var raised = False
+    try:
+        command.add_argument(
+            Argument("color", help="Colour")
+            .long["color"]()
+            .flag()
+            .default["maybe"]()
+        )
+    except:
+        raised = True
+    assert_true(raised, msg="non-boolean flag default must raise")
+
+
+def test_non_integer_count_default_raises() raises:
+    """A count default has to be an integer."""
+    var command = Command("test", "Test app")
+    var raised = False
+    try:
+        command.add_argument(
+            Argument("verbose", help="Verbosity")
+            .long["verbose"]()
+            .count()
+            .default["many"]()
+        )
+    except:
+        raised = True
+    assert_true(raised, msg="non-integer count default must raise")
+
+
+def test_malformed_map_default_raises() raises:
+    """A map default has to be in key=value form."""
+    var command = Command("test", "Test app")
+    var raised = False
+    try:
+        command.add_argument(
+            Argument("def", help="Define")
+            .long["define"]()
+            .map_option()
+            .default["NOEQUALS"]()
+        )
+    except:
+        raised = True
+    assert_true(raised, msg="malformed map default must raise")
 
 
 def main() raises:

--- a/tests/test_parse.mojo
+++ b/tests/test_parse.mojo
@@ -1264,5 +1264,202 @@ def test_negative_expression_parse_known() raises:
     assert_equal(unknown[0], "--color")
 
 
+# ── Required positionals vs. defaults on later slots ─────────────────────────
+
+
+def test_missing_required_positional_with_later_default() raises:
+    """A required positional is still required when a later one has a default.
+
+    Filling the default pads the positional list up to that slot, which used
+    to make the earlier, empty slot look like it had been provided.
+    """
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("src", help="Source").positional().required())
+    command.add_argument(
+        Argument("dst", help="Destination").positional().default["out.txt"]()
+    )
+
+    var args: List[String] = ["test"]
+    var raised = False
+    try:
+        _ = command.parse_arguments(args)
+    except:
+        raised = True
+    assert_true(raised, msg="missing required positional must raise")
+
+
+def test_required_positional_with_later_default_accepts_input() raises:
+    """The same command parses fine once the required positional is given."""
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("src", help="Source").positional().required())
+    command.add_argument(
+        Argument("dst", help="Destination").positional().default["out.txt"]()
+    )
+
+    var args: List[String] = ["test", "in.txt"]
+    var result = command.parse_arguments(args)
+    assert_equal(result.get_string("src"), "in.txt")
+    assert_equal(result.get_string("dst"), "out.txt")
+    assert_true(result.was_provided("src"), msg="src was typed")
+    assert_false(result.was_provided("dst"), msg="dst is a default")
+
+
+def test_required_positional_with_own_default_is_satisfied() raises:
+    """A default on the required positional itself still satisfies it."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("src", help="Source").positional().required().default["."]()
+    )
+
+    var args: List[String] = ["test"]
+    var result = command.parse_arguments(args)
+    assert_equal(result.get_string("src"), ".")
+
+
+# ── Malformed long options ───────────────────────────────────────────────────
+
+
+def test_empty_long_option_name_rejected() raises:
+    """``--=value`` has no option name and must not bind to a positional."""
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("file", help="File").positional())
+    command.add_argument(
+        Argument("verbose", help="Verbose").long["verbose"]().flag()
+    )
+
+    var args: List[String] = ["test", "--=hello"]
+    var raised = False
+    try:
+        _ = command.parse_arguments(args)
+    except:
+        raised = True
+    assert_true(raised, msg="--=hello must be rejected")
+
+
+def test_empty_long_option_name_rejected_with_short_only_option() raises:
+    """Same guard, with a short-only option as the empty-long-name candidate."""
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("out", help="Out").short["o"]().takes_value())
+
+    var args: List[String] = ["test", "--=hello"]
+    var raised = False
+    try:
+        _ = command.parse_arguments(args)
+    except:
+        raised = True
+    assert_true(raised, msg="--=hello must not bind to a short-only option")
+
+
+# ── An option must not swallow another option as its value ───────────────────
+
+
+def test_long_option_rejects_known_option_as_value() raises:
+    """``--output --verbose`` is a missing value, not an output named
+    ``--verbose``."""
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("output", help="Out").long["output"]())
+    command.add_argument(
+        Argument("verbose", help="Verbose").long["verbose"]().flag()
+    )
+
+    var args: List[String] = ["test", "--output", "--verbose"]
+    var raised = False
+    try:
+        _ = command.parse_arguments(args)
+    except:
+        raised = True
+    assert_true(raised, msg="--output --verbose must raise")
+
+
+def test_short_option_rejects_known_option_as_value() raises:
+    """The same guard applies to short options."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("output", help="Out").long["output"]().short["o"]()
+    )
+    command.add_argument(
+        Argument("verbose", help="Verbose")
+        .long["verbose"]()
+        .short["v"]()
+        .flag()
+    )
+
+    var args: List[String] = ["test", "-o", "-v"]
+    var raised = False
+    try:
+        _ = command.parse_arguments(args)
+    except:
+        raised = True
+    assert_true(raised, msg="-o -v must raise")
+
+
+def test_nargs_rejects_known_option_as_value() raises:
+    """A multi-value option stops at the next registered option."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("point", help="Point").long["point"]().number_of_values[2]()
+    )
+    command.add_argument(
+        Argument("verbose", help="Verbose").long["verbose"]().flag()
+    )
+
+    var args: List[String] = ["test", "--point", "1", "--verbose"]
+    var raised = False
+    try:
+        _ = command.parse_arguments(args)
+    except:
+        raised = True
+    assert_true(raised, msg="--point 1 --verbose must raise")
+
+
+def test_option_rejects_double_dash_as_value() raises:
+    """The ``--`` end-of-options marker is never a value."""
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("output", help="Out").long["output"]())
+
+    var args: List[String] = ["test", "--output", "--", "file.txt"]
+    var raised = False
+    try:
+        _ = command.parse_arguments(args)
+    except:
+        raised = True
+    assert_true(raised, msg="-- must not be consumed as a value")
+
+
+def test_option_still_accepts_negative_number_value() raises:
+    """Only *registered* options are refused, so ``-5`` still works."""
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("offset", help="Offset").long["offset"]())
+
+    var args: List[String] = ["test", "--offset", "-5"]
+    var result = command.parse_arguments(args)
+    assert_equal(result.get_string("offset"), "-5")
+
+
+def test_option_still_accepts_unregistered_hyphen_value() raises:
+    """A hyphen-prefixed token that is not a known option is a valid value."""
+    var command = Command("test", "Test app")
+    command.add_argument(Argument("pattern", help="Pattern").long["pattern"]())
+
+    var args: List[String] = ["test", "--pattern", "-foo"]
+    var result = command.parse_arguments(args)
+    assert_equal(result.get_string("pattern"), "-foo")
+
+
+def test_allow_hyphen_values_opts_out_of_the_guard() raises:
+    """``allow_hyphen_values()`` keeps the old, permissive behaviour."""
+    var command = Command("test", "Test app")
+    command.add_argument(
+        Argument("cmd", help="Command").long["cmd"]().allow_hyphen_values()
+    )
+    command.add_argument(
+        Argument("verbose", help="Verbose").long["verbose"]().flag()
+    )
+
+    var args: List[String] = ["test", "--cmd", "--verbose"]
+    var result = command.parse_arguments(args)
+    assert_equal(result.get_string("cmd"), "--verbose")
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()

--- a/tests/test_subcommands.mojo
+++ b/tests/test_subcommands.mojo
@@ -2046,5 +2046,111 @@ def test_parent_with_subcommands() raises:
     assert_equal(sub_result.get_string("target"), "main")
 
 
+# ── Persistent conflicts are detected in either registration order ───────────
+
+
+def test_persistent_conflict_when_argument_added_after_subcommand() raises:
+    """The conflict check does not depend on the order of the two calls.
+
+    ``add_subcommand()`` checks the persistent arguments registered so far;
+    this covers the mirror case, where the persistent argument is registered
+    after the subcommand.
+    """
+    var app = Command("app", "")
+    var build = Command("build", "")
+    build.add_argument(
+        Argument("verbose", help="").long["verbose"]().short["v"]().flag()
+    )
+    app.add_subcommand(build^)
+
+    var raised = False
+    try:
+        app.add_argument(
+            Argument("verbose", help="")
+            .long["verbose"]()
+            .short["v"]()
+            .flag()
+            .persistent()
+        )
+    except:
+        raised = True
+    assert_true(
+        raised,
+        msg="a late persistent argument must still report the conflict",
+    )
+
+
+def test_persistent_short_conflict_after_subcommand() raises:
+    """Short-flag collisions are caught in the same order."""
+    var app = Command("app", "")
+    var build = Command("build", "")
+    build.add_argument(
+        Argument("version", help="").long["ver"]().short["v"]().flag()
+    )
+    app.add_subcommand(build^)
+
+    var raised = False
+    try:
+        app.add_argument(
+            Argument("verbose", help="")
+            .long["verbose"]()
+            .short["v"]()
+            .flag()
+            .persistent()
+        )
+    except:
+        raised = True
+    assert_true(raised, msg="short-flag conflict must be reported")
+
+
+def test_non_persistent_argument_after_subcommand_is_fine() raises:
+    """Only persistent arguments are checked against subcommands."""
+    var app = Command("app", "")
+    var build = Command("build", "")
+    build.add_argument(
+        Argument("verbose", help="").long["verbose"]().short["v"]().flag()
+    )
+    app.add_subcommand(build^)
+
+    app.add_argument(
+        Argument("verbose", help="").long["verbose"]().short["v"]().flag()
+    )
+    assert_true(True, msg="a non-persistent argument must not conflict")
+
+
+def test_persistent_argument_injected_once_into_child() raises:
+    """A persistent argument reaches the child exactly once.
+
+    The injection in ``_dispatch_subcommand`` bypasses ``add_argument()``, so
+    it does its own duplicate check; registering the same flag on both sides
+    is refused earlier, in ``add_argument()`` / ``add_subcommand()``.
+    """
+    var app = Command("app", "")
+    app.add_argument(
+        Argument("verbose", help="Root verbose")
+        .long["verbose"]()
+        .short["v"]()
+        .flag()
+        .persistent()
+    )
+    var build = Command("build", "Build it")
+    build.add_argument(Argument("target", help="Target").positional())
+    app.add_subcommand(build^)
+
+    var args: List[String] = ["app", "build", "mylib", "--verbose"]
+    var result = app.parse_arguments(args)
+    assert_equal(result.subcommand, "build")
+    assert_true(
+        result.get_flag("verbose"),
+        msg="the persistent flag must bubble up to the root result",
+    )
+    var child = result.get_subcommand_result()
+    assert_true(
+        child.get_flag("verbose"),
+        msg="the persistent flag must be readable on the child result",
+    )
+    assert_equal(child.get_string("target"), "mylib")
+
+
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
This PR update documents for release and fix several issues.

The main reason to upgrade is an FFI signature clash in _read_password_asterisk(). Our read(2) binding passed its buffer as Int(ptr), declaring read as (Int, Int, Int) -> Int while the standard library declares the same symbol with a pointer. Any module linking both failed to lower to LLVM IR, so this could break the build of a project that merely depends on ArgMojo. The buffer is passed as a real pointer now.

Twelve parser bugs are fixed. Several of them share one root cause: has() is true for an argument that only carries a .default(), and four group constraints plus implies() were using it to mean "the user typed this". They ask the new was_provided() now. The rest are independent: defaults were all written to the string store, so a .flag().default()
was invisible to get_flag(); an argument with both .prompt() and .default() was never prompted; an option could swallow the next option as its value; a required positional could be satisfied by a later positional's default; persistent-argument conflicts were caught in only one registration order; non-ASCII passwords came back corrupted; and
`--=hello` set the first positional instead of being rejected. Bad defaults are now caught at registration rather than reaching the user.

New API: was_provided() and get_float() on ParseResult, working Float64 options and positionals, Int() unwrapping for Count, and a consistent parameter set across the four declarative wrappers, so a positional no longer has to drop to the builder API for prompt, password, hidden, deprecated or ranges.

Compiling a program that uses ArgMojo is about 20% faster. Most of it is examples/build.sh linking the prebuilt package instead of recompiling the sources into all eight binaries; the rest is argument lookup returning an index instead of deep-copying the Argument on every option token, String(...) in place of long + chains, and byte comparisons in _looks_like_number() and _levenshtein(). Help text, completion scripts and error messages are byte-for-byte identical before and after.

CI also runs tests/test_dispatch.mojo now. It was in the local test task but in none of the workflow jobs, so the auto-dispatch tests added in v0.6.0 had never run on a pull request.

733 tests across 13 modules pass, along with the negative schema checks and all eight examples.